### PR TITLE
Footer copyright: collapse a same-year range to a single year

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -298,6 +298,7 @@ https://github.com/google/docsy/issues/1944,200,1782498238
 https://github.com/google/docsy/issues/2,200,1782498235
 https://github.com/google/docsy/issues/2001,200,1782498235
 https://github.com/google/docsy/issues/2035,200,1782498234
+https://github.com/google/docsy/issues/2047,200,1786837489
 https://github.com/google/docsy/issues/2108,200,1782498237
 https://github.com/google/docsy/issues/2115,200,1782498224
 https://github.com/google/docsy/issues/2116,200,1782563369

--- a/docsy.dev/content/en/blog/2024/0.9.0.md
+++ b/docsy.dev/content/en/blog/2024/0.9.0.md
@@ -55,7 +55,7 @@ fallback:
   default `authors` is "<Site.Title> Authors" and this field is rendered as
   markdown.
 - If `params.copyright` is unset, then the [site `copyright`][] configuration
-  option will be used and rendered as markdown "as is" &mdash; with no date(s)
+  option will be used and rendered as HTML "as is" &mdash; with no date(s)
   added.
 
 [site `copyright`]: https://gohugo.io/methods/site/copyright/

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -832,12 +832,10 @@ a map with the following optional fields:
   - Tip: a non-year string such as "present" also works, and stays accurate even
     when the site isn't rebuilt every year.
 
-The notice shows a year range only when `from_year` and `to_year` differ;
-otherwise it shows a single year. A `from_year` later than `to_year` renders as
-configured; when both values are years, the build also logs a warning. Set
-`from_year` to your site's launch year to get a notice that spans the launch
-year through the build year, and shows the launch year alone until the year
-after launch. For example:
+A `from_year` later than `to_year` renders as configured; when both values are
+years, the build also logs a warning. Set `from_year` to your site's launch year
+to get a notice that spans the launch year through the build year, and shows the
+launch year alone until the year after launch. For example:
 
 ```yaml
 params:

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -814,6 +814,41 @@ params:
   https://github.com/google/docsy/blob/main/theme/layouts/_partials/theme-toggler.html
 [search box]: /docs/content/search/
 
+## Footer copyright
+
+Use the `params.copyright` config option to set the copyright notice shown in
+the site footer. It can be a plain string, used as the copyright-holder text, or
+a map with the following optional fields:
+
+- `authors`: the copyright holders, rendered as Markdown. Default: the site
+  title followed by " Authors".
+- `from_year`: the first year of publication. Default: the value of `to_year`.
+- `to_year`: the last year of publication; can also be a non-year string such as
+  "present". Default: the year that the site was built.
+
+The notice shows a year range only when `from_year` and `to_year` differ;
+otherwise it shows a single year. Set `from_year` to your site's launch year to
+get a notice that spans the launch year through the build year, and shows the
+launch year alone until the year after launch. For example:
+
+```yaml
+params:
+  copyright:
+    authors: >-
+      Docsy Authors | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0)
+    from_year: 2018
+```
+
+With a build year of 2026, this renders as:
+
+> © 2018–2026 Docsy Authors | [CC BY 4.0][]
+
+If `params.copyright` is unset, the [site `copyright`][] option is used instead,
+rendered as HTML, with no year added.
+
+[CC BY 4.0]: https://creativecommons.org/licenses/by/4.0
+[site `copyright`]: https://gohugo.io/methods/site/copyright/
+
 ## Alerts
 
 > [!NOTE] Coming soon: how to customize alerts

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -821,7 +821,7 @@ the site footer. It can be a plain string, used as the copyright-holder text, or
 a map with the following optional fields:
 
 - `authors`:
-  - Copyright holders, as single-paragraph Markdown.
+  - Copyright holders, as a single Markdown paragraph.
   - Default: the site title followed by "Authors".
 - `from_year`:
   - First year of publication.

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -825,7 +825,7 @@ a map with the following optional fields:
   - Default: the site title followed by "Authors".
 - `from_year`:
   - First year of publication.
-  - Default: the value of `to_year`.
+  - When unset, or equal to `to_year`, the notice shows a single year.
 - `to_year`:
   - Last year of publication.
   - Default: the year that the site was built.
@@ -833,8 +833,9 @@ a map with the following optional fields:
     when the site isn't rebuilt every year.
 
 The notice shows a year range only when `from_year` and `to_year` differ;
-otherwise it shows a single year. Set `from_year` to your site's launch year to
-get a notice that spans the launch year through the build year, and shows the
+otherwise it shows a single year. A `from_year` later than `to_year` renders as
+configured and logs a build warning. Set `from_year` to your site's launch year
+to get a notice that spans the launch year through the build year, and shows the
 launch year alone until the year after launch. For example:
 
 ```yaml

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -820,11 +820,15 @@ Use the `params.copyright` config option to set the copyright notice shown in
 the site footer. It can be a plain string, used as the copyright-holder text, or
 a map with the following optional fields:
 
-- `authors`: the copyright holders, rendered as Markdown. Default: the site
-  title followed by " Authors".
-- `from_year`: the first year of publication. Default: the value of `to_year`.
-- `to_year`: the last year of publication; can also be a non-year string such as
-  "present". Default: the year that the site was built.
+- `authors`:
+  - Copyright holders, rendered as Markdown.
+  - Default: the site title followed by "Authors".
+- `from_year`:
+  - First year of publication.
+  - Default: the value of `to_year`.
+- `to_year`:
+  - Last year of publication; can also be a non-year string such as "present".
+  - Default: the year that the site was built.
 
 The notice shows a year range only when `from_year` and `to_year` differ;
 otherwise it shows a single year. Set `from_year` to your site's launch year to

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -821,7 +821,7 @@ the site footer. It can be a plain string, used as the copyright-holder text, or
 a map with the following optional fields:
 
 - `authors`:
-  - Copyright holders, rendered as Markdown.
+  - Copyright holders, as single-paragraph Markdown.
   - Default: the site title followed by "Authors".
 - `from_year`:
   - First year of publication.
@@ -834,9 +834,10 @@ a map with the following optional fields:
 
 The notice shows a year range only when `from_year` and `to_year` differ;
 otherwise it shows a single year. A `from_year` later than `to_year` renders as
-configured and logs a build warning. Set `from_year` to your site's launch year
-to get a notice that spans the launch year through the build year, and shows the
-launch year alone until the year after launch. For example:
+configured; when both values are years, the build also logs a warning. Set
+`from_year` to your site's launch year to get a notice that spans the launch
+year through the build year, and shows the launch year alone until the year
+after launch. For example:
 
 ```yaml
 params:

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -849,8 +849,8 @@ With a build year of 2026, this renders as:
 
 > © 2018–2026 Docsy Authors | [CC BY 4.0][]
 
-If `params.copyright` is unset, the [site `copyright`][] option is used instead,
-rendered as HTML, with no year added.
+If `params.copyright` is unset or empty, the [site `copyright`][] option is used
+instead, rendered as HTML, with no year added.
 
 [CC BY 4.0]: https://creativecommons.org/licenses/by/4.0
 [site `copyright`]: https://gohugo.io/methods/site/copyright/

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -832,10 +832,8 @@ a map with the following optional fields:
   - Tip: a non-year string such as "present" also works, and stays accurate even
     when the site isn't rebuilt every year.
 
-A `from_year` later than `to_year` renders as configured; when both values are
-years, the build also logs a warning. Set `from_year` to your site's launch year
-to get a notice that spans the launch year through the build year, and shows the
-launch year alone until the year after launch. For example:
+Set `from_year` to your site's launch year to get a notice that spans the launch
+year through the build year. For example:
 
 ```yaml
 params:
@@ -848,6 +846,9 @@ params:
 With a build year of 2026, this renders as:
 
 > © 2018–2026 Docsy Authors | [CC BY 4.0][]
+
+A `from_year` later than `to_year` renders as configured; when both values are
+years, the build also logs a warning.
 
 If `params.copyright` is unset or empty, the [site `copyright`][] option is used
 instead, rendered as HTML, with no year added.

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -827,8 +827,10 @@ a map with the following optional fields:
   - First year of publication.
   - Default: the value of `to_year`.
 - `to_year`:
-  - Last year of publication; can also be a non-year string such as "present".
+  - Last year of publication.
   - Default: the year that the site was built.
+  - Tip: a non-year string such as "present" also works, and stays accurate even
+    when the site isn't rebuilt every year.
 
 The notice shows a year range only when `from_year` and `to_year` differ;
 otherwise it shows a single year. Set `from_year` to your site's launch year to

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -162,9 +162,8 @@ For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
 
 **Other changes**:
 
-- Fixed the footer copyright notice to show a single year when the year range
-  starts and ends in the same year; a range now renders only when `from_year`
-  and `to_year` differ. See the [footer copyright docs][] ([#2047][]).
+- Fixed and documented footer copyright year handling. See the [footer copyright
+  docs][] ([#2047][]).
 - Pinned the default Mermaid version to 11.16.1; pages previously loaded
   whatever `latest` resolved to on the CDN at page load. Sites can still
   override the version via [`params.mermaid.version`][mermaid-version]

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -162,6 +162,9 @@ For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
 
 **Other changes**:
 
+- Fixed the footer copyright notice to show a single year when the year range
+  starts and ends in the same year; a range now renders only when `from_year`
+  and `to_year` differ. See the [footer copyright docs][] ([#2047][]).
 - Pinned the default Mermaid version to 11.16.1; pages previously loaded
   whatever `latest` resolved to on the CDN at page load. Sites can still
   override the version via [`params.mermaid.version`][mermaid-version]
@@ -184,10 +187,12 @@ For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
   `params.mermaid.version`, guarded by the repo test suite (`test:repo`). See
   [Default Mermaid version][mermaid-version-notes].
 
+[#2047]: https://github.com/google/docsy/issues/2047
 [#2700]: https://github.com/google/docsy/pull/2700
 [#2703]: https://github.com/google/docsy/issues/2703
 [#2712]: https://github.com/google/docsy/pull/2712
 [#2714]: https://github.com/google/docsy/pull/2714
+[footer copyright docs]: /docs/content/lookandfeel/#footer-copyright
 [mermaid-version]: /docs/content/diagrams-and-formulae/#diagrams-with-mermaid
 [mermaid-version-notes]: /project/about/maintainer-notes/#mermaid-version
 [0.16.1]: https://github.com/google/docsy/releases/latest?FIXME=v0.16.1

--- a/tests/fixture-site/copyright.test.mjs
+++ b/tests/fixture-site/copyright.test.mjs
@@ -12,10 +12,9 @@ import { buildSite } from './lib/build-site.mjs';
 // a dropped or ignored clock flag fails the build-year assertions.
 const BUILD_YEAR = new Date().getFullYear() + 4;
 
-// Builds a fixture site with the given `params.copyright` fields and returns
-// the rendered copyright text, whitespace-normalized, up to the authors span.
-function copyrightText(name, fields) {
-  const r = buildSite(`copyright-${name}`, {
+// Builds a fixture site with the given `params.copyright` fields.
+function build(name, fields) {
+  return buildSite(`copyright-${name}`, {
     files: {
       'content/docs/_index.md': '---\ntitle: Copyright check\n---\n',
     },
@@ -28,6 +27,12 @@ function copyrightText(name, fields) {
         .map(([k, v]) => `    ${k}: ${JSON.stringify(v)}\n`)
         .join(''),
   });
+}
+
+// Returns the rendered copyright text, whitespace-normalized, up to the
+// authors span.
+function copyrightText(name, fields) {
+  const r = build(name, fields);
   assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
   const m = r
     .publicFile('docs/index.html')
@@ -99,6 +104,32 @@ test('build year alone renders when both year fields are unset', () => {
     copyrightText('no-years', { authors: 'Test Authors' }),
     `&copy; ${BUILD_YEAR}`,
   );
+});
+
+test('from_year later than to_year logs a build warning', () => {
+  const r = build('reversed', { from_year: 2025, to_year: 2024 });
+  assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
+  assert.match(
+    r.stdout + r.stderr,
+    /WARN.*from_year \(2025\) is later than to_year \(2024\)/,
+    'reversed year range logs a warning',
+  );
+});
+
+test('valid year configs build without warnings', () => {
+  for (const fields of [
+    { from_year: 2018, to_year: 2024 },
+    { from_year: 2018, to_year: 'present' },
+    { from_year: 2018 },
+  ]) {
+    const r = build('no-warn', fields);
+    assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
+    assert.doesNotMatch(
+      r.stdout + r.stderr,
+      /WARN.*_year/,
+      `no year warning for ${JSON.stringify(fields)}`,
+    );
+  }
 });
 
 // Param-level rule: an empty `params.copyright` value behaves as unset, so

--- a/tests/fixture-site/copyright.test.mjs
+++ b/tests/fixture-site/copyright.test.mjs
@@ -8,9 +8,9 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { buildSite } from './lib/build-site.mjs';
 
-// Distinct from the real current year, so a passing build-year assertion
-// proves the default comes from the test-pinned build clock.
-const BUILD_YEAR = 2030;
+// Pinned via --clock; derived to always differ from the real current year, so
+// a dropped or ignored clock flag fails the build-year assertions.
+const BUILD_YEAR = new Date().getFullYear() + 4;
 
 // Builds a fixture site with the given `params.copyright` fields and returns
 // the rendered copyright text, whitespace-normalized, up to the authors span.
@@ -23,7 +23,9 @@ function copyrightText(name, fields) {
     extraConfig:
       'params:\n  copyright:\n' +
       Object.entries(fields)
-        .map(([k, v]) => `    ${k}: ${v}\n`)
+        // JSON.stringify quotes strings, keeping numbers bare, so YAML
+        // preserves each field's JS type (e.g. a quoted numeric to_year).
+        .map(([k, v]) => `    ${k}: ${JSON.stringify(v)}\n`)
         .join(''),
   });
   assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
@@ -53,6 +55,13 @@ test('non-year to_year such as "present" renders a range', () => {
 test('from_year equal to to_year collapses to a single year', () => {
   assert.equal(
     copyrightText('same-year', { from_year: 2024, to_year: 2024 }),
+    '&copy; 2024',
+  );
+});
+
+test('quoted-string to_year equal to numeric from_year collapses', () => {
+  assert.equal(
+    copyrightText('mixed-types', { from_year: 2024, to_year: '2024' }),
     '&copy; 2024',
   );
 });

--- a/tests/fixture-site/copyright.test.mjs
+++ b/tests/fixture-site/copyright.test.mjs
@@ -80,6 +80,20 @@ test('from_year equal to the build year collapses to a single year', () => {
   );
 });
 
+test('whitespace-only from_year behaves as unset', () => {
+  assert.equal(
+    copyrightText('ws-from', { from_year: '   ', to_year: 2024 }),
+    '&copy; 2024',
+  );
+});
+
+test('whitespace-only to_year behaves as unset', () => {
+  assert.equal(
+    copyrightText('ws-to', { from_year: 2018, to_year: '   ' }),
+    `&copy; 2018&ndash;${BUILD_YEAR}`,
+  );
+});
+
 test('build year alone renders when both year fields are unset', () => {
   assert.equal(
     copyrightText('no-years', { authors: 'Test Authors' }),

--- a/tests/fixture-site/copyright.test.mjs
+++ b/tests/fixture-site/copyright.test.mjs
@@ -29,10 +29,9 @@ function build(name, fields) {
   });
 }
 
-// Returns the rendered copyright text, whitespace-normalized, up to the
-// authors span.
-function copyrightText(name, fields) {
-  const r = build(name, fields);
+// Returns the rendered copyright text of a build result,
+// whitespace-normalized, up to the authors span.
+function noticeText(r) {
   assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
   const m = r
     .publicFile('docs/index.html')
@@ -41,6 +40,10 @@ function copyrightText(name, fields) {
     );
   assert.ok(m, 'footer copyright span is rendered');
   return m[1].replace(/\s+/g, ' ').trim();
+}
+
+function copyrightText(name, fields) {
+  return noticeText(build(name, fields));
 }
 
 test('from_year earlier than to_year renders a range', () => {
@@ -106,14 +109,37 @@ test('build year alone renders when both year fields are unset', () => {
   );
 });
 
+test('padded year values are trimmed for rendering', () => {
+  assert.equal(
+    copyrightText('padded', { from_year: ' 2018 ', to_year: 2024 }),
+    '&copy; 2018&ndash;2024',
+  );
+});
+
 test('from_year later than to_year logs a build warning', () => {
   const r = build('reversed', { from_year: 2025, to_year: 2024 });
-  assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
   assert.match(
     r.stdout + r.stderr,
     /WARN.*from_year \(2025\) is later than to_year \(2024\)/,
     'reversed year range logs a warning',
   );
+  assert.equal(
+    noticeText(r),
+    '&copy; 2025&ndash;2024',
+    'reversed range still renders as configured',
+  );
+});
+
+test('years outside the diagnostic domain render without warning', () => {
+  const r = build('huge-years', {
+    from_year: '9223372036854775808',
+    to_year: '9223372036854775807',
+  });
+  assert.equal(
+    noticeText(r),
+    '&copy; 9223372036854775808&ndash;9223372036854775807',
+  );
+  assert.doesNotMatch(r.stdout + r.stderr, /WARN.*copyright/i);
 });
 
 test('valid year configs build without warnings', () => {
@@ -121,19 +147,21 @@ test('valid year configs build without warnings', () => {
     { from_year: 2018, to_year: 2024 },
     { from_year: 2018, to_year: 'present' },
     { from_year: 2018 },
+    { from_year: 2024, to_year: 2024 },
+    { from_year: ' 2024 ', to_year: 2024 },
   ]) {
     const r = build('no-warn', fields);
     assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
     assert.doesNotMatch(
       r.stdout + r.stderr,
-      /WARN.*_year/,
-      `no year warning for ${JSON.stringify(fields)}`,
+      /WARN.*copyright/i,
+      `no copyright warning for ${JSON.stringify(fields)}`,
     );
   }
 });
 
 // Param-level rule: an empty `params.copyright` value behaves as unset, so
-// the site `copyright` fallback applies (rendered as is, no year added).
+// the site `copyright` fallback applies (rendered as raw HTML, no year added).
 for (const [name, value] of [
   ['empty map', '{}'],
   ['empty string', "''"],
@@ -143,13 +171,13 @@ for (const [name, value] of [
       files: {
         'content/docs/_index.md': '---\ntitle: Copyright check\n---\n',
       },
-      extraConfig: `copyright: Site fallback\nparams:\n  copyright: ${value}\n`,
+      extraConfig: `copyright: <b>Site</b> fallback\nparams:\n  copyright: ${value}\n`,
     });
     assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
     const m = r
       .publicFile('docs/index.html')
       .match(/<span class="td-footer__copyright">([\s\S]*?)<\/span>/);
     assert.ok(m, 'footer copyright span is rendered');
-    assert.equal(m[1].replace(/\s+/g, ' ').trim(), 'Site fallback');
+    assert.equal(m[1].replace(/\s+/g, ' ').trim(), '<b>Site</b> fallback');
   });
 }

--- a/tests/fixture-site/copyright.test.mjs
+++ b/tests/fixture-site/copyright.test.mjs
@@ -160,6 +160,26 @@ test('valid year configs build without warnings', () => {
   }
 });
 
+test('authors Markdown renders on non-Markdown pages', () => {
+  const r = buildSite('copyright-org-page', {
+    files: {
+      'content/docs/_index.md': '---\ntitle: Copyright check\n---\n',
+      'content/docs/org/index.org': '#+title: Org page\n',
+    },
+    extraConfig:
+      'params:\n  copyright:\n' +
+      '    authors: "[ACME](https://example.com/authors)"\n',
+  });
+  assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
+  for (const page of ['docs/index.html', 'docs/org/index.html']) {
+    assert.match(
+      r.publicFile(page),
+      /<span class="td-footer__authors"><a href="https:\/\/example\.com\/authors">ACME<\/a><\/span>/,
+      `authors link is Markdown-rendered on ${page}`,
+    );
+  }
+});
+
 // Param-level rule: an empty `params.copyright` value behaves as unset, so
 // the site `copyright` fallback applies (rendered as raw HTML, no year added).
 for (const [name, value] of [

--- a/tests/fixture-site/copyright.test.mjs
+++ b/tests/fixture-site/copyright.test.mjs
@@ -1,6 +1,5 @@
-// Contract tests for the footer copyright partial (#2047): `to_year` defaults
-// to the build year, and a year range renders only when `from_year` differs
-// from the resolved `to_year` — otherwise the footer shows `to_year` alone.
+// Contract tests for the footer copyright partial's year handling (#2047);
+// the contract's home is the user guide's "Footer copyright" section.
 //
 // TDD trace: the two collapse cases were red against the pre-#2047 partial.
 
@@ -12,7 +11,6 @@ import { buildSite } from './lib/build-site.mjs';
 // a dropped or ignored clock flag fails the build-year assertions.
 const BUILD_YEAR = new Date().getFullYear() + 4;
 
-// Builds a fixture site with the given `params.copyright` fields.
 function build(name, fields) {
   return buildSite(`copyright-${name}`, {
     files: {
@@ -126,7 +124,7 @@ test('from_year later than to_year logs a build warning', () => {
   assert.equal(
     noticeText(r),
     '&copy; 2025&ndash;2024',
-    'reversed range still renders as configured',
+    'reversed range renders as configured',
   );
 });
 
@@ -155,7 +153,7 @@ test('valid year configs build without warnings', () => {
     assert.doesNotMatch(
       r.stdout + r.stderr,
       /WARN.*copyright/i,
-      `no copyright warning for ${JSON.stringify(fields)}`,
+      `warning-free build for ${JSON.stringify(fields)}`,
     );
   }
 });
@@ -216,8 +214,8 @@ test('authors defaults to the site title plus "Authors"', () => {
   );
 });
 
-// Param-level rule: an empty `params.copyright` value behaves as unset, so
-// the site `copyright` fallback applies (rendered as raw HTML, no year added).
+// Param-level rule: an empty `params.copyright` behaves as unset, exercising
+// the site `copyright` fallback.
 for (const [name, value] of [
   ['empty map', '{}'],
   ['empty string', "''"],

--- a/tests/fixture-site/copyright.test.mjs
+++ b/tests/fixture-site/copyright.test.mjs
@@ -100,3 +100,25 @@ test('build year alone renders when both year fields are unset', () => {
     `&copy; ${BUILD_YEAR}`,
   );
 });
+
+// Param-level rule: an empty `params.copyright` value behaves as unset, so
+// the site `copyright` fallback applies (rendered as is, no year added).
+for (const [name, value] of [
+  ['empty map', '{}'],
+  ['empty string', "''"],
+]) {
+  test(`${name} params.copyright falls back to site copyright`, () => {
+    const r = buildSite(`copyright-fallback-${name.replace(' ', '-')}`, {
+      files: {
+        'content/docs/_index.md': '---\ntitle: Copyright check\n---\n',
+      },
+      extraConfig: `copyright: Site fallback\nparams:\n  copyright: ${value}\n`,
+    });
+    assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
+    const m = r
+      .publicFile('docs/index.html')
+      .match(/<span class="td-footer__copyright">([\s\S]*?)<\/span>/);
+    assert.ok(m, 'footer copyright span is rendered');
+    assert.equal(m[1].replace(/\s+/g, ' ').trim(), 'Site fallback');
+  });
+}

--- a/tests/fixture-site/copyright.test.mjs
+++ b/tests/fixture-site/copyright.test.mjs
@@ -180,6 +180,42 @@ test('authors Markdown renders on non-Markdown pages', () => {
   }
 });
 
+test('string params.copyright is the authors text', () => {
+  const r = buildSite('copyright-string-form', {
+    files: {
+      'content/docs/_index.md': '---\ntitle: Copyright check\n---\n',
+    },
+    args: ['--clock', `${BUILD_YEAR}-06-01T00:00:00Z`],
+    extraConfig: 'params:\n  copyright: ACME Legal\n',
+  });
+  assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
+  const m = r
+    .publicFile('docs/index.html')
+    .match(/<span class="td-footer__copyright">([\s\S]*?)<\/span>\s*<\/span>/);
+  assert.ok(m, 'footer copyright span is rendered');
+  assert.equal(
+    m[1].replace(/\s+/g, ' ').trim(),
+    `&copy; ${BUILD_YEAR} <span class="td-footer__authors">ACME Legal`,
+  );
+});
+
+test('authors defaults to the site title plus "Authors"', () => {
+  const r = buildSite('copyright-default-authors', {
+    title: 'ACME Docs',
+    files: {
+      'content/docs/_index.md': '---\ntitle: Copyright check\n---\n',
+    },
+    args: ['--clock', `${BUILD_YEAR}-06-01T00:00:00Z`],
+    extraConfig: 'params:\n  copyright:\n    from_year: 2018\n',
+  });
+  assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
+  assert.match(
+    r.publicFile('docs/index.html'),
+    /<span class="td-footer__authors">ACME Docs Authors<\/span>/,
+    'default authors text is rendered',
+  );
+});
+
 // Param-level rule: an empty `params.copyright` value behaves as unset, so
 // the site `copyright` fallback applies (rendered as raw HTML, no year added).
 for (const [name, value] of [

--- a/tests/fixture-site/copyright.test.mjs
+++ b/tests/fixture-site/copyright.test.mjs
@@ -1,0 +1,79 @@
+// Contract tests for the footer copyright partial (#2047): `to_year` defaults
+// to the build year, and a year range renders only when `from_year` differs
+// from the resolved `to_year` — otherwise the footer shows `to_year` alone.
+//
+// TDD trace: the two collapse cases were red against the pre-#2047 partial.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSite } from './lib/build-site.mjs';
+
+// Distinct from the real current year, so a passing build-year assertion
+// proves the default comes from the test-pinned build clock.
+const BUILD_YEAR = 2030;
+
+// Builds a fixture site with the given `params.copyright` fields and returns
+// the rendered copyright text, whitespace-normalized, up to the authors span.
+function copyrightText(name, fields) {
+  const r = buildSite(`copyright-${name}`, {
+    files: {
+      'content/docs/_index.md': '---\ntitle: Copyright check\n---\n',
+    },
+    args: ['--clock', `${BUILD_YEAR}-06-01T00:00:00Z`],
+    extraConfig:
+      'params:\n  copyright:\n' +
+      Object.entries(fields)
+        .map(([k, v]) => `    ${k}: ${v}\n`)
+        .join(''),
+  });
+  assert.equal(r.status, 0, `hugo build succeeded:\n${r.stdout}${r.stderr}`);
+  const m = r
+    .publicFile('docs/index.html')
+    .match(
+      /<span class="td-footer__copyright">([\s\S]*?)<span class="td-footer__authors">/,
+    );
+  assert.ok(m, 'footer copyright span is rendered');
+  return m[1].replace(/\s+/g, ' ').trim();
+}
+
+test('from_year earlier than to_year renders a range', () => {
+  assert.equal(
+    copyrightText('range', { from_year: 2018, to_year: 2024 }),
+    '&copy; 2018&ndash;2024',
+  );
+});
+
+test('non-year to_year such as "present" renders a range', () => {
+  assert.equal(
+    copyrightText('present', { from_year: 2018, to_year: 'present' }),
+    '&copy; 2018&ndash;present',
+  );
+});
+
+test('from_year equal to to_year collapses to a single year', () => {
+  assert.equal(
+    copyrightText('same-year', { from_year: 2024, to_year: 2024 }),
+    '&copy; 2024',
+  );
+});
+
+test('to_year defaults to the build year', () => {
+  assert.equal(
+    copyrightText('from-only', { from_year: 2018 }),
+    `&copy; 2018&ndash;${BUILD_YEAR}`,
+  );
+});
+
+test('from_year equal to the build year collapses to a single year', () => {
+  assert.equal(
+    copyrightText('launch-year', { from_year: BUILD_YEAR }),
+    `&copy; ${BUILD_YEAR}`,
+  );
+});
+
+test('build year alone renders when both year fields are unset', () => {
+  assert.equal(
+    copyrightText('no-years', { authors: 'Test Authors' }),
+    `&copy; ${BUILD_YEAR}`,
+  );
+});

--- a/tests/fixture-site/lib/build-site.mjs
+++ b/tests/fixture-site/lib/build-site.mjs
@@ -52,7 +52,7 @@ themesDir: ${repoRoot}
 // result plus the site path and a `publicFile(relPath)` reader over the output.
 export function buildSite(
   name,
-  { files = {}, srcDir, extraConfig = '', env = {}, title } = {},
+  { files = {}, srcDir, extraConfig = '', env = {}, title, args = [] } = {},
 ) {
   const site = path.join(FIXTURE_SITE_TMP, name);
   rmSync(site, { recursive: true, force: true });
@@ -75,7 +75,7 @@ export function buildSite(
   );
   // Run the locked local CLI through Node: no registry fallback or
   // platform-specific npm shim.
-  const r = spawnSync(process.execPath, [hugoCli], {
+  const r = spawnSync(process.execPath, [hugoCli, ...args], {
     cwd: site,
     encoding: 'utf8',
     env: { ...hugoEnv(), ...env },

--- a/tests/fixture-site/lib/build-site.mjs
+++ b/tests/fixture-site/lib/build-site.mjs
@@ -48,8 +48,10 @@ themesDir: ${repoRoot}
 // Site files come from `srcDir` (a checked-in fixture directory), `files`
 // (a relative-path → content map), or both. The generated hugo.yaml can be
 // extended via `extraConfig`, and its site `title` overridden (handy when two
-// builds must be identical apart from their output dir). Returns the spawnSync
-// result plus the site path and a `publicFile(relPath)` reader over the output.
+// builds must be identical apart from their output dir); extra Hugo CLI args
+// pass through `args`, process-env overrides through `env`. Returns the
+// spawnSync result plus the site path and a `publicFile(relPath)` reader over
+// the output.
 export function buildSite(
   name,
   { files = {}, srcDir, extraConfig = '', env = {}, title, args = [] } = {},

--- a/theme/layouts/_partials/footer/copyright.html
+++ b/theme/layouts/_partials/footer/copyright.html
@@ -27,7 +27,7 @@
     <span class="td-footer__authors">
       {{- $authors
             | default (printf "%s Authors" ($.Site.Title | default "Site"))
-            | $page.RenderString -}}
+            | $page.RenderString (dict "markup" "markdown") -}}
     </span>
     {{- /* Trim WS */ -}}
   </span>

--- a/theme/layouts/_partials/footer/copyright.html
+++ b/theme/layouts/_partials/footer/copyright.html
@@ -11,7 +11,7 @@
     {{ $authors = . -}}
   {{ end -}}
   {{ $toYear = $toYear | default now.Year -}}
-  {{ if and (findRE `^\d+$` $fromYear) (findRE `^\d+$` (string $toYear)) -}}
+  {{ if and (findRE `^[1-9]\d{0,3}$` $fromYear) (findRE `^[1-9]\d{0,3}$` (string $toYear)) -}}
     {{ if gt (int $fromYear) (int $toYear) -}}
       {{ warnf "Config params.copyright: from_year (%v) is later than to_year (%v)." $fromYear $toYear -}}
     {{ end -}}

--- a/theme/layouts/_partials/footer/copyright.html
+++ b/theme/layouts/_partials/footer/copyright.html
@@ -10,9 +10,14 @@
   {{ else -}}
     {{ $authors = . -}}
   {{ end -}}
+  {{ $toYear = $toYear | default now.Year -}}
+  {{ if and (findRE `^\d+$` $fromYear) (findRE `^\d+$` (string $toYear)) -}}
+    {{ if gt (int $fromYear) (int $toYear) -}}
+      {{ warnf "Config params.copyright: from_year (%v) is later than to_year (%v)." $fromYear $toYear -}}
+    {{ end -}}
+  {{ end -}}
 
   <span class="td-footer__copyright">&copy;
-    {{ $toYear = $toYear | default now.Year -}}
     {{ with $fromYear -}}
       {{ if ne (string .) (string $toYear) -}}
         {{ . }}&ndash;

--- a/theme/layouts/_partials/footer/copyright.html
+++ b/theme/layouts/_partials/footer/copyright.html
@@ -12,10 +12,13 @@
   {{ end -}}
 
   <span class="td-footer__copyright">&copy;
+    {{ $toYear = $toYear | default now.Year -}}
     {{ with $fromYear -}}
-      {{ . }}&ndash;
-    {{- end -}}
-    {{ $toYear | default now.Year }}
+      {{ if ne (string .) (string $toYear) -}}
+        {{ . }}&ndash;
+      {{- end -}}
+    {{ end -}}
+    {{ $toYear }}
     <span class="td-footer__authors">
       {{- $authors
             | default (printf "%s Authors" ($.Site.Title | default "Site"))

--- a/theme/layouts/_partials/footer/copyright.html
+++ b/theme/layouts/_partials/footer/copyright.html
@@ -11,6 +11,7 @@
     {{ $authors = . -}}
   {{ end -}}
   {{ $toYear = $toYear | default now.Year -}}
+  {{/* Diagnose only plausible years: skips values `int` can't take. */ -}}
   {{ if and (findRE `^[1-9]\d{0,3}$` $fromYear) (findRE `^[1-9]\d{0,3}$` (string $toYear)) -}}
     {{ if gt (int $fromYear) (int $toYear) -}}
       {{ warnf "Config params.copyright: from_year (%v) is later than to_year (%v)." $fromYear $toYear -}}

--- a/theme/layouts/_partials/footer/copyright.html
+++ b/theme/layouts/_partials/footer/copyright.html
@@ -4,8 +4,8 @@
   {{ $toYear := "" -}}
   {{ $authors := "" -}}
   {{ if reflect.IsMap . -}}
-    {{ $fromYear = .from_year -}}
-    {{ $toYear = .to_year -}}
+    {{ $fromYear = strings.TrimSpace (.from_year | default "") -}}
+    {{ $toYear = strings.TrimSpace (.to_year | default "") -}}
     {{ $authors = .authors -}}
   {{ else -}}
     {{ $authors = . -}}

--- a/theme/layouts/_partials/footer/copyright.html
+++ b/theme/layouts/_partials/footer/copyright.html
@@ -11,7 +11,7 @@
     {{ $authors = . -}}
   {{ end -}}
   {{ $toYear = $toYear | default now.Year -}}
-  {{/* Diagnose only plausible years: skips values `int` can't take. */ -}}
+  {{/* Diagnose only 1-4-digit years; wider input could break the int casts. */ -}}
   {{ if and (findRE `^[1-9]\d{0,3}$` $fromYear) (findRE `^[1-9]\d{0,3}$` (string $toYear)) -}}
     {{ if gt (int $fromYear) (int $toYear) -}}
       {{ warnf "Config params.copyright: from_year (%v) is later than to_year (%v)." $fromYear $toYear -}}


### PR DESCRIPTION
- Fixes #2047; supersedes #2091 (thanks @tcrouch for seeding the fix)
- **Contract**:
  - Renders a year range only when `from_year` differs from the resolved `to_year`; blank year fields count as unset
  - Keeps non-year `to_year` values such as "present" working (docsy.dev uses one)
  - Logs a build warning when `from_year` is later than `to_year`
  - Renders `authors` as Markdown on every page, fixing mangled footers on non-Markdown (e.g. Org) pages
  - Fails the build on non-scalar year values, which main rendered verbatim
- **Tests**:
  - Contract tests, red-proven against the pre-fix partial
  - The fixture harness gains Hugo CLI arg pass-through, used to pin the build clock
- **Docs**: adds the first user-guide home for `params.copyright` (new "Footer copyright" section) and a changelog entry
- **Preview(s)**:
  - [Footer copyright docs](https://deploy-preview-2720--docsydocs.netlify.app/docs/content/lookandfeel/#footer-copyright)
  - [Changelog entry](https://deploy-preview-2720--docsydocs.netlify.app/project/about/changelog/#next)
