### PR TITLE
Fix section index for the home page of docs-only sites

### DIFF
--- a/layouts/_partials/section-index.html
+++ b/layouts/_partials/section-index.html
@@ -1,8 +1,12 @@
 <div class="section-index">
     {{ $page := .Page -}}
-    {{ $pages := (where .Site.Pages "Section" .Section).ByWeight -}}
+    {{ $pages := .Site.Pages.ByWeight -}}
+    {{ if .Section -}}
+        {{ $pages = (where $pages "Section" .Section) -}}
+    {{ end -}}
     {{ $pages = (where $pages "Type" "!=" "search") }}
     {{ $pages = (where $pages ".Params.hide_summary" "!=" true) -}}
+    {{ $pages = (where $pages ".Kind" "!=" "taxonomy") -}}
     {{ $pages = (where $pages ".Parent" "!=" nil) -}}
     {{ $pages = (where $pages ".Parent.File" "!=" nil) -}}
     {{ if $page.File -}}


### PR DESCRIPTION
Home pages of docs-only sites also contain a section index list. Currently, only the direct children that are not opening a deeper section are listed. 

This is fixed by this PR by considering all pages as candidates for home page section indexes and not only those that are in the same section.

In addition, pages of kind "taxonomy" are filtered out, to leave categories and tags out.

- Fixes #2499