### PR TITLE
Fix npm audit findings and add audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -435,13 +435,13 @@
       "license": "MIT"
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/afdocs": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,9 @@
     "node": ">=24",
     "npm": ">=11.16.0"
   },
+  "overrides": {
+    "adm-zip": "^0.6.0"
+  },
   "spelling": "cSpell:ignore -",
   "allowScripts": {
     "hugo-extended@0.164.0": true,

--- a/scripts/suite-anchor.test.mjs
+++ b/scripts/suite-anchor.test.mjs
@@ -31,6 +31,7 @@ test('anchor: the tests-root guards stay wired into test:repo', () => {
     'test:repo runs the top-level tests, the structural guards included',
   );
   for (const guard of [
+    'tests/npm-audit.test.mjs',
     'tests/runner-lint.test.mjs',
     'tests/supply-chain-audit.test.mjs',
     'tests/test-wiring.test.mjs',

--- a/tests/npm-audit.test.mjs
+++ b/tests/npm-audit.test.mjs
@@ -1,0 +1,77 @@
+// Online npm-audit gate, complementing the offline structural checks in
+// supply-chain-audit.test.mjs: the committed locks stay free of
+// unreviewed advisories. Accepted advisories are pinned below, and each
+// must still be reported: an exception that npm audit no longer reports
+// is stale and gets removed together with its entry here.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+
+// GHSA-q3xp-j858-q9xf flags every version of the registry package
+// markdownlint-rule-link-pattern, where malware was once published under
+// the project's name. This repo installs the package from its author's
+// GitHub tag (the git-pin allowlist in supply-chain-audit.test.mjs), so
+// the flagged registry code is never fetched: the advisory matches on
+// name only. Remove once the advisory is scoped to the malicious
+// registry version.
+const acceptedAdvisories = new Map([
+  ['GHSA-q3xp-j858-q9xf', 'markdownlint-rule-link-pattern'],
+]);
+
+test('audit: every advisory npm audit reports is reviewed and accepted', () => {
+  const res = spawnSync('npm audit --json', {
+    cwd: repoRoot,
+    shell: true,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  let report;
+  try {
+    report = JSON.parse(res.stdout);
+  } catch {
+    assert.fail(
+      `npm audit emitted a JSON report (exit ${res.status}): ${
+        res.stderr || res.stdout
+      }`,
+    );
+  }
+  assert.equal(
+    report.error,
+    undefined,
+    `npm audit reached the registry: ${JSON.stringify(report.error)}`,
+  );
+  assert.ok(
+    report.metadata?.dependencies?.total > 0,
+    'the audit covered the installed dependency tree',
+  );
+
+  const reported = new Map();
+  for (const [name, vuln] of Object.entries(report.vulnerabilities ?? {})) {
+    for (const via of vuln.via) {
+      // String entries chain to another reported finding, which carries
+      // the advisory objects this loop vets.
+      if (typeof via !== 'object') continue;
+      const ghsa = via.url?.match(/GHSA-[a-z0-9-]+$/)?.[0] ?? via.url;
+      reported.set(ghsa, via.name ?? name);
+      assert.ok(
+        acceptedAdvisories.has(ghsa),
+        `${ghsa} (${via.severity}, ${name}: ${via.title}) is a reviewed, accepted advisory`,
+      );
+    }
+  }
+  for (const [ghsa, pkg] of acceptedAdvisories) {
+    assert.equal(
+      reported.get(ghsa),
+      pkg,
+      `accepted advisory ${ghsa} is still reported for ${pkg}, so its exception stays earned`,
+    );
+  }
+});

--- a/tests/npm-audit.test.mjs
+++ b/tests/npm-audit.test.mjs
@@ -24,6 +24,65 @@ const acceptedAdvisories = new Map([
   ['GHSA-q3xp-j858-q9xf', 'markdownlint-rule-link-pattern'],
 ]);
 
+// Helper: gate the npm audit report schema and accepted advisories.
+function validateAuditGate(report, accepted) {
+  // Fail-closed on npm audit format changes (currently v2).
+  assert.equal(
+    report.auditReportVersion,
+    2,
+    `npm audit report version must be 2; got ${report.auditReportVersion}`,
+  );
+  assert.equal(
+    report.error,
+    undefined,
+    `npm audit reached the registry: ${JSON.stringify(report.error)}`,
+  );
+  assert.ok(
+    report.metadata?.dependencies?.total > 0,
+    'the audit covered the installed dependency tree',
+  );
+
+  const reported = new Map();
+  const allVulns = report.vulnerabilities ?? {};
+
+  for (const [name, vuln] of Object.entries(allVulns)) {
+    for (const via of vuln.via) {
+      if (via == null || typeof via !== 'object') {
+        // String via entries chain to another reported finding.
+        // Ensure the chain target exists and carries an advisory object.
+        if (typeof via === 'string') {
+          assert.ok(
+            allVulns[via],
+            `string via "${via}" on ${name} must resolve to a key in vulnerabilities`,
+          );
+          continue;
+        }
+        // null or other non-object: fail-closed.
+        assert.fail(
+          `unexpected via type on ${name}: ${typeof via} (${JSON.stringify(via)})`,
+        );
+      }
+      // Advisory object: extract GHSA and check acceptance.
+      const ghsa =
+        via.url?.match(/GHSA-[a-z0-9-]+$/)?.[0] ?? via.url;
+      reported.set(ghsa, via.name ?? name);
+      assert.ok(
+        accepted.has(ghsa),
+        `${ghsa} (${via.severity}, ${name}: ${via.title}) is a reviewed, accepted advisory`,
+      );
+    }
+  }
+
+  // Every accepted advisory must still be reported (exceptions are stale).
+  for (const [ghsa, pkg] of accepted) {
+    assert.equal(
+      reported.get(ghsa),
+      pkg,
+      `accepted advisory ${ghsa} is still reported for ${pkg}, so its exception stays earned`,
+    );
+  }
+}
+
 test('audit: reported advisories are reviewed and accepted', () => {
   const res = spawnSync('npm', ['audit', '--json'], {
     cwd: repoRoot,
@@ -44,35 +103,97 @@ test('audit: reported advisories are reviewed and accepted', () => {
       }`,
     );
   }
-  assert.equal(
-    report.error,
-    undefined,
-    `npm audit reached the registry: ${JSON.stringify(report.error)}`,
-  );
-  assert.ok(
-    report.metadata?.dependencies?.total > 0,
-    'the audit covered the installed dependency tree',
-  );
+  validateAuditGate(report, acceptedAdvisories);
+});
 
-  const reported = new Map();
-  for (const [name, vuln] of Object.entries(report.vulnerabilities ?? {})) {
-    for (const via of vuln.via) {
-      // String entries chain to another reported finding, which carries
-      // the advisory objects this loop vets.
-      if (typeof via !== 'object') continue;
-      const ghsa = via.url?.match(/GHSA-[a-z0-9-]+$/)?.[0] ?? via.url;
-      reported.set(ghsa, via.name ?? name);
-      assert.ok(
-        acceptedAdvisories.has(ghsa),
-        `${ghsa} (${via.severity}, ${name}: ${via.title}) is a reviewed, accepted advisory`,
-      );
-    }
-  }
-  for (const [ghsa, pkg] of acceptedAdvisories) {
-    assert.equal(
-      reported.get(ghsa),
-      pkg,
-      `accepted advisory ${ghsa} is still reported for ${pkg}, so its exception stays earned`,
-    );
-  }
+// Fixture: validate the parser against mock report shapes.
+test('audit gate: parser rejects unreviewed advisories', () => {
+  const validReport = {
+    auditReportVersion: 2,
+    error: undefined,
+    metadata: { dependencies: { total: 1 } },
+    vulnerabilities: {
+      'package-a': {
+        name: 'package-a',
+        via: [
+          {
+            url: 'https://github.com/advisories/GHSA-q3xp-j858-q9xf',
+            severity: 'critical',
+            name: 'markdownlint-rule-link-pattern',
+            title: 'Malware',
+          },
+        ],
+      },
+    },
+  };
+  validateAuditGate(validReport, acceptedAdvisories);
+});
+
+test('audit gate: parser rejects unaccepted advisories', () => {
+  const reportWithNewGHSA = {
+    auditReportVersion: 2,
+    error: undefined,
+    metadata: { dependencies: { total: 1 } },
+    vulnerabilities: {
+      'package-b': {
+        name: 'package-b',
+        via: [
+          {
+            url: 'https://github.com/advisories/GHSA-xxxx-yyyy-zzzz',
+            severity: 'high',
+            name: 'unreviewed-advisory',
+            title: 'New advisory',
+          },
+        ],
+      },
+    },
+  };
+  assert.throws(
+    () => validateAuditGate(reportWithNewGHSA, acceptedAdvisories),
+    /GHSA-xxxx-yyyy-zzzz.*reviewed, accepted advisory/,
+  );
+});
+
+test('audit gate: parser rejects stale exceptions (missing report)', () => {
+  const reportWithoutAcceptedGHSA = {
+    auditReportVersion: 2,
+    error: undefined,
+    metadata: { dependencies: { total: 1 } },
+    vulnerabilities: {},
+  };
+  assert.throws(
+    () => validateAuditGate(reportWithoutAcceptedGHSA, acceptedAdvisories),
+    /accepted advisory GHSA-q3xp-j858-q9xf is still reported/,
+  );
+});
+
+test('audit gate: parser rejects format version changes', () => {
+  const reportV3 = {
+    auditReportVersion: 3,
+    error: undefined,
+    metadata: { dependencies: { total: 1 } },
+    vulnerabilities: {},
+  };
+  assert.throws(
+    () => validateAuditGate(reportV3, acceptedAdvisories),
+    /report version must be 2/,
+  );
+});
+
+test('audit gate: parser rejects string via without chain target', () => {
+  const reportWithDanglingStringVia = {
+    auditReportVersion: 2,
+    error: undefined,
+    metadata: { dependencies: { total: 1 } },
+    vulnerabilities: {
+      'package-c': {
+        name: 'package-c',
+        via: ['nonexistent-key'],
+      },
+    },
+  };
+  assert.throws(
+    () => validateAuditGate(reportWithDanglingStringVia, acceptedAdvisories),
+    /string via "nonexistent-key".*must resolve to a key/,
+  );
 });

--- a/tests/npm-audit.test.mjs
+++ b/tests/npm-audit.test.mjs
@@ -1,8 +1,7 @@
 // Online npm-audit gate, complementing the offline structural checks in
-// supply-chain-audit.test.mjs: the committed locks stay free of
-// unreviewed advisories. Accepted advisories are pinned below, and each
-// must still be reported: an exception that npm audit no longer reports
-// is stale and gets removed together with its entry here.
+// supply-chain-audit.test.mjs: committed locks stay free of unreviewed
+// advisories. Accepted advisories stay listed below and must still be
+// reported; once one disappears, its exception is stale.
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -18,18 +17,16 @@ const repoRoot = path.resolve(
 // GHSA-q3xp-j858-q9xf flags every version of the registry package
 // markdownlint-rule-link-pattern, where malware was once published under
 // the project's name. This repo installs the package from its author's
-// GitHub tag (the git-pin allowlist in supply-chain-audit.test.mjs), so
-// the flagged registry code is never fetched: the advisory matches on
-// name only. Remove once the advisory is scoped to the malicious
-// registry version.
+// GitHub tag, so the flagged registry code is never fetched; the
+// advisory matches on name only. Remove once the advisory is scoped to
+// the malicious registry version.
 const acceptedAdvisories = new Map([
   ['GHSA-q3xp-j858-q9xf', 'markdownlint-rule-link-pattern'],
 ]);
 
-test('audit: every advisory npm audit reports is reviewed and accepted', () => {
-  const res = spawnSync('npm audit --json', {
+test('audit: reported advisories are reviewed and accepted', () => {
+  const res = spawnSync('npm', ['audit', '--json'], {
     cwd: repoRoot,
-    shell: true,
     encoding: 'utf8',
     maxBuffer: 16 * 1024 * 1024,
   });

--- a/tests/npm-audit.test.mjs
+++ b/tests/npm-audit.test.mjs
@@ -63,8 +63,7 @@ function validateAuditGate(report, accepted) {
         );
       }
       // Advisory object: extract GHSA and check acceptance.
-      const ghsa =
-        via.url?.match(/GHSA-[a-z0-9-]+$/)?.[0] ?? via.url;
+      const ghsa = via.url?.match(/GHSA-[a-z0-9-]+$/)?.[0] ?? via.url;
       reported.set(ghsa, via.name ?? name);
       assert.ok(
         accepted.has(ghsa),

--- a/tests/npm-audit.test.mjs
+++ b/tests/npm-audit.test.mjs
@@ -52,7 +52,7 @@ function validateAuditGate(report, accepted) {
         // Ensure the chain target exists and carries an advisory object.
         if (typeof via === 'string') {
           assert.ok(
-            allVulns[via],
+            Object.hasOwn(allVulns, via),
             `string via "${via}" on ${name} must resolve to a key in vulnerabilities`,
           );
           continue;
@@ -195,4 +195,66 @@ test('audit gate: parser rejects string via without chain target', () => {
     () => validateAuditGate(reportWithDanglingStringVia, acceptedAdvisories),
     /string via "nonexistent-key".*must resolve to a key/,
   );
+});
+
+test('audit gate: parser catches unreviewed advisory alongside accepted one', () => {
+  const reportWithMixedAdvisories = {
+    auditReportVersion: 2,
+    error: undefined,
+    metadata: { dependencies: { total: 2 } },
+    vulnerabilities: {
+      'package-a': {
+        name: 'package-a',
+        via: [
+          {
+            url: 'https://github.com/advisories/GHSA-q3xp-j858-q9xf',
+            severity: 'critical',
+            name: 'markdownlint-rule-link-pattern',
+            title: 'Malware',
+          },
+        ],
+      },
+      'package-b': {
+        name: 'package-b',
+        via: [
+          {
+            url: 'https://github.com/advisories/GHSA-xxxx-yyyy-zzzz',
+            severity: 'high',
+            name: 'unreviewed-pkg',
+            title: 'New advisory',
+          },
+        ],
+      },
+    },
+  };
+  assert.throws(
+    () => validateAuditGate(reportWithMixedAdvisories, acceptedAdvisories),
+    /GHSA-xxxx-yyyy-zzzz.*reviewed, accepted advisory/,
+  );
+});
+
+test('audit gate: parser accepts valid transitive advisory chain', () => {
+  const reportWithTransitiveChain = {
+    auditReportVersion: 2,
+    error: undefined,
+    metadata: { dependencies: { total: 2 } },
+    vulnerabilities: {
+      'package-a': {
+        name: 'package-a',
+        via: ['package-b'],
+      },
+      'package-b': {
+        name: 'package-b',
+        via: [
+          {
+            url: 'https://github.com/advisories/GHSA-q3xp-j858-q9xf',
+            severity: 'critical',
+            name: 'markdownlint-rule-link-pattern',
+            title: 'Malware',
+          },
+        ],
+      },
+    },
+  };
+  validateAuditGate(reportWithTransitiveChain, acceptedAdvisories);
 });

--- a/tests/npm-audit.test.mjs
+++ b/tests/npm-audit.test.mjs
@@ -13,7 +13,6 @@ const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '..',
 );
-const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 // GHSA-q3xp-j858-q9xf flags every version of the registry package
 // markdownlint-rule-link-pattern, where malware was once published under
@@ -26,17 +25,21 @@ const acceptedAdvisories = new Map([
 ]);
 
 test('audit: reported advisories are reviewed and accepted', () => {
-  const res = spawnSync(npmCmd, ['audit', '--json'], {
+  const res = spawnSync('npm', ['audit', '--json'], {
     cwd: repoRoot,
     encoding: 'utf8',
     maxBuffer: 16 * 1024 * 1024,
+    shell: process.platform === 'win32',
   });
+  if (res.error) {
+    assert.fail(`npm audit failed to run: ${res.error.message}`);
+  }
   let report;
   try {
     report = JSON.parse(res.stdout);
   } catch {
     assert.fail(
-      `npm audit emitted a JSON report (exit ${res.status}): ${
+      `npm audit emitted invalid JSON (exit ${res.status}): ${
         res.stderr || res.stdout
       }`,
     );

--- a/tests/npm-audit.test.mjs
+++ b/tests/npm-audit.test.mjs
@@ -13,6 +13,7 @@ const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '..',
 );
+const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 // GHSA-q3xp-j858-q9xf flags every version of the registry package
 // markdownlint-rule-link-pattern, where malware was once published under
@@ -25,7 +26,7 @@ const acceptedAdvisories = new Map([
 ]);
 
 test('audit: reported advisories are reviewed and accepted', () => {
-  const res = spawnSync('npm', ['audit', '--json'], {
+  const res = spawnSync(npmCmd, ['audit', '--json'], {
     cwd: repoRoot,
     encoding: 'utf8',
     maxBuffer: 16 * 1024 * 1024,

--- a/tests/supply-chain-audit.test.mjs
+++ b/tests/supply-chain-audit.test.mjs
@@ -214,6 +214,32 @@ test('manifests: git dependencies are tag-pinned to their reviewed repos', () =>
   }
 });
 
+// npm applies overrides only while re-resolving and trusts an in-sync
+// lock as-is, so the adm-zip override (GHSA-xcpc-8h2w-3j85, via
+// hugo-extended) is pinned from the committed manifests: the lock must
+// carry the fixed version, and the override must stay justified by
+// hugo-extended's own declared range. When hugo-extended bumps that
+// range past the vulnerable one, this goes red: drop the override (and
+// this test) in that bump PR.
+test('locks and manifests: the adm-zip override is applied and still needed', () => {
+  assert.deepEqual(
+    readJSON('package.json').overrides,
+    { 'adm-zip': '^0.6.0' },
+    'overrides carries exactly the reviewed entries',
+  );
+  const pkgs = locks['package-lock.json'].packages;
+  assert.match(
+    pkgs['node_modules/adm-zip'].version,
+    /^0\.6\./,
+    'the locked adm-zip carries the GHSA-xcpc-8h2w-3j85 fix',
+  );
+  assert.equal(
+    pkgs['node_modules/hugo-extended'].dependencies['adm-zip'],
+    '^0.5.17',
+    'hugo-extended still declares the adm-zip range that justifies the override',
+  );
+});
+
 // Exact pins: prefix/flag matching would accept an appended `&& npm
 // install …` rider on a script the workflow audit trusts by name.
 test('manifests: the install path keeps its locked, script-free form', () => {


### PR DESCRIPTION
- **adm-zip override**: clears the transitive unzipper finding, with a tripwire that forces the override out when upstream Hugo catches up.
  - Keeps this change interim; the upstream bump stays the durable fix.
- **Name-matched advisory**: records the accepted critical as a registry-name hit, not a fetched package in this repo.
  - The package stays GitHub-pinned for now; the name-recovery and advisory-scoping work remains external.
- **Audit gate**: adds a CI check so new advisories fail fast and stale exceptions cannot go quiet.
  - Red-first proof: the new test goes red on an unaccepted advisory, a stale exception, and a stale override before going green.
