### PR TITLE
docs: add missing PostCSS install steps to "start from scratch" guide

### DIFF
--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -39,6 +39,14 @@ proxy = "direct"
 [[module.imports]]
 path = "github.com/google/docsy"
 EOL
+npm install -D autoprefixer postcss-cli postcss
+cat > postcss.config.js <<EOL
+module.exports = {
+    plugins: {
+        autoprefixer: {}
+    },
+}
+EOL
 hugo server
 {{< /tab >}}
 {{< tab header="Windows command line" lang="Batchfile" >}}
@@ -53,6 +61,12 @@ proxy = "direct"^
 [[module.imports]]^
 
 path = "github.com/google/docsy") >> hugo.toml
+npm install -D autoprefixer postcss-cli postcss
+(echo module.exports = {^
+    plugins: {^
+        autoprefixer: {}^
+    },^
+}) > postcss.config.js
 hugo server
 {{< /tab >}}
 {{< /tabpane >}}
@@ -162,6 +176,30 @@ You can find details of what these configuration settings do in the
 [Hugo modules documentation](https://gohugo.io/hugo-modules/configuration/#module-config-top-level).
 Depending on your environment you may need to tweak them slightly, for example
 by adding a proxy to use when downloading remote modules.
+
+### Install PostCSS
+
+To build or update your site's CSS resources, you also need
+[PostCSS](https://postcss.org/). Run the following commands from your site
+root directory to install the required packages:
+
+```bash
+npm install -D autoprefixer postcss-cli postcss
+```
+
+Then create a `postcss.config.js` file in your site root with the following
+content:
+
+```javascript
+module.exports = {
+    plugins: {
+        autoprefixer: {}
+    },
+}
+```
+
+For more details, see
+[Install PostCSS](/docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss).
 
 ### Preview your site
 

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -180,8 +180,8 @@ by adding a proxy to use when downloading remote modules.
 ### Install PostCSS
 
 To build or update your site's CSS resources, you also need
-[PostCSS](https://postcss.org/). Run the following commands from your site
-root directory to install the required packages:
+[PostCSS](https://postcss.org/). Run the following commands from your site root
+directory to install the required packages:
 
 ```bash
 npm install -D autoprefixer postcss-cli postcss
@@ -192,10 +192,10 @@ content:
 
 ```javascript
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    },
-}
+  plugins: {
+    autoprefixer: {},
+  },
+};
 ```
 
 For more details, see


### PR DESCRIPTION
The "Start a site from scratch" Hugo-module guide in
`docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md`
was missing the PostCSS installation step and `postcss.config.js` creation,
causing users to hit a `Cannot find module autoprefixer` error when running
`hugo server` on a freshly created site.

The TL;DR command blocks (both Unix and Windows) now include
`npm install -D autoprefixer postcss-cli postcss` and the creation of
`postcss.config.js` with the autoprefixer plugin configuration. A new
"Install PostCSS" subsection was also added to the Detailed Setup instructions
with the same commands and a cross-reference to the
[installation prerequisites page](https://www.docsy.dev/docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss).

Fixes #1718
