### PR TITLE
Add i18n support for dark/light mode menu

### DIFF
--- a/theme/i18n/ar.yaml
+++ b/theme/i18n/ar.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: السَّابق
 ui_pager_next: التَّالي
 ui_read_more: اِقْرأ اَلمزِيد
 ui_search: اِبْحث فِي هذَا اَلموْقِع
+ui_theme_light: فاتح
+ui_theme_dark: داكن
+ui_theme_auto: تلقائي
 
 # Used in sentences such as "Posted in News"
 ui_in: فِي

--- a/theme/i18n/az.yaml
+++ b/theme/i18n/az.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: Əvvəlki
 ui_pager_next: Növbəti
 ui_read_more: Daha çox oxu
 ui_search: Bu saytda axtarın...
+ui_theme_light: Açıq
+ui_theme_dark: Tünd
+ui_theme_auto: Avtomatik
 
 # Used in sentences such as "Posted in News"
 ui_in: daxilində

--- a/theme/i18n/bg.yaml
+++ b/theme/i18n/bg.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: Предишен
 ui_pager_next: Следващ
 ui_read_more: Прочети повече
 ui_search: Търси в тази страница…
+ui_theme_light: Светла
+ui_theme_dark: Тъмна
+ui_theme_auto: Автоматична
 
 # Used in sentences such as "Posted in News"
 ui_in: в

--- a/theme/i18n/bn.yaml
+++ b/theme/i18n/bn.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: পূর্ববর্তী
 ui_pager_next: পরবর্তী
 ui_read_more: আরও পড়ুন
 ui_search: এই সাইটে খোঁজ করুন…
+ui_theme_light: হালকা
+ui_theme_dark: গাঢ়
+ui_theme_auto: স্বয়ংক্রিয়
 
 # "পোস্ট করা নিউজ" এর মতো বাক্যে ব্যবহৃত
 ui_in: মধ্যে

--- a/theme/i18n/de.yaml
+++ b/theme/i18n/de.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: Zurück
 ui_pager_next: Weiter
 ui_read_more: Weiterlesen
 ui_search: Diese Seite durchsuchen…
+ui_theme_light: Hell
+ui_theme_dark: Dunkel
+ui_theme_auto: Automatisch
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/en.yaml
+++ b/theme/i18n/en.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: Previous
 ui_pager_next: Next
 ui_read_more: Read more
 ui_search: Search this site…
+ui_theme_light: Light
+ui_theme_dark: Dark
+ui_theme_auto: Auto
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/es.yaml
+++ b/theme/i18n/es.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: Previo
 ui_pager_next: Siguiente
 ui_read_more: Continuar leyendo
 ui_search: Buscar
+ui_theme_light: Claro
+ui_theme_dark: Oscuro
+ui_theme_auto: Automático
 
 # Used in sentences such as "Posted in News"
 ui_in: en

--- a/theme/i18n/et.yaml
+++ b/theme/i18n/et.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: Eelmine
 ui_pager_next: Järgmine
 ui_read_more: Loe lähemalt
 ui_search: Otsi lehelt…
+ui_theme_light: Hele
+ui_theme_dark: Tume
+ui_theme_auto: Automaatne
 
 # Used in sentences such as "Posted in News"
 # not perfect. In Estonian this idea is represented by a suffix, not a separate word.

--- a/theme/i18n/fa.yaml
+++ b/theme/i18n/fa.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: قبلی
 ui_pager_next: بعدی
 ui_read_more: بیشتر بخوانید
 ui_search: در این سایت جستجو کنید...
+ui_theme_light: روشن
+ui_theme_dark: تاریک
+ui_theme_auto: خودکار
 
 # Used in sentences such as "Posted in News"
 ui_in: در

--- a/theme/i18n/fi.yaml
+++ b/theme/i18n/fi.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: Edellinen
 ui_pager_next: Seuraava
 ui_read_more: Lue lisää
 ui_search: Hae sivustolta...
+ui_theme_light: Vaalea
+ui_theme_dark: Tumma
+ui_theme_auto: Automaattinen
 
 # Used in sentences such as "Posted in News"
 ui_in:

--- a/theme/i18n/fr.yaml
+++ b/theme/i18n/fr.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: Précédent
 ui_pager_next: Suivant
 ui_read_more: Lire plus
 ui_search: Rechercher
+ui_theme_light: Clair
+ui_theme_dark: Sombre
+ui_theme_auto: Automatique
 
 # Used in sentences such as "Posted in News"
 ui_in: dans

--- a/theme/i18n/he.yaml
+++ b/theme/i18n/he.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: הקודם
 ui_pager_next: הבא
 ui_read_more: קרא עוד
 ui_search: חיפוש באתר…
+ui_theme_light: בהיר
+ui_theme_dark: כהה
+ui_theme_auto: אוטומטי
 
 # Used in sentences such as "Posted in News"
 ui_in: ב

--- a/theme/i18n/hi.yaml
+++ b/theme/i18n/hi.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: पिछला
 ui_pager_next: अगला
 ui_read_more: अधिक जानें
 ui_search: इस साइट में खोजें…
+ui_theme_light: हल्का
+ui_theme_dark: गहरा
+ui_theme_auto: स्वचालित
 
 # Used in sentences such as "Posted in News"
 ui_in: में

--- a/theme/i18n/hu.yaml
+++ b/theme/i18n/hu.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: Előző
 ui_pager_next: Következő
 ui_read_more: További olvasnivaló
 ui_search: Keresés ezen az oldalon…
+ui_theme_light: Világos
+ui_theme_dark: Sötét
+ui_theme_auto: Automatikus
 
 # so I left it as is
 ui_in: in

--- a/theme/i18n/it.yaml
+++ b/theme/i18n/it.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: Precedente
 ui_pager_next: Successivo
 ui_read_more: Leggi tutto
 ui_search: Cerca nel sito…
+ui_theme_light: Chiaro
+ui_theme_dark: Scuro
+ui_theme_auto: Automatico
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/ja.yaml
+++ b/theme/i18n/ja.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: 前へ
 ui_pager_next: 次へ
 ui_read_more: 続きを読む
 ui_search: サイトを検索...
+ui_theme_light: ライト
+ui_theme_dark: ダーク
+ui_theme_auto: 自動
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/ko.yaml
+++ b/theme/i18n/ko.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: 이전
 ui_pager_next: 다음
 ui_read_more: 더 읽기
 ui_search: 사이트에서 검색…
+ui_theme_light: 라이트
+ui_theme_dark: 다크
+ui_theme_auto: 자동
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/nl.yaml
+++ b/theme/i18n/nl.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: Vorige
 ui_pager_next: Volgende
 ui_read_more: Lees meer
 ui_search: Doorzoek deze site
+ui_theme_light: Licht
+ui_theme_dark: Donker
+ui_theme_auto: Automatisch
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/no.yaml
+++ b/theme/i18n/no.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: Forrige
 ui_pager_next: Neste
 ui_read_more: Les mer
 ui_search: Søk på nettstedet…
+ui_theme_light: Lyst
+ui_theme_dark: Mørkt
+ui_theme_auto: Automatisk
 
 # Used in sentences such as "Posted in News"
 ui_in: i

--- a/theme/i18n/oc.yaml
+++ b/theme/i18n/oc.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: Precedent
 ui_pager_next: Seguent
 ui_read_more: Ne legir mai
 ui_search: Cercar dins lo site…
+ui_theme_light: Clar
+ui_theme_dark: Escur
+ui_theme_auto: Automatic
 
 # Used in sentences such as "Posted in News"
 ui_in: Dins

--- a/theme/i18n/pl.yaml
+++ b/theme/i18n/pl.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: Wstecz
 ui_pager_next: Dalej
 ui_read_more: Zobacz więcej
 ui_search: Szukaj na stronie ...
+ui_theme_light: Jasny
+ui_theme_dark: Ciemny
+ui_theme_auto: Automatyczny
 
 # Used in sentences such as "Posted in News"
 ui_in: w

--- a/theme/i18n/pt-br.yaml
+++ b/theme/i18n/pt-br.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: Anterior
 ui_pager_next: Próximo
 ui_read_more: Ler mais
 ui_search: Buscar no site…
+ui_theme_light: Claro
+ui_theme_dark: Escuro
+ui_theme_auto: Automático
 
 # Used in sentences such as "Posted in News"
 ui_in: em

--- a/theme/i18n/ro.yaml
+++ b/theme/i18n/ro.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: Anterior
 ui_pager_next: Următor
 ui_read_more: Citește mai mult
 ui_search: Caută pe acest site…
+ui_theme_light: Luminoasă
+ui_theme_dark: Întunecată
+ui_theme_auto: Automată
 
 # Used in sentences such as "Posted in News"
 ui_in: în

--- a/theme/i18n/ru.yaml
+++ b/theme/i18n/ru.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: Предыдущая
 ui_pager_next: Следующая
 ui_read_more: Подробнее
 ui_search: Поиск по сайту…
+ui_theme_light: Светлая
+ui_theme_dark: Тёмная
+ui_theme_auto: Авто
 
 # Used in sentences such as "Posted in News"
 ui_in: в

--- a/theme/i18n/sr-cyrl.yaml
+++ b/theme/i18n/sr-cyrl.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: Претходно
 ui_pager_next: Наредно
 ui_read_more: Прочитајте више
 ui_search: Претражите сајт…
+ui_theme_light: Светла
+ui_theme_dark: Тамна
+ui_theme_auto: Аутоматска
 
 # Used in sentences such as "Posted in News"
 ui_in: у

--- a/theme/i18n/sr-latn.yaml
+++ b/theme/i18n/sr-latn.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: Prethodno
 ui_pager_next: Naredno
 ui_read_more: Pročitajte više
 ui_search: Pretražite sajt…
+ui_theme_light: Svetla
+ui_theme_dark: Tamna
+ui_theme_auto: Automatska
 
 # Used in sentences such as "Posted in News"
 ui_in: u

--- a/theme/i18n/sv.yaml
+++ b/theme/i18n/sv.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: Tidigare
 ui_pager_next: Nästa
 ui_read_more: Läs mer
 ui_search: Sök denna sida…
+ui_theme_light: Ljust
+ui_theme_dark: Mörkt
+ui_theme_auto: Automatiskt
 
 # Used in sentences such as "Posted in News"
 ui_in: i

--- a/theme/i18n/tr.yaml
+++ b/theme/i18n/tr.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: Önceki
 ui_pager_next: Sonraki
 ui_read_more: Daha fazla oku
 ui_search: Bu sitede arayın…
+ui_theme_light: Açık
+ui_theme_dark: Koyu
+ui_theme_auto: Otomatik
 
 # Used in sentences such as "Posted in News"
 ui_in: içinde

--- a/theme/i18n/uk.yaml
+++ b/theme/i18n/uk.yaml
@@ -3,6 +3,9 @@ ui_pager_prev: Попередня
 ui_pager_next: Наступна
 ui_read_more: Читати далі
 ui_search: Пошук по сайту…
+ui_theme_light: Світла
+ui_theme_dark: Темна
+ui_theme_auto: Авто
 
 # Used in sentences such as "Posted in News"
 ui_in: у

--- a/theme/i18n/uk.yaml
+++ b/theme/i18n/uk.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: Попередня
 ui_pager_next: Наступна
 ui_read_more: Читати далі
 ui_search: Пошук по сайту…
+ui_theme_light: Світла
+ui_theme_dark: Темна
+ui_theme_auto: Авто
 
 # Used in sentences such as "Posted in News"
 ui_in: у

--- a/theme/i18n/zh-cn.yaml
+++ b/theme/i18n/zh-cn.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: 上一页
 ui_pager_next: 下一页
 ui_read_more: 阅读全文
 ui_search: 站内搜索……
+ui_theme_light: 浅色
+ui_theme_dark: 深色
+ui_theme_auto: 自动
 
 # Used in sentences such as "Posted in News"
 ui_in: 在

--- a/theme/i18n/zh-tw.yaml
+++ b/theme/i18n/zh-tw.yaml
@@ -10,6 +10,9 @@ ui_pager_prev: 上一頁
 ui_pager_next: 下一頁
 ui_read_more: 閱讀全文
 ui_search: 站內搜尋…
+ui_theme_light: 淺色
+ui_theme_dark: 深色
+ui_theme_auto: 自動
 
 # Used in sentences such as "Posted in News"
 ui_in: 於

--- a/theme/layouts/_partials/theme-toggler.html
+++ b/theme/layouts/_partials/theme-toggler.html
@@ -37,21 +37,21 @@
   <li>
     <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="light" aria-pressed="false">
       <svg class="bi me-2 opacity-50"><use href="#sun-fill"></use></svg>
-      Light
+      {{ T "ui_theme_light" }}
       <svg class="bi ms-auto d-none"><use href="#check2"></use></svg>
     </button>
   </li>
   <li>
     <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="dark" aria-pressed="false">
       <svg class="bi me-2 opacity-50"><use href="#moon-stars-fill"></use></svg>
-      Dark
+      {{ T "ui_theme_dark" }}
       <svg class="bi ms-auto d-none"><use href="#check2"></use></svg>
     </button>
   </li>
   <li>
     <button type="button" class="dropdown-item d-flex align-items-center active" data-bs-theme-value="auto" aria-pressed="true">
       <svg class="bi me-2 opacity-50"><use href="#circle-half"></use></svg>
-      Auto
+      {{ T "ui_theme_auto" }}
       <svg class="bi ms-auto d-none"><use href="#check2"></use></svg>
     </button>
   </li>


### PR DESCRIPTION
- Fixes #1987
- **Replaces the hardcoded** `Light`/`Dark`/`Auto` labels in the theme-toggler menu with `ui_theme_*` i18n lookups, so that sites can localize or override them without forking the partial
- **Adds the three keys to all 31 locale catalogs**, with best-effort translations using OS-canonical terms; native-speaker corrections welcome as follow-up PRs
- **Known limitation**: the toggler's `aria-label`s and hidden toggle text remain hardcoded English; screen-reader localization is a follow-up
- **Preview**: [deploy-preview-2482](https://deploy-preview-2482--docsydocs.netlify.app/) and its [fr locale](https://deploy-preview-2482--docsydocs.netlify.app/fr/) rendering Clair/Sombre/Automatique; the menu sits in the top navbar
