### PR TITLE
Breadcrumb: swap Bootstrap classes for td- semantic classes

### DIFF
--- a/tests/fixture-site/goldens/breadcrumb-blog.html
+++ b/tests/fixture-site/goldens/breadcrumb-blog.html
@@ -1,8 +1,8 @@
 <nav aria-label="breadcrumb" class="td-breadcrumbs">
-  <ol class="breadcrumb">
-  <li class="breadcrumb-item">
+  <ol class="td-breadcrumbs__list">
+  <li class="td-breadcrumbs__item">
     <a href="/blog/">Blog</a></li>
-  <li class="breadcrumb-item active" aria-current="page">
+  <li class="td-breadcrumbs__item td-breadcrumbs__item--active" aria-current="page">
     First post</li>
   </ol>
 </nav>

--- a/tests/fixture-site/goldens/breadcrumb-blog.html
+++ b/tests/fixture-site/goldens/breadcrumb-blog.html
@@ -2,7 +2,7 @@
   <ol class="td-breadcrumbs__list">
   <li class="td-breadcrumbs__item">
     <a href="/blog/">Blog</a></li>
-  <li class="td-breadcrumbs__item td-breadcrumbs__item--active" aria-current="page">
+  <li class="td-breadcrumbs__item" aria-current="page">
     First post</li>
   </ol>
 </nav>

--- a/tests/fixture-site/goldens/breadcrumb-deep.html
+++ b/tests/fixture-site/goldens/breadcrumb-deep.html
@@ -1,10 +1,10 @@
 <nav aria-label="breadcrumb" class="td-breadcrumbs">
-  <ol class="breadcrumb">
-  <li class="breadcrumb-item">
+  <ol class="td-breadcrumbs__list">
+  <li class="td-breadcrumbs__item">
     <a href="/docs/">Docs</a></li>
-  <li class="breadcrumb-item">
+  <li class="td-breadcrumbs__item">
     <a href="/docs/getting-started/">Getting started</a></li>
-  <li class="breadcrumb-item active" aria-current="page">
+  <li class="td-breadcrumbs__item td-breadcrumbs__item--active" aria-current="page">
     Install</li>
   </ol>
 </nav>

--- a/tests/fixture-site/goldens/breadcrumb-deep.html
+++ b/tests/fixture-site/goldens/breadcrumb-deep.html
@@ -4,7 +4,7 @@
     <a href="/docs/">Docs</a></li>
   <li class="td-breadcrumbs__item">
     <a href="/docs/getting-started/">Getting started</a></li>
-  <li class="td-breadcrumbs__item td-breadcrumbs__item--active" aria-current="page">
+  <li class="td-breadcrumbs__item" aria-current="page">
     Install</li>
   </ol>
 </nav>

--- a/tests/fixture-site/goldens/breadcrumb-mid.html
+++ b/tests/fixture-site/goldens/breadcrumb-mid.html
@@ -2,7 +2,7 @@
   <ol class="td-breadcrumbs__list">
   <li class="td-breadcrumbs__item">
     <a href="/docs/">Docs</a></li>
-  <li class="td-breadcrumbs__item td-breadcrumbs__item--active" aria-current="page">
+  <li class="td-breadcrumbs__item" aria-current="page">
     Getting started</li>
   </ol>
 </nav>

--- a/tests/fixture-site/goldens/breadcrumb-mid.html
+++ b/tests/fixture-site/goldens/breadcrumb-mid.html
@@ -1,8 +1,8 @@
 <nav aria-label="breadcrumb" class="td-breadcrumbs">
-  <ol class="breadcrumb">
-  <li class="breadcrumb-item">
+  <ol class="td-breadcrumbs__list">
+  <li class="td-breadcrumbs__item">
     <a href="/docs/">Docs</a></li>
-  <li class="breadcrumb-item active" aria-current="page">
+  <li class="td-breadcrumbs__item td-breadcrumbs__item--active" aria-current="page">
     Getting started</li>
   </ol>
 </nav>

--- a/tests/fixture-site/goldens/breadcrumb-single.html
+++ b/tests/fixture-site/goldens/breadcrumb-single.html
@@ -1,6 +1,6 @@
 <nav aria-label="breadcrumb" class="td-breadcrumbs td-breadcrumbs__single">
-  <ol class="breadcrumb">
-  <li class="breadcrumb-item active" aria-current="page">
+  <ol class="td-breadcrumbs__list">
+  <li class="td-breadcrumbs__item td-breadcrumbs__item--active" aria-current="page">
     Docs</li>
   </ol>
 </nav>

--- a/tests/fixture-site/goldens/breadcrumb-single.html
+++ b/tests/fixture-site/goldens/breadcrumb-single.html
@@ -1,6 +1,6 @@
 <nav aria-label="breadcrumb" class="td-breadcrumbs td-breadcrumbs__single">
   <ol class="td-breadcrumbs__list">
-  <li class="td-breadcrumbs__item td-breadcrumbs__item--active" aria-current="page">
+  <li class="td-breadcrumbs__item" aria-current="page">
     Docs</li>
   </ol>
 </nav>

--- a/tests/fixture-site/goldens/breadcrumb-term.html
+++ b/tests/fixture-site/goldens/breadcrumb-term.html
@@ -1,10 +1,10 @@
 <nav class="td-breadcrumbs">
-  <ol class="breadcrumb">
-  <li class="breadcrumb-item">
+  <ol class="td-breadcrumbs__list">
+  <li class="td-breadcrumbs__item">
     <a href="/docs/">Docs</a></li>
-  <li class="breadcrumb-item">
+  <li class="td-breadcrumbs__item">
     <a href="/docs/getting-started/">Getting started</a></li>
-  <li class="breadcrumb-item">
+  <li class="td-breadcrumbs__item">
     Install</li>
   </ol>
 </nav>

--- a/tests/fixture-site/lib/markup-goldens.mjs
+++ b/tests/fixture-site/lib/markup-goldens.mjs
@@ -64,9 +64,10 @@ params:
 
 // name → golden file goldens/NAME.html; page → public file holding the
 // region; re overrides the default breadcrumb extractor. The term region
-// pins term.html's class-coupled post-processing of the breadcrumb partial
-// (replaceRE strips aria attributes and the active class), which silently
-// no-ops if the partial's class names change without the caller following.
+// pins term.html's post-processing of the breadcrumb partial (replaceRE
+// strips aria attributes, and with aria-current the current-item styling
+// hook), which silently no-ops if the partial's attribute emission changes
+// without the caller following.
 export const regions = [
   { name: 'breadcrumb-single', page: 'docs/index.html' },
   { name: 'breadcrumb-mid', page: 'docs/getting-started/index.html' },

--- a/tests/fixture-site/lib/markup-goldens.mjs
+++ b/tests/fixture-site/lib/markup-goldens.mjs
@@ -64,9 +64,9 @@ params:
 
 // name → golden file goldens/NAME.html; page → public file holding the
 // region; re overrides the default breadcrumb extractor. The term region
-// pins the partial's summary mode (term.html renders it without aria
-// attributes and active marking), so its extractor keys on the class, not
-// the aria label.
+// pins term.html's class-coupled post-processing of the breadcrumb partial
+// (replaceRE strips aria attributes and the active class), which silently
+// no-ops if the partial's class names change without the caller following.
 export const regions = [
   { name: 'breadcrumb-single', page: 'docs/index.html' },
   { name: 'breadcrumb-mid', page: 'docs/getting-started/index.html' },

--- a/tests/fixture-site/lib/markup-goldens.mjs
+++ b/tests/fixture-site/lib/markup-goldens.mjs
@@ -75,7 +75,7 @@ export const regions = [
   {
     name: 'breadcrumb-term',
     page: 'tags/setup/index.html',
-    re: /<nav[^>]*class="td-breadcrumbs[\s\S]*?<\/nav>/,
+    re: /<nav[^>]*class="td-breadcrumbs(?=[\s"])[\s\S]*?<\/nav>/,
   },
   // Blog baseof wraps the same partial in a different layout context.
   { name: 'breadcrumb-blog', page: 'blog/first-post/index.html' },

--- a/tests/fixture-site/lib/markup-goldens.mjs
+++ b/tests/fixture-site/lib/markup-goldens.mjs
@@ -64,9 +64,9 @@ params:
 
 // name → golden file goldens/NAME.html; page → public file holding the
 // region; re overrides the default breadcrumb extractor. The term region
-// pins term.html's class-coupled post-processing of the breadcrumb partial
-// (replaceRE strips aria attributes and the active class), which silently
-// no-ops if the partial's class names change without the caller following.
+// pins the partial's summary mode (term.html renders it without aria
+// attributes and active marking), so its extractor keys on the class, not
+// the aria label.
 export const regions = [
   { name: 'breadcrumb-single', page: 'docs/index.html' },
   { name: 'breadcrumb-mid', page: 'docs/getting-started/index.html' },

--- a/tests/fixture-site/output-classes.test.mjs
+++ b/tests/fixture-site/output-classes.test.mjs
@@ -20,7 +20,23 @@ import { buildFixture } from './lib/markup-goldens.mjs';
 // name → label; partial → the CLEARED_PARTIALS entry this region covers;
 // re → the rendered region (global regex: every instance on every listed
 // page is checked); pages → every fixture page kind the partial renders on.
-const CLEARED_REGIONS = [];
+const CLEARED_REGIONS = [
+  {
+    name: 'breadcrumb',
+    partial: '_partials/breadcrumb.html',
+    re: /<nav[^>]*class="td-breadcrumbs[\s\S]*?<\/nav>/g,
+    pages: [
+      'blog/first-post/index.html',
+      'blog/index.html',
+      'docs/getting-started/index.html',
+      'docs/getting-started/install/index.html',
+      'docs/index.html',
+      'docs/reference/config/index.html',
+      'docs/reference/index.html',
+      'tags/setup/index.html',
+    ],
+  },
+];
 
 // partial → why the fixture cannot render it (config-gated, error-path…).
 // An entry here is reviewed debt: the lint and review are its only nets.

--- a/tests/fixture-site/output-classes.test.mjs
+++ b/tests/fixture-site/output-classes.test.mjs
@@ -24,7 +24,7 @@ const CLEARED_REGIONS = [
   {
     name: 'breadcrumb',
     partial: '_partials/breadcrumb.html',
-    re: /<nav[^>]*class="td-breadcrumbs[\s\S]*?<\/nav>/g,
+    re: /<nav[^>]*class="td-breadcrumbs(?=[\s"])[\s\S]*?<\/nav>/g,
     pages: [
       'blog/first-post/index.html',
       'blog/index.html',

--- a/tests/lib/cleared-partials.mjs
+++ b/tests/lib/cleared-partials.mjs
@@ -4,4 +4,4 @@
 // (../fixture-site/output-classes.test.mjs) enforces that each one's
 // rendered surface is covered by a region (or carries a documented
 // exemption). Paths are relative to theme/layouts/.
-export const CLEARED_PARTIALS = [];
+export const CLEARED_PARTIALS = ['_partials/breadcrumb.html'];

--- a/theme/assets/scss/td/_breadcrumb.scss
+++ b/theme/assets/scss/td/_breadcrumb.scss
@@ -1,37 +1,14 @@
 // Breadcrumb
 
-// Bootstrap's breadcrumb styling mapped onto the td- semantic classes,
-// still consuming the --bs-* customization vars (Docsy-own tokens are the
-// token-inventory increment's job). Vars Bootstrap leaves empty (bg,
-// border-radius, font-size) are consumed but not redefined: unset they
-// compute to the same values, and an ancestor-level override now reaches
-// them.
+// Bootstrap skin: style by @extend. State classes are written out against
+// Bootstrap's public vars (extending a generic state class like .active
+// would splice us into every compound that uses it).
 .td-breadcrumbs__list {
-  --bs-breadcrumb-padding-x: 0;
-  --bs-breadcrumb-padding-y: 0;
-  --bs-breadcrumb-margin-bottom: 1rem;
-  --bs-breadcrumb-divider-color: var(--bs-secondary-color);
-  --bs-breadcrumb-item-padding-x: 0.5rem;
-  --bs-breadcrumb-item-active-color: var(--bs-secondary-color);
-  display: flex;
-  flex-wrap: wrap;
-  padding: var(--bs-breadcrumb-padding-y) var(--bs-breadcrumb-padding-x);
-  margin-bottom: var(--bs-breadcrumb-margin-bottom);
-  font-size: var(--bs-breadcrumb-font-size);
-  list-style: none;
-  background-color: var(--bs-breadcrumb-bg);
-  border-radius: var(--bs-breadcrumb-border-radius);
+  @extend .breadcrumb;
 }
 
-.td-breadcrumbs__item + .td-breadcrumbs__item {
-  padding-left: var(--bs-breadcrumb-item-padding-x);
-
-  &::before {
-    float: left;
-    padding-right: var(--bs-breadcrumb-item-padding-x);
-    color: var(--bs-breadcrumb-divider-color);
-    content: var(--bs-breadcrumb-divider, '/');
-  }
+.td-breadcrumbs__item {
+  @extend .breadcrumb-item;
 }
 
 .td-breadcrumbs__item--active {

--- a/theme/assets/scss/td/_breadcrumb.scss
+++ b/theme/assets/scss/td/_breadcrumb.scss
@@ -1,5 +1,43 @@
 // Breadcrumb
 
+// Bootstrap's breadcrumb styling mapped onto the td- semantic classes,
+// still consuming the --bs-* customization vars (Docsy-own tokens are the
+// token-inventory increment's job). Vars Bootstrap leaves empty (bg,
+// border-radius, font-size) are consumed but not redefined: unset they
+// compute to the same values, and an ancestor-level override now reaches
+// them.
+.td-breadcrumbs__list {
+  --bs-breadcrumb-padding-x: 0;
+  --bs-breadcrumb-padding-y: 0;
+  --bs-breadcrumb-margin-bottom: 1rem;
+  --bs-breadcrumb-divider-color: var(--bs-secondary-color);
+  --bs-breadcrumb-item-padding-x: 0.5rem;
+  --bs-breadcrumb-item-active-color: var(--bs-secondary-color);
+  display: flex;
+  flex-wrap: wrap;
+  padding: var(--bs-breadcrumb-padding-y) var(--bs-breadcrumb-padding-x);
+  margin-bottom: var(--bs-breadcrumb-margin-bottom);
+  font-size: var(--bs-breadcrumb-font-size);
+  list-style: none;
+  background-color: var(--bs-breadcrumb-bg);
+  border-radius: var(--bs-breadcrumb-border-radius);
+}
+
+.td-breadcrumbs__item + .td-breadcrumbs__item {
+  padding-left: var(--bs-breadcrumb-item-padding-x);
+
+  &::before {
+    float: left;
+    padding-right: var(--bs-breadcrumb-item-padding-x);
+    color: var(--bs-breadcrumb-divider-color);
+    content: var(--bs-breadcrumb-divider, '/');
+  }
+}
+
+.td-breadcrumbs__item--active {
+  color: var(--bs-breadcrumb-item-active-color);
+}
+
 .td-breadcrumbs {
   @media print {
     display: none;
@@ -9,7 +47,7 @@
     display: none;
   }
 
-  .breadcrumb {
+  .td-breadcrumbs__list {
     background: inherit;
     padding-left: 0;
     padding-top: 0;

--- a/theme/assets/scss/td/_breadcrumb.scss
+++ b/theme/assets/scss/td/_breadcrumb.scss
@@ -1,10 +1,5 @@
 // Breadcrumb
 
-// Bootstrap skin: style by @extend. State rules key on semantic attributes
-// (aria-current) and are written out against Bootstrap's public vars
-// (extending a generic state class like .active would splice us into every
-// compound that uses it); the BS-mirror marker cites the mirrored source
-// rule for upgrade audits.
 .td-breadcrumbs__list {
   @extend .breadcrumb;
 }

--- a/theme/assets/scss/td/_breadcrumb.scss
+++ b/theme/assets/scss/td/_breadcrumb.scss
@@ -1,18 +1,5 @@
 // Breadcrumb
 
-.td-breadcrumbs__list {
-  @extend .breadcrumb;
-}
-
-.td-breadcrumbs__item {
-  @extend .breadcrumb-item;
-}
-
-// BS mirror: _breadcrumb.scss .breadcrumb-item.active
-.td-breadcrumbs__item[aria-current='page'] {
-  color: var(--bs-breadcrumb-item-active-color);
-}
-
 .td-breadcrumbs {
   @media print {
     display: none;
@@ -22,9 +9,20 @@
     display: none;
   }
 
-  .td-breadcrumbs__list {
+  &__list {
+    @extend .breadcrumb;
+
     background: inherit;
     padding-left: 0;
     padding-top: 0;
+  }
+
+  &__item {
+    @extend .breadcrumb-item;
+
+    // BS mirror: _breadcrumb.scss .breadcrumb-item.active
+    &[aria-current='page'] {
+      color: var(--bs-breadcrumb-item-active-color);
+    }
   }
 }

--- a/theme/assets/scss/td/_breadcrumb.scss
+++ b/theme/assets/scss/td/_breadcrumb.scss
@@ -13,9 +13,10 @@
     @extend .breadcrumb;
   }
 
-  // Descendant-scoped: outranks consumer rules on the extended .breadcrumb
-  // group, which tie a flat &__list in specificity and win by source order.
-  .td-breadcrumbs__list {
+  // Descendant-scoped (& &__list): outranks consumer rules on the extended
+  // .breadcrumb group, which tie a flat &__list in specificity and win by
+  // source order.
+  & &__list {
     background: inherit;
     padding-left: 0;
     padding-top: 0;

--- a/theme/assets/scss/td/_breadcrumb.scss
+++ b/theme/assets/scss/td/_breadcrumb.scss
@@ -1,8 +1,10 @@
 // Breadcrumb
 
-// Bootstrap skin: style by @extend. State classes are written out against
-// Bootstrap's public vars (extending a generic state class like .active
-// would splice us into every compound that uses it).
+// Bootstrap skin: style by @extend. State rules key on semantic attributes
+// (aria-current) and are written out against Bootstrap's public vars
+// (extending a generic state class like .active would splice us into every
+// compound that uses it); the BS-mirror marker cites the mirrored source
+// rule for upgrade audits.
 .td-breadcrumbs__list {
   @extend .breadcrumb;
 }
@@ -11,7 +13,8 @@
   @extend .breadcrumb-item;
 }
 
-.td-breadcrumbs__item--active {
+// BS mirror: _breadcrumb.scss .breadcrumb-item.active
+.td-breadcrumbs__item[aria-current='page'] {
   color: var(--bs-breadcrumb-item-active-color);
 }
 

--- a/theme/assets/scss/td/_breadcrumb.scss
+++ b/theme/assets/scss/td/_breadcrumb.scss
@@ -13,9 +13,10 @@
     @extend .breadcrumb;
   }
 
-  // Descendant-scoped (& &__list): outranks consumer rules on the extended
-  // .breadcrumb group, which tie a flat &__list in specificity and win by
-  // source order.
+  // Descendant-scoped (& &__list) to preserve the pre-swap cascade: these
+  // defaults sat at .td-breadcrumbs .breadcrumb, above generic consumer
+  // .breadcrumb rules (which @extend now rewrites to also target the td-
+  // class). Consumers override as before, by matching the specificity.
   & &__list {
     background: inherit;
     padding-left: 0;

--- a/theme/assets/scss/td/_breadcrumb.scss
+++ b/theme/assets/scss/td/_breadcrumb.scss
@@ -11,7 +11,11 @@
 
   &__list {
     @extend .breadcrumb;
+  }
 
+  // Descendant-scoped: outranks consumer rules on the extended .breadcrumb
+  // group, which tie a flat &__list in specificity and win by source order.
+  .td-breadcrumbs__list {
     background: inherit;
     padding-left: 0;
     padding-top: 0;
@@ -22,7 +26,7 @@
 
     // BS mirror: _breadcrumb.scss .breadcrumb-item.active
     &[aria-current='page'] {
-      color: var(--bs-breadcrumb-item-active-color);
+      color: var(--#{$prefix}breadcrumb-item-active-color);
     }
   }
 }

--- a/theme/assets/scss/td/_taxonomy.scss
+++ b/theme/assets/scss/td/_taxonomy.scss
@@ -333,7 +333,7 @@
     margin-bottom: 1.5em;
   }
 
-  .breadcrumb {
+  .td-breadcrumbs__list {
     margin-bottom: 0;
     font-size: 0.85rem;
   }

--- a/theme/layouts/_partials/breadcrumb.html
+++ b/theme/layouts/_partials/breadcrumb.html
@@ -1,25 +1,35 @@
+{{/* Breadcrumb for the current page. Context: the Page, or a dict
+  { page: Page, summary: true } to drop the nav semantics (aria attributes,
+  active marking) that are inappropriate in page-summary contexts. */ -}}
+{{ $page := . -}}
+{{ $summary := false -}}
+{{ if reflect.IsMap . -}}
+  {{ $page = .page -}}
+  {{ $summary = .summary -}}
+{{ end -}}
 {{ $isSingle := true -}}
-{{ with .Parent -}}
+{{ with $page.Parent -}}
   {{ $isSingle = .IsHome -}}
 {{ end -}}
-<nav aria-label="breadcrumb" class="td-breadcrumbs
+<nav{{ if not $summary }} aria-label="breadcrumb"{{ end }} class="td-breadcrumbs
     {{- if $isSingle }} td-breadcrumbs__single {{- end }}">
-  <ol class="breadcrumb">
-    {{- template "breadcrumbnav" (dict "p1" . "p2" .) }}
+  <ol class="td-breadcrumbs__list">
+    {{- template "breadcrumbnav" (dict "p1" $page "p2" $page "summary" $summary) }}
   </ol>
 </nav>
 
 {{- define "breadcrumbnav" -}}
   {{ if .p1.Parent -}}
     {{ if not .p1.Parent.IsHome -}}
-      {{ template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2 )  -}}
+      {{ template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2 "summary" .summary)  -}}
     {{ end -}}
   {{ else if not .p1.IsHome -}}
-    {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 )  -}}
+    {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 "summary" .summary)  -}}
   {{ end -}}
-  {{ $isActive :=  eq .p1 .p2 }}
-  <li class="breadcrumb-item{{ if $isActive }} active{{ end }}"
-      {{- if $isActive }} aria-current="page"{{ end }}>
+  {{ $isActive := eq .p1 .p2 }}
+  {{ $isCurrent := and $isActive (not .summary) -}}
+  <li class="td-breadcrumbs__item{{ if $isCurrent }} td-breadcrumbs__item--active{{ end }}"
+      {{- if $isCurrent }} aria-current="page"{{ end }}>
     {{ if $isActive -}}
       {{ .p1.LinkTitle -}}
     {{ else -}}

--- a/theme/layouts/_partials/breadcrumb.html
+++ b/theme/layouts/_partials/breadcrumb.html
@@ -18,7 +18,7 @@
     {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 )  -}}
   {{ end -}}
   {{ $isActive :=  eq .p1 .p2 }}
-  <li class="td-breadcrumbs__item{{ if $isActive }} td-breadcrumbs__item--active{{ end }}"
+  <li class="td-breadcrumbs__item"
       {{- if $isActive }} aria-current="page"{{ end }}>
     {{ if $isActive -}}
       {{ .p1.LinkTitle -}}

--- a/theme/layouts/_partials/breadcrumb.html
+++ b/theme/layouts/_partials/breadcrumb.html
@@ -1,36 +1,26 @@
-{{/* Breadcrumb for the current page. Context: the Page, or a dict
-  { page: Page, summary: true } to drop the nav semantics (aria attributes,
-  active marking) that are inappropriate in page-summary contexts. */ -}}
-{{ $page := . -}}
-{{ $summary := false -}}
-{{ if reflect.IsMap . -}}
-  {{ $page = .page -}}
-  {{ $summary = .summary -}}
-{{ end -}}
 {{ $isSingle := true -}}
-{{ with $page.Parent -}}
+{{ with .Parent -}}
   {{ $isSingle = .IsHome -}}
 {{ end -}}
-<nav{{ if not $summary }} aria-label="breadcrumb"{{ end }} class="td-breadcrumbs
+<nav aria-label="breadcrumb" class="td-breadcrumbs
     {{- if $isSingle }} td-breadcrumbs__single {{- end }}">
   <ol class="td-breadcrumbs__list">
-    {{- template "breadcrumbnav" (dict "p1" $page "p2" $page "summary" $summary) }}
+    {{- template "breadcrumbnav" (dict "p1" . "p2" .) }}
   </ol>
 </nav>
 
 {{- define "breadcrumbnav" -}}
   {{ if .p1.Parent -}}
     {{ if not .p1.Parent.IsHome -}}
-      {{ template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2 "summary" .summary)  -}}
+      {{ template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2 )  -}}
     {{ end -}}
   {{ else if not .p1.IsHome -}}
-    {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 "summary" .summary)  -}}
+    {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 )  -}}
   {{ end -}}
-  {{ $isCurrentPage := eq .p1 .p2 }}
-  {{ $isActive := and $isCurrentPage (not .summary) -}}
+  {{ $isActive :=  eq .p1 .p2 }}
   <li class="td-breadcrumbs__item{{ if $isActive }} td-breadcrumbs__item--active{{ end }}"
       {{- if $isActive }} aria-current="page"{{ end }}>
-    {{ if $isCurrentPage -}}
+    {{ if $isActive -}}
       {{ .p1.LinkTitle -}}
     {{ else -}}
       <a href="{{ .p1.RelPermalink }}">{{ .p1.LinkTitle }}</a>

--- a/theme/layouts/_partials/breadcrumb.html
+++ b/theme/layouts/_partials/breadcrumb.html
@@ -26,11 +26,11 @@
   {{ else if not .p1.IsHome -}}
     {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 "summary" .summary)  -}}
   {{ end -}}
-  {{ $isActive := eq .p1 .p2 }}
-  {{ $isCurrent := and $isActive (not .summary) -}}
-  <li class="td-breadcrumbs__item{{ if $isCurrent }} td-breadcrumbs__item--active{{ end }}"
-      {{- if $isCurrent }} aria-current="page"{{ end }}>
-    {{ if $isActive -}}
+  {{ $isCurrentPage := eq .p1 .p2 }}
+  {{ $isActive := and $isCurrentPage (not .summary) -}}
+  <li class="td-breadcrumbs__item{{ if $isActive }} td-breadcrumbs__item--active{{ end }}"
+      {{- if $isActive }} aria-current="page"{{ end }}>
+    {{ if $isCurrentPage -}}
       {{ .p1.LinkTitle -}}
     {{ else -}}
       <a href="{{ .p1.RelPermalink }}">{{ .p1.LinkTitle }}</a>

--- a/theme/layouts/term.html
+++ b/theme/layouts/term.html
@@ -11,7 +11,10 @@
         <article class="card article-teaser article-type-{{ with .Type }}{{ ( urlize . ) }}{{ end }}">
           <h3><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></h3>
           {{ if not .Site.Params.ui.taxonomy_breadcrumb_disable -}}
-            {{ partial "breadcrumb.html" (dict "page" . "summary" true) -}}
+            {{/* Use breadcrumb partial, but remove attributes that are invalid or inappropriate in this page-summary context. */ -}}
+            {{ partial "breadcrumb.html" .
+              | replaceRE ` aria-\w+=\".*?\"|(td-breadcrumbs__item) td-breadcrumbs__item--active` "$1" | safeHTML
+            -}}
           {{ end -}}
           <p>{{ .Description | markdownify }}</p>
           <header class="article-meta">

--- a/theme/layouts/term.html
+++ b/theme/layouts/term.html
@@ -11,9 +11,9 @@
         <article class="card article-teaser article-type-{{ with .Type }}{{ ( urlize . ) }}{{ end }}">
           <h3><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></h3>
           {{ if not .Site.Params.ui.taxonomy_breadcrumb_disable -}}
-            {{/* Use breadcrumb partial, but remove attributes that are invalid or inappropriate in this page-summary context. */ -}}
+            {{/* Use breadcrumb partial, but remove attributes that are invalid or inappropriate in this page-summary context (stripping aria-current also drops its styling). */ -}}
             {{ partial "breadcrumb.html" .
-              | replaceRE ` aria-\w+=\".*?\"|(td-breadcrumbs__item) td-breadcrumbs__item--active` "$1" | safeHTML
+              | replaceRE ` aria-\w+=\".*?\"` "" | safeHTML
             -}}
           {{ end -}}
           <p>{{ .Description | markdownify }}</p>

--- a/theme/layouts/term.html
+++ b/theme/layouts/term.html
@@ -11,10 +11,7 @@
         <article class="card article-teaser article-type-{{ with .Type }}{{ ( urlize . ) }}{{ end }}">
           <h3><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></h3>
           {{ if not .Site.Params.ui.taxonomy_breadcrumb_disable -}}
-            {{/* Use breadcrumb partial, but remove attributes that are invalid or inappropriate in this page-summary context. */ -}}
-            {{ partial "breadcrumb.html" .
-              | replaceRE ` aria-\w+=\".*?\"|(breadcrumb-item) active` "$1" | safeHTML
-            -}}
+            {{ partial "breadcrumb.html" (dict "page" . "summary" true) -}}
           {{ end -}}
           <p>{{ .Description | markdownify }}</p>
           <header class="article-meta">


### PR DESCRIPTION
- Contributes to #783; the first class-swap increment on the #2719/#2721 harness.
- **Swaps the breadcrumb partial's classes** to the `td-` vocabulary: `breadcrumb` → `td-breadcrumbs__list`, `breadcrumb-item` → `td-breadcrumbs__item`, and `active` → no class — the styling hook for the current item is now `[aria-current="page"]` (site CSS/JS keyed on `.active` inside breadcrumbs must move to the attribute).
- **Binds the Bootstrap styling by `@extend`** (the theme's existing `.td-navbar` idiom), so the skin tracks the installed Bootstrap instead of drifting as a copied snapshot; simple-selector extends only, verified byte-identical under libsass and dart-sass.
- **Keys the active-item styling on `aria-current="page"`** instead of a state class: the styling hook is the a11y annotation, so the two can't drift; the written-out state rule consumes Bootstrap's prefix-aware breadcrumb active-color custom property and carries a `BS mirror:` audit marker.
- **Keeps `term.html`'s replaceRE post-processing**, re-targeted: with attribute-keyed state, stripping `aria-current` also strips its styling; the term golden pins the coupling.
- **Clears the partial in the migration ratchet**, red-first: the lint and the output net both failed before the swap and are driven green by it, with the sentinel binding proof now active.
- **Review artifacts**: the markup-golden diff is pure class renames plus the state-class removal; visual goldens are untouched (all 28 golden comparisons pass unchanged in the authoritative Linux `visual` job).
