### PR TITLE
Draft the 0.17.0 release report; reconcile the changelog

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -627,6 +627,7 @@ https://github.com/prettier/prettier/issues/15720,200,1782563368
 https://github.com/protocolbuffers/protocolbuffers.github.io,200,1782498549
 https://github.com/sarahmaddox,200,1782498238
 https://github.com/sass/dart-sass/pull/2413,200,1787153685
+https://github.com/sass/dart-sass/releases,200,1787161178
 https://github.com/shurup,200,1785178993
 https://github.com/tektoncd,200,1782498549
 https://github.com/theupdateframework/theupdateframework.io/pull/105,200,1782498236

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -73,6 +73,7 @@ https://docs.npmjs.com/cli/v11/commands/npm-dist-tag,200,1784978353
 https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/,200,1784978429
 https://docs.npmjs.com/cli/v11/commands/npm-install#description,200,1784982268
 https://docs.npmjs.com/cli/v11/using-npm/scripts,200,1787095600
+https://docs.npmjs.com/trusted-publishers,200,1787153684
 https://docs.npmjs.com/trusted-publishers/,200,1786206945
 https://docsy.dev/,200,1782563367
 https://domsignal.com/x-frame-options-test,200,1782498238
@@ -259,6 +260,7 @@ https://github.com/google/docsy/blob/v0.7.0/layouts/partials/footer.html,200,178
 https://github.com/google/docsy/commits/main,200,1782563369
 https://github.com/google/docsy/compare/v0.15.0...main,200,1782563370
 https://github.com/google/docsy/compare/v0.15.0...v0.16.0,200,1785360538
+https://github.com/google/docsy/compare/v0.16.0...main,200,1787153684
 https://github.com/google/docsy/compare/v0.8.0...v0.9.0,200,1782498238
 https://github.com/google/docsy/discussions,200,1782563367
 https://github.com/google/docsy/discussions/1308,200,1782498228
@@ -401,6 +403,7 @@ https://github.com/google/docsy/issues/new?title=Release%200.13.0%20report%20and
 https://github.com/google/docsy/issues/new?title=Release%200.14.0%20report%20and%20upgrade%20guide,200,1782498546
 https://github.com/google/docsy/issues/new?title=Release%200.15.0%20report%20and%20upgrade%20guide,200,1782498546
 https://github.com/google/docsy/issues/new?title=Release%200.16.0%20report%20and%20upgrade%20guide,200,1782498546
+https://github.com/google/docsy/issues/new?title=Release%200.17.0%20report%20and%20upgrade%20guide,200,1787153684
 https://github.com/google/docsy/issues/new?title=Repository%20Links%20and%20other%20page%20information,200,1782498241
 https://github.com/google/docsy/issues/new?title=Repository-root%20markdown%20files,200,1782498547
 https://github.com/google/docsy/issues/new?title=ScrollSpy%20patch,200,1782498547
@@ -423,6 +426,7 @@ https://github.com/google/docsy/issues/new?title=Welcome%20to%20Docsy,200,178249
 https://github.com/google/docsy/issues/new?title=blocks/cover,200,1782498230
 https://github.com/google/docsy/issues?q=is%3Aissue%20state%3Aclosed%20sort%3Areactions-%2B1-desc%20closed%3A2025-01-01..2025-12-31,200,1782498234
 https://github.com/google/docsy/milestone/2,200,1782498241
+https://github.com/google/docsy/milestone/27,200,1787153685
 https://github.com/google/docsy/milestones,200,1782563369
 https://github.com/google/docsy/network/dependents,200,1782498236
 https://github.com/google/docsy/pull/1009,200,1782498229
@@ -522,8 +526,10 @@ https://github.com/google/docsy/pull/2662,200,1782498231
 https://github.com/google/docsy/pull/2664,200,1784236427
 https://github.com/google/docsy/pull/2677,200,1784292830
 https://github.com/google/docsy/pull/2700,200,1786106543
+https://github.com/google/docsy/pull/2708,200,1787153684
 https://github.com/google/docsy/pull/2712,200,1786305687
 https://github.com/google/docsy/pull/2714,200,1786628621
+https://github.com/google/docsy/pull/2722,200,1787153684
 https://github.com/google/docsy/pull/2724,200,1787076569
 https://github.com/google/docsy/pull/2726,200,1787137876
 https://github.com/google/docsy/pull/941,200,1782498225
@@ -620,6 +626,7 @@ https://github.com/prettier/prettier/issues/15528,200,1782563367
 https://github.com/prettier/prettier/issues/15720,200,1782563368
 https://github.com/protocolbuffers/protocolbuffers.github.io,200,1782498549
 https://github.com/sarahmaddox,200,1782498238
+https://github.com/sass/dart-sass/pull/2413,200,1787153685
 https://github.com/shurup,200,1785178993
 https://github.com/tektoncd,200,1782498549
 https://github.com/theupdateframework/theupdateframework.io/pull/105,200,1782498236
@@ -691,6 +698,7 @@ https://gohugo.io/getting-started/directory-structure/#static,200,1782498236
 https://gohugo.io/getting-started/directory-structure/#theme-skeleton,200,1785237454
 https://gohugo.io/getting-started/directory-structure/#unified-file-system,200,1782563368
 https://gohugo.io/getting-started/directory-structure/,200,1782498235
+https://gohugo.io/host-and-deploy/host-on-cloudflare/,200,1787153684
 https://gohugo.io/hosting-and-deployment/,200,1782563367
 https://gohugo.io/hosting-and-deployment/hosting-on-aws-amplify/,200,1782563367
 https://gohugo.io/hosting-and-deployment/hosting-on-github/,200,1782563367

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -160,38 +160,22 @@ mode][dart-sass-2413].
 ## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
 
 Docsy's chrome markup is moving from Bootstrap utility and component classes to
-Docsy-owned `td-` **semantic classes** over the coming releases, and breadcrumbs
-go first. Each migrating release's report will carry a selector table like the
-one below.
-
-<!-- TODO(#2727): once merged, wire the user guide's consumer-contract section
-  (/docs/content/lookandfeel/#semantic-classes; audience split: the
-  contributor page /project/implementation/semantic-classes/ is for
-  maintainer-facing links only) into this section, trimming what that section
-  now owns:
-  1. Intro: link "semantic classes"; drop the "Each migrating release's report
-     will carry a selector table" sentence (the docs own the per-release
-     selector-changes promise).
-  2. SCSS bullet: replace the @extend mechanism and not-a-promise clauses with
-     the link (both are docs-owned); the post keeps the action: migrate now.
-  3. Table note: consider trimming the "so visual state and accessibility
-     state can't drift apart" rationale (owned by the implementation page's
-     State styling section).
-  4. What's next: drop or re-point "each with a selector table like this
-     post's" (the per-release selector-changes promise is docs-owned). -->
+Docsy-owned `td-` [semantic classes][] over the coming releases, and breadcrumbs
+go first.
 
 ### Selector migration table
 
-| 0.16 emitted                | 0.17 emitted                                   |
-| --------------------------- | ---------------------------------------------- |
-| `ol.breadcrumb`             | `ol.td-breadcrumbs__list`                      |
-| `li.breadcrumb-item`        | `li.td-breadcrumbs__item`                      |
-| `li.breadcrumb-item.active` | `li.td-breadcrumbs__item[aria-current="page"]` |
+| 0.16 emitted                 | 0.17 emitted                                   |
+| ---------------------------- | ---------------------------------------------- |
+| `ol.breadcrumb`              | `ol.td-breadcrumbs__list`                      |
+| `li.breadcrumb-item`         | `li.td-breadcrumbs__item`                      |
+| `li.breadcrumb-item.active`  | `li.td-breadcrumbs__item[aria-current="page"]` |
+| `nav.td-breadcrumbs__single` | `nav.td-breadcrumbs--single`                   |
 
-Unchanged: the `td-breadcrumbs` and `td-breadcrumbs__single` classes on the
-`<nav>` element. The `active` class is no longer emitted: state styling keys on
-the ARIA-mandated `aria-current="page"` attribute, so visual state and
-accessibility state can't drift apart.
+Unchanged: the `td-breadcrumbs` class on the `<nav>` element. The `active` class
+is no longer emitted: state styling keys on the ARIA-mandated
+`aria-current="page"` attribute, so visual state and accessibility state can't
+drift apart.
 
 One related fix: breadcrumbs in taxonomy-term page summaries now render without
 ARIA attributes (a page summary isn't the current page), and with the attribute
@@ -215,13 +199,16 @@ the breadcrumb `.active`.
   summaries, since `term.html`'s summary sanitizer now strips ARIA attributes
   only.
 
-**Applies if** your project's Sass styles the old Bootstrap class names.
+{{% _param BREAKING %}} **Applies if** your project's Sass styles the old
+Bootstrap class names.
 
-- Your rules keep working for now: the theme binds the new classes to
-  Bootstrap's styles, which incidentally rewrites `.breadcrumb`-family Sass
-  rules to also match the `td-` classes. This keep-alive is an accident of the
-  transition mechanism, **not a compatibility promise**: it ends when the
-  Bootstrap binding retires. Migrate your Sass selectors now, with the rest.
+- Migrate all your selectors now, per the
+  [table above](#selector-migration-table). Rules on the old **structural**
+  names (`.breadcrumb`, `.breadcrumb-item`) keep matching for the moment, an
+  accident of the theme's Bootstrap binding rather than a compatibility promise.
+  Rules involving the **state** class are already broken:
+  `.breadcrumb-item.active` no longer matches anything, and a `:not(.active)`
+  now also matches the current item.
 
 ## {{% _param BREAKING %}} Install command renamed {#install-command}
 
@@ -256,8 +243,7 @@ Hugo-module and `@docsy/theme` registry installs are unaffected.
 
 Docsy now pins the default [Mermaid][mermaid-docs] version (11.16.1 for this
 release) instead of loading whatever `latest` resolves to on the CDN, so diagram
-rendering no longer changes when an upstream major ships. The pin advances with
-each theme release.
+rendering no longer changes when an upstream major ships.
 
 ### Actions {#mermaid-actions}
 
@@ -351,9 +337,10 @@ In addition to the [generic site checks][check], for this release:
 
 ## What's next?
 
-The semantic-class transition continues: more chrome partials will move to `td-`
-classes in coming releases, each with a selector table like this post's. Work
-towards the next release is tracked under the [0.18.0 milestone][].
+The [semantic-class transition](#semantic-classes) continues: more chrome
+partials will move to `td-` classes in coming releases. For what your site can
+rely on during the transition, see [semantic classes][]. Work towards the next
+release is tracked under the [0.18.0 milestone][].
 
 <!-- prettier-ignore -->
 > [!INFO]- Your opinion counts!
@@ -403,6 +390,7 @@ About this release:
 [official support policy]: /project/about/changelog/#official-support
 [order of steps]: /docs/update/#update-order
 [overrides]: /docs/update/#update-overrides
+[semantic classes]: /docs/content/lookandfeel/#semantic-classes
 [trusted publishing]: https://docs.npmjs.com/trusted-publishers
 [Update Docsy]: /docs/update/
 [update-hugo]: /docs/update/#update-hugo

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -51,8 +51,8 @@ params:
   - {{% _param BREAKING %}} [Dart Sass replaces LibSass](#dart-sass)
   - {{% _param BREAKING %}} [Breadcrumb semantic classes](#semantic-classes)
   - {{% _param BREAKING %}} [Install command renamed](#install-command)
-- No Hugo change this release: the theme minimum stays [0.160.1][], and the
-  project still builds and tests with Hugo {{% param hugoSupportedVersion %}}.
+- No Hugo change this release: the [version list](#upgrade) is otherwise
+  unchanged too.
 - Optionally skim:
   - [Default Mermaid version pinned](#mermaid)
   - [Other notable changes](#other-notable-changes), and
@@ -69,12 +69,14 @@ build prerequisite: the `sass` CLI must be available on your build's `PATH`.
 Why now? Hugo deprecated its embedded LibSass in 0.153.0, with removal to
 follow, and Hugo will never bundle Dart Sass -- the planned [pure-JS embedded
 mode][dart-sass-2413] targets platforms without prebuilt binaries, not an
-in-binary compiler. Staying on LibSass would keep growing the set of sites on a
-dying pipeline; switching now keeps Docsy sites on the maintained one.
+in-binary compiler. Every further LibSass-built release would grow the set of
+sites on a dying pipeline.
 
 <!-- TODO(hold, own-warnings PR): warnings-expected clause lands here -- exact
   wording to come from the css-closeout lane once Docsy's own Sass
-  function-class warnings are zeroed. -->
+  function-class warnings are zeroed. When adding it, confirm the 1.74.0 floor
+  rationale under Actions reads coherently against it (the floor cites the
+  toCSS deprecation-silencing options). -->
 
 ### Actions {#dart-sass-actions}
 
@@ -91,10 +93,9 @@ update in the [order of steps][]:
   npm install --save-dev sass-embedded
   ```
 
-- **CI providers**: GitHub Actions and Netlify setups are covered in the
-  [deployment docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]): if your
-  build runs through npm scripts, the `sass-embedded` dependency above is all
-  you need.
+- **CI providers**: GitHub Actions and Netlify are covered in the [deployment
+  docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]); if your build runs
+  through npm scripts, the `sass-embedded` dependency above is all you need.
 - **Cloudflare Pages** (and other providers where the build doesn't run through
   npm scripts): install the standalone binary and add it to `PATH`, with
   `DART_SASS_VERSION` set as an environment variable in your project settings
@@ -123,6 +124,12 @@ zero-threshold visual regression suite.
   that is the serialization change, not drift.
 - Recheck anything that string-matches `--bs-*` values in CSS, JavaScript, or
   tests, and update the expected strings.
+- Custom Chroma style sheets (`assets/scss/td/chroma/_light.scss` and
+  `_dark.scss`) are now loaded as isolated Sass modules. Raw
+  `hugo gen chromastyles` dumps -- the documented form -- are unaffected, but a
+  hand-tuned dump that references theme or Bootstrap variables such as
+  `$primary` now fails with "Undefined variable": inline the color values
+  instead.
 
 ### LibSass escape hatch {#libsass-escape-hatch}
 
@@ -144,13 +151,6 @@ point's `@use` through as an unknown at-rule instead of failing.
 This hatch is terminal -- it dies when Hugo removes LibSass. For binary-less
 platforms, the durable path is Dart Sass's planned [pure-JS embedded
 mode][dart-sass-2413].
-
-One related isolation change: custom Chroma style sheets
-(`assets/scss/td/chroma/_light.scss` and `_dark.scss`) are now loaded as
-isolated Sass modules. Raw `hugo gen chromastyles` dumps -- the documented form
--- are unaffected, but a hand-tuned dump that references theme or Bootstrap
-variables such as `$primary` now fails with "Undefined variable": inline the
-color values instead.
 
 ## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
 
@@ -214,8 +214,8 @@ the breadcrumb `.active`.
 
 The command that installs the theme's npm dependencies is renamed:
 `npm run postinstall` is now `npm run install:theme-deps`. Docsy's packages no
-longer declare npm lifecycle install hooks at all, so installs behave the same
-with or without `--ignore-scripts` -- one less place where a dependency can run
+longer declare npm lifecycle install hooks, so installs behave the same with or
+without `--ignore-scripts` -- one less place where a dependency can run
 unreviewed code.
 
 ### Actions {#install-command-actions}
@@ -242,18 +242,15 @@ Hugo-module and `@docsy/theme` registry installs are unaffected.
 ## Default Mermaid version pinned {#mermaid}
 
 Docsy now pins the default [Mermaid][mermaid-docs] version -- 11.16.1 for this
-release -- instead of loading whatever `latest` resolved to on the CDN when a
-page loads. Diagram rendering no longer changes overnight because an upstream
-major shipped, and the version your site runs is the one the release was tested
-with.
+release -- instead of loading whatever `latest` resolves to on the CDN, so
+diagram rendering no longer changes when an upstream major ships. The pin
+advances with each theme release.
 
 ### Actions {#mermaid-actions}
 
 **Applies if** you want a different Mermaid version.
 
-- Set [`params.mermaid.version`][mermaid-docs] in your site config; sites that
-  were relying on the floating `latest` should prefer pinning their own version
-  the same way.
+- Set [`params.mermaid.version`][mermaid-docs] in your site config.
 
 ## Other notable changes
 
@@ -269,11 +266,12 @@ sites.
 
 ### {{% _param CLEANUP %}} Supply-chain hardening {#supply-chain}
 
-- npm lockfiles are committed, and installs are lock-exact and script-free.
-- A committed supply-chain audit and a script-runner lint guard the dependency
-  and workflow surface, backed by an `npm audit` gate.
-- npm `pre`/`post` lifecycle hooks are inlined into their parent scripts, and
-  the full test-suite entry point is renamed `ci:test` to `test:full`.
+0.17.0 hardens the project's supply-chain posture: npm lockfiles are committed
+with lock-exact, script-free installs; a committed supply-chain audit, a
+script-runner lint, and an `npm audit` gate guard the dependency and workflow
+surface; and npm lifecycle hooks are gone (inlined into their parent scripts),
+with the full test suite renamed to `test:full`. The changelog's
+[For-maintainers list][CL@0.17.0] itemizes these.
 
 ### {{% _param CLEANUP %}} npm trusted publishing {#trusted-publishing}
 
@@ -304,8 +302,7 @@ section. {{< /comment >}}
     [{{% param hugoSupportedVersion %}}][hugo-supported-version] (unchanged;
     theme minimum [0.160.1][])
   - **[Node][update-node]**: LTS 24 (unchanged)
-  - **Dart Sass**: new requirement -- see
-    [Dart Sass actions](#dart-sass-actions)
+  - **Dart Sass**: [new requirement](#dart-sass-actions)
 - Remember to [review your theme overrides][overrides]: this release reworks
   theme files that sites commonly override, including `head-css.html` and
   `breadcrumb.html`.

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -98,7 +98,8 @@ update in the [order of steps][]:
 - **Cloudflare Pages** (and other providers where the build doesn't run through
   npm scripts): install the standalone binary and add it to `PATH`, with
   `DART_SASS_VERSION` set as an environment variable in your project settings
-  (1.74.0 or later; adapted from [Hugo's Cloudflare Pages guide][cf-pages]):
+  (1.74.0 or later; adapted from [Hugo's Cloudflare hosting
+  guide][cf-hosting]):
 
   ```sh
   curl -LJO https://github.com/sass/dart-sass/releases/download/$DART_SASS_VERSION/dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
@@ -375,7 +376,7 @@ About this release:
   <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoSupportedVersion %}}>
 [`@docsy/theme`]: https://www.npmjs.com/package/@docsy/theme
 [`sass-embedded`]: https://www.npmjs.com/package/sass-embedded
-[cf-pages]: https://gohugo.io/host-and-deploy/host-on-cloudflare-pages/
+[cf-hosting]: https://gohugo.io/host-and-deploy/host-on-cloudflare/
 [check]: /docs/update/#check
 [CL@0.17.0]: /project/about/changelog/#next
 [compare-0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -99,10 +99,12 @@ update in the [order of steps][]:
   docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]); if your build runs
   through npm scripts, the `sass-embedded` dependency above is all you need.
 - **Cloudflare Pages** (and other providers where the build doesn't run through
-  npm scripts): install the standalone binary and add it to `PATH`, with
-  `DART_SASS_VERSION` set as an environment variable in your project settings to
-  an unprefixed version, 1.74.0 or later (for example, `1.102.0`; snippet
-  adapted from [Hugo's Cloudflare hosting guide][cf-hosting]):
+  npm scripts): install the standalone binary and add it to `PATH`. The snippet
+  below covers Linux x64 builders such as Cloudflare Pages; on other platforms,
+  substitute the matching [dart-sass release asset][dart-sass releases]. Set
+  `DART_SASS_VERSION` as an environment variable in your project settings, to an
+  unprefixed version, 1.74.0 or later (for example, `1.102.0`; snippet adapted
+  from [Hugo's Cloudflare hosting guide][cf-hosting]):
 
   ```sh
   curl -fLJO https://github.com/sass/dart-sass/releases/download/$DART_SASS_VERSION/dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
@@ -119,8 +121,9 @@ update in the [order of steps][]:
 Dart Sass serializes some Sass-computed colors differently than LibSass did (for
 example, `rgb(81.02%, 88.63%, 99.84%)` where LibSass emitted `#cfe2ff`), across
 Bootstrap-computed custom properties such as `--bs-*-bg-subtle` and
-`--bs-table-*`. **Rendered colors are unchanged**; this was verified with a
-zero-threshold visual regression suite.
+`--bs-table-*`. **Rendered colors are visually unchanged**: a bit-exact visual
+regression suite found at most single-channel rounding differences on a few
+dozen pixels per page.
 
 - If you diff built CSS across the upgrade, expect thousands of changed lines:
   that is the serialization change, not drift.
@@ -279,9 +282,9 @@ sites.
 0.17.0 hardens the project's supply-chain posture: npm lockfiles are committed
 with lock-exact, script-free installs; a committed supply-chain audit, a
 script-runner lint, and an `npm audit` gate guard the dependency and workflow
-surface; and npm lifecycle hooks are gone (inlined into their parent scripts),
-with the full test suite renamed to `test:full`. The changelog's
-[For-maintainers list][CL@0.17.0] itemizes these.
+surface; and npm install hooks and implicit `pre`/`post` run-hooks are gone
+(inlined into their parent scripts), with the full test suite renamed to
+`test:full`. The changelog's [For-maintainers list][CL@0.17.0] itemizes these.
 
 ### {{% _param CLEANUP %}} npm trusted publishing {#trusted-publishing}
 
@@ -337,8 +340,8 @@ In addition to the [generic site checks][check], for this release:
 - [ ] Every environment that builds your site provides the `sass` CLI
       (`sass --version`); see [Dart Sass actions](#dart-sass-actions).
 - [ ] If you diff built CSS, the changes are
-      [serialization-only](#dart-sass-recheck); spot-check that rendered colors
-      are unchanged.
+      [serialization-only](#dart-sass-recheck); spot-check for visible color
+      drift (single-channel rounding differences are expected).
 - [ ] Breadcrumbs render styled, especially if you had custom breadcrumb CSS,
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).
@@ -389,6 +392,7 @@ About this release:
 [CL@0.17.0]: /project/about/changelog/#next
 [compare-0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main
 [Dart Sass]: https://sass-lang.com/dart-sass/
+[dart-sass releases]: https://github.com/sass/dart-sass/releases
 [dart-sass-2413]: https://github.com/sass/dart-sass/pull/2413
 [deployment docs]: /docs/deployment/
 [footer copyright docs]: /docs/content/lookandfeel/#footer-copyright

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -159,13 +159,19 @@ Docsy-owned `td-` **semantic classes** over the coming releases, and breadcrumbs
 go first. Each migrating release's report will carry a selector table like the
 one below.
 
-<!-- TODO(#2727): once merged, link "semantic classes" in the intro above to
-  the user guide's consumer-contract section
+<!-- TODO(#2727): once merged, wire the user guide's consumer-contract section
   (/docs/content/lookandfeel/#semantic-classes; audience split: the
   contributor page /project/implementation/semantic-classes/ is for
-  maintainer-facing links only), and in the SCSS bullet below, replace the
-  @extend mechanism clause with that link (mechanism is page-owned; the post
-  keeps only the action and the not-a-promise caveat). -->
+  maintainer-facing links only) into this section, trimming what that section
+  now owns:
+  1. Intro: link "semantic classes"; drop the "Each migrating release's report
+     will carry a selector table" sentence (the docs own the per-release
+     selector-changes promise).
+  2. SCSS bullet: replace the @extend mechanism and not-a-promise clauses with
+     the link (both are docs-owned); the post keeps the action: migrate now.
+  3. Table note: consider trimming the "so visual state and accessibility
+     state can't drift apart" rationale (owned by the implementation page's
+     State styling section). -->
 
 ### Selector migration table
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -98,8 +98,7 @@ update in the [order of steps][]:
 - **Cloudflare Pages** (and other providers where the build doesn't run through
   npm scripts): install the standalone binary and add it to `PATH`, with
   `DART_SASS_VERSION` set as an environment variable in your project settings
-  (1.74.0 or later; adapted from [Hugo's Cloudflare hosting
-  guide][cf-hosting]):
+  (1.74.0 or later; adapted from [Hugo's Cloudflare hosting guide][cf-hosting]):
 
   ```sh
   curl -LJO https://github.com/sass/dart-sass/releases/download/$DART_SASS_VERSION/dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -1,0 +1,396 @@
+---
+title: Release 0.17.0 report and upgrade guide
+linkTitle: Release 0.17.0
+date: 2026-08-19
+draft: true
+description: >-
+  Docsy now builds with Dart Sass, so the sass CLI joins your build. This
+  release also debuts semantic classes in breadcrumbs, pins the default Mermaid
+  version, and renames the theme-dependencies install command.
+author: >-
+  [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
+  for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
+body_class: release-highlights
+tags: [release, upgrade]
+params:
+  hugoSupportedVersion: 0.164.0
+---
+
+<!-- markdownlint-disable descriptive-link-text no-space-in-emphasis -->
+
+{{% card header="Highlights" %}}
+
+- {{% _param FAS_LG palette primary %}} <span>**[Dart Sass](#dart-sass)**: Docsy
+  moves off Hugo's deprecated embedded LibSass -- one new build
+  prerequisite</span>
+- {{% _param FAS_LG tags info %}}
+  <span>**[Semantic classes](#semantic-classes)**: Docsy chrome starts getting
+  its own `td-` class names, beginning with breadcrumbs</span>
+- {{% _param FAS_LG thumbtack warning %}} <span>**[Pinned Mermaid](#mermaid)**:
+  diagrams no longer float on the CDN's `latest`</span>
+
+{{% /card %}}
+
+## Release summary
+
+- **[Dart Sass replaces LibSass](#dart-sass)**: the `sass` CLI becomes a build
+  prerequisite
+- **[Semantic classes](#semantic-classes)**: breadcrumbs debut Docsy's own `td-`
+  chrome classes
+- **Install and defaults**:
+  - [Theme-dependencies install command renamed](#install-command)
+  - [Default Mermaid version pinned](#mermaid): no longer the CDN's `latest`
+- **[Other notable changes](#other-notable-changes)**, and
+  [for maintainers](#for-maintainers): supply-chain hardening and npm trusted
+  publishing
+
+## Ready to upgrade? <a id="breaking-changes"></a>
+
+- :warning: Respect the [order of steps][] to avoid breaking your build.
+- Review {{% _param BADGE BREAKING warning %}} changes:
+  - {{% _param BREAKING %}} [Dart Sass replaces LibSass](#dart-sass)
+  - {{% _param BREAKING %}} [Breadcrumb semantic classes](#semantic-classes)
+  - {{% _param BREAKING %}} [Install command renamed](#install-command)
+- No Hugo change this release: the theme minimum stays [0.160.1][], and the
+  project still builds and tests with Hugo {{% param hugoSupportedVersion %}}.
+- Optionally skim:
+  - [Default Mermaid version pinned](#mermaid)
+  - [Other notable changes](#other-notable-changes), and
+    [for maintainers](#for-maintainers)
+- {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.17.0](#upgrade)
+  yourself, or [ask an AI agent](#upgrading-with-ai).
+
+## {{% _param BREAKING %}} Dart Sass replaces LibSass {#dart-sass}
+
+Docsy's stylesheets are now transpiled with [Dart Sass][], the actively
+developed Sass implementation, instead of Hugo's embedded LibSass. This adds one
+build prerequisite: the `sass` CLI must be available on your build's `PATH`.
+
+Why now? Hugo deprecated its embedded LibSass in 0.153.0, with removal to
+follow, and Hugo will never bundle Dart Sass -- the planned [pure-JS embedded
+mode][dart-sass-2413] targets platforms without prebuilt binaries, not an
+in-binary compiler. Staying on LibSass would keep growing the set of sites on a
+dying pipeline; switching now keeps Docsy sites on the maintained one.
+
+<!-- TODO(hold, own-warnings PR): warnings-expected clause lands here -- exact
+  wording to come from the css-closeout lane once Docsy's own Sass
+  function-class warnings are zeroed. -->
+
+### Actions {#dart-sass-actions}
+
+{{% _param BREAKING %}} **Applies to all sites** -- every install mode uses the
+theme's default Sass pipeline.
+
+Provide Dart Sass in each environment that builds your site, before the theme
+update in the [order of steps][]:
+
+- **Local and npm-managed builds**: install the [`sass-embedded`][] package from
+  your project root, per [Install Dart Sass][]:
+
+  ```sh
+  npm install --save-dev sass-embedded
+  ```
+
+- **CI providers**: GitHub Actions and Netlify setups are covered in the
+  [deployment docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]): if your
+  build runs through npm scripts, the `sass-embedded` dependency above is all
+  you need.
+- **Cloudflare Pages** (and other providers where the build doesn't run through
+  npm scripts): install the standalone binary and add it to `PATH`, with
+  `DART_SASS_VERSION` set as an environment variable in your project settings
+  (1.74.0 or later; adapted from [Hugo's Cloudflare Pages guide][cf-pages]):
+
+  ```sh
+  curl -LJO https://github.com/sass/dart-sass/releases/download/$DART_SASS_VERSION/dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
+  tar -xf dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
+  export PATH=$PWD/dart-sass:$PATH
+  ```
+
+- **Self-provisioned compilers**: use Dart Sass **1.74.0 or later**, the first
+  release with the `toCSS` deprecation-silencing options that override-based
+  noise control relies on. Sites using `sass-embedded` get a validated version
+  through the pin.
+
+### What to recheck after upgrading {#dart-sass-recheck}
+
+Dart Sass serializes some Sass-computed colors differently than LibSass did --
+for example, `rgb(81.02%, 88.63%, 99.84%)` where LibSass emitted `#cfe2ff` --
+across Bootstrap-computed custom properties such as `--bs-*-bg-subtle` and
+`--bs-table-*`. **Rendered colors are unchanged**; this was verified with a
+zero-threshold visual regression suite.
+
+- If you diff built CSS across the upgrade, expect thousands of changed lines:
+  that is the serialization change, not drift.
+- Recheck anything that string-matches `--bs-*` values in CSS, JavaScript, or
+  tests, and update the expected strings.
+
+### LibSass escape hatch {#libsass-escape-hatch}
+
+**Applies if** your build platform has no Dart Sass distribution (for example,
+the BSDs).
+
+You can restore the LibSass pipeline for as long as your Hugo build still
+bundles LibSass, by overriding **all three** of these theme files with their
+0.16 versions:
+
+1. `layouts/_partials/head-css.html`: a plain `toCSS` call.
+2. `assets/scss/main.scss`: back to `@import 'td/main';`.
+3. `assets/scss/td/_code-dark.scss`: back to its nested-`@import` form.
+
+The three are an atomic set. In particular, overriding `head-css.html` alone
+**builds green but ships an unstyled site**: LibSass passes the shipped entry
+point's `@use` through as an unknown at-rule instead of failing.
+
+This hatch is terminal -- it dies when Hugo removes LibSass. For binary-less
+platforms, the durable path is Dart Sass's planned [pure-JS embedded
+mode][dart-sass-2413].
+
+One related isolation change: custom Chroma style sheets
+(`assets/scss/td/chroma/_light.scss` and `_dark.scss`) are now loaded as
+isolated Sass modules. Raw `hugo gen chromastyles` dumps -- the documented form
+-- are unaffected, but a hand-tuned dump that references theme or Bootstrap
+variables such as `$primary` now fails with "Undefined variable": inline the
+color values instead.
+
+## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
+
+Docsy's chrome markup is moving from Bootstrap utility and component classes to
+Docsy-owned `td-` **semantic classes** over the coming releases, and breadcrumbs
+go first. Each migrating release's report will carry a selector table like the
+one below.
+
+<!-- TODO(#2727): once merged, link "semantic-class conventions"
+  (/project/implementation/semantic-classes/) from this intro, and from the
+  SCSS bullet below (§ "What this means for your site"). -->
+
+### Selector migration table
+
+| 0.16 emitted                | 0.17 emitted                                   |
+| --------------------------- | ---------------------------------------------- |
+| `ol.breadcrumb`             | `ol.td-breadcrumbs__list`                      |
+| `li.breadcrumb-item`        | `li.td-breadcrumbs__item`                      |
+| `li.breadcrumb-item.active` | `li.td-breadcrumbs__item[aria-current="page"]` |
+
+Unchanged: the `td-breadcrumbs` and `td-breadcrumbs__single` classes on the
+`<nav>` element. The `active` class is no longer emitted: state styling keys on
+the ARIA-mandated `aria-current="page"` attribute, so visual state and
+accessibility state can't drift apart.
+
+One related fix: breadcrumbs in taxonomy-term page summaries now render without
+ARIA attributes -- a page summary isn't the current page -- and with the
+attribute gone, its styling drops too, by design.
+
+### Actions {#semantic-classes-actions}
+
+{{% _param BREAKING %}} **Applies if** you style or script against breadcrumb
+markup from outside the theme's Sass pipeline: plain CSS files, JavaScript
+`querySelector` calls, or tests matching `.breadcrumb`, `.breadcrumb-item`, or
+the breadcrumb `.active`.
+
+- Update your selectors per the [table above](#selector-migration-table).
+
+{{% _param BREAKING %}} **Applies if** you override `breadcrumb.html` or
+`term.html`.
+
+- Refresh your overridden copies from the 0.17 theme -- partial overrides are
+  version-coupled ([review your theme overrides][overrides]). A pre-0.17
+  `breadcrumb.html` copy also leaks the stale `active` class into term-page
+  summaries, since `term.html`'s summary sanitizer now strips ARIA attributes
+  only.
+
+**Applies if** your project's Sass styles the old Bootstrap class names.
+
+- Your rules keep working for now -- the theme binds the new classes to
+  Bootstrap's styles, which incidentally rewrites `.breadcrumb`-family Sass
+  rules to also match the `td-` classes. This keep-alive is an accident of the
+  transition mechanism, **not a compatibility promise**: it ends when the
+  Bootstrap binding retires. Migrate your Sass selectors now, with the rest.
+
+## {{% _param BREAKING %}} Install command renamed {#install-command}
+
+The command that installs the theme's npm dependencies is renamed:
+`npm run postinstall` is now `npm run install:theme-deps`. Docsy's packages no
+longer declare npm lifecycle install hooks at all, so installs behave the same
+with or without `--ignore-scripts` -- one less place where a dependency can run
+unreviewed code.
+
+### Actions {#install-command-actions}
+
+{{% _param BREAKING %}} **Applies if** your site keeps Docsy under
+`themes/docsy/` as a clone or Git submodule.
+
+- After updating the theme, run the renamed command from `themes/docsy/`:
+
+  ```sh
+  npm run install:theme-deps
+  ```
+
+{{% _param BREAKING %}} **Applies if** your site installs Docsy from GitHub with
+npm (development and testing only).
+
+- The theme's dependencies are no longer installed as a side effect of
+  `npm install`. Run the install command yourself, from `node_modules/docsy/`,
+  or switch to the [`@docsy/theme`][] registry package, which needs no install
+  step.
+
+Hugo-module and `@docsy/theme` registry installs are unaffected.
+
+## Default Mermaid version pinned {#mermaid}
+
+Docsy now pins the default [Mermaid][mermaid-docs] version -- 11.16.1 for this
+release -- instead of loading whatever `latest` resolved to on the CDN when a
+page loads. Diagram rendering no longer changes overnight because an upstream
+major shipped, and the version your site runs is the one the release was tested
+with.
+
+### Actions {#mermaid-actions}
+
+**Applies if** you want a different Mermaid version.
+
+- Set [`params.mermaid.version`][mermaid-docs] in your site config; sites that
+  were relying on the floating `latest` should prefer pinning their own version
+  the same way.
+
+## Other notable changes
+
+- **Footer copyright**: a same-year range now renders as the single year --
+  `© 2026` instead of `© 2026–2026`. See the [footer copyright docs][].
+
+For this and all other changes, see the [0.17.0][] release page.
+
+## For maintainers
+
+Changes in this section affect Docsy maintainers and contributors, not consuming
+sites.
+
+### {{% _param CLEANUP %}} Supply-chain hardening {#supply-chain}
+
+- npm lockfiles are committed, and installs are lock-exact and script-free.
+- A committed supply-chain audit and a script-runner lint guard the dependency
+  and workflow surface, backed by an `npm audit` gate.
+- npm `pre`/`post` lifecycle hooks are inlined into their parent scripts, and
+  the full test-suite entry point is renamed `ci:test` to `test:full`.
+
+### {{% _param CLEANUP %}} npm trusted publishing {#trusted-publishing}
+
+Stable [`@docsy/theme`][] releases are now published from CI via npm [trusted
+publishing][] (OIDC) -- no long-lived registry tokens. This completes the
+npm-registry arc announced with 0.16.0.
+
+### {{% _param NEW %}} Chrome test baselines {#chrome-baselines}
+
+Markup goldens, a framework-class output check, and a visual regression suite
+now guard the theme's chrome partials. These baselines gate the semantic-class
+migration above and future chrome rework.
+
+## {{% _param FAS rocket primary %}} Upgrade to 0.17.0 {#upgrade}
+
+Follow [Update Docsy][] and as you do:
+
+{{< comment >}} Deliberate repeat of the warning from
+[Breaking changes](#breaking-changes), for readers who jump straight to this
+section. {{< /comment >}}
+
+- :warning: Respect the [order of steps][] to avoid breaking your build.
+- Provide Dart Sass in every build environment **before** updating the theme;
+  see [Dart Sass actions](#dart-sass-actions).
+- Use these versions:[^vers-note]
+  - **[Docsy][update-theme]**: [0.16.0][] -> [0.17.0][]
+  - **[Hugo][update-hugo]**:
+    [{{% param hugoSupportedVersion %}}][hugo-supported-version] (unchanged;
+    theme minimum [0.160.1][])
+  - **[Node][update-node]**: LTS 24 (unchanged)
+  - **Dart Sass**: new requirement -- see
+    [Dart Sass actions](#dart-sass-actions)
+- Remember to [review your theme overrides][overrides]: this release reworks
+  theme files that sites commonly override, including `head-css.html` and
+  `breadcrumb.html`.
+
+[^vers-note]:
+    Matches `docsy.dev`'s tested Hugo pin and the theme's declared minimum Hugo
+    version. Later Hugo or Node versions may work; see the [official support
+    policy][].
+
+### {{% _param FAS robot info %}} Upgrading with AI?
+
+Give your assistant this post as context: like its predecessors, it is written
+to double as operating instructions, with applies-if gates, per-mode actions,
+verification steps, and sanity checks.
+
+<section class="td-checkbox-list-wrapper">
+
+### {{% _param FAS square-check primary %}} Sanity checks
+
+In addition to the [generic site checks][check], for this release:
+
+- [ ] Every environment that builds your site provides the `sass` CLI
+      (`sass --version`); see [Dart Sass actions](#dart-sass-actions).
+- [ ] If you diff built CSS, the changes are
+      [serialization-only](#dart-sass-recheck); spot-check that rendered colors
+      are unchanged.
+- [ ] Breadcrumbs render styled -- especially if you had custom breadcrumb CSS,
+      JavaScript, or overrides; see the
+      [selector migration table](#selector-migration-table).
+- [ ] Mermaid diagrams render at the [pinned version](#mermaid).
+
+</section>
+
+## What's next?
+
+The semantic-class transition continues: more chrome partials will move to `td-`
+classes in coming releases, each with a selector table like this post's. Work
+towards the next release is tracked under the [0.18.0 milestone][].
+
+<!-- prettier-ignore -->
+> [!INFO]- Your opinion counts!
+>
+> - {{% _param FAS thumbs-up success %}} If you'd like a feature or fix to be
+>   considered for inclusion in an upcoming release, **upvote** (with a thumbs up)
+>   the associated issue or PR.
+>
+> - {{% _param FAS star warning %}} If you find Docsy useful, consider [starring
+>   the repository][star-the-repo] to show your support.
+{._list-unstyled}
+
+[star-the-repo]: https://github.com/google/docsy
+
+## References
+
+About this release:
+
+- Changelog entry for [0.17.0][CL@0.17.0]
+- Release page for [0.17.0][]
+- [Release 0.17.0 preparation issue (#2691)][#2691]
+- Git history since [0.16.0][compare-0.16.0]
+
+<!-- prettier-ignore-start -->
+[#2691]: https://github.com/google/docsy/issues/2691
+[0.16.0]: https://github.com/google/docsy/releases/v0.16.0
+[0.17.0]: https://github.com/google/docsy/releases/v0.17.0
+[0.18.0 milestone]: https://github.com/google/docsy/milestone/27
+[0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
+[hugo-supported-version]:
+  <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoSupportedVersion %}}>
+[`@docsy/theme`]: https://www.npmjs.com/package/@docsy/theme
+[`sass-embedded`]: https://www.npmjs.com/package/sass-embedded
+[cf-pages]: https://gohugo.io/host-and-deploy/host-on-cloudflare-pages/
+[check]: /docs/update/#check
+[CL@0.17.0]: /project/about/changelog/#next
+[compare-0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main
+[Dart Sass]: https://sass-lang.com/dart-sass/
+[dart-sass-2413]: https://github.com/sass/dart-sass/pull/2413
+[deployment docs]: /docs/deployment/
+[footer copyright docs]: /docs/content/lookandfeel/#footer-copyright
+[gh-pages-deploy]: /docs/deployment/github-pages/
+[Install Dart Sass]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass
+[mermaid-docs]: /docs/content/diagrams-and-formulae/#diagrams-with-mermaid
+[Netlify]: /docs/deployment/netlify/
+[official support policy]: /project/about/changelog/#official-support
+[order of steps]: /docs/update/#update-order
+[overrides]: /docs/update/#update-overrides
+[trusted publishing]: https://docs.npmjs.com/trusted-publishers
+[Update Docsy]: /docs/update/
+[update-hugo]: /docs/update/#update-hugo
+[update-node]: /docs/update/#update-node
+[update-theme]: /docs/update/#update-theme
+<!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -21,8 +21,8 @@ params:
 {{% card header="Highlights" %}}
 
 - {{% _param FAS_LG palette primary %}} <span>**[Dart Sass](#dart-sass)**: Docsy
-  moves off Hugo's deprecated embedded LibSass -- one new build
-  prerequisite</span>
+  moves off Hugo's deprecated embedded LibSass (one new build
+  prerequisite)</span>
 - {{% _param FAS_LG tags info %}}
   <span>**[Semantic classes](#semantic-classes)**: Docsy chrome starts getting
   its own `td-` class names, beginning with breadcrumbs</span>
@@ -67,12 +67,12 @@ developed Sass implementation, instead of Hugo's embedded LibSass. This adds one
 build prerequisite: the `sass` CLI must be available on your build's `PATH`.
 
 Why now? Hugo deprecated its embedded LibSass in 0.153.0, with removal to
-follow, and Hugo will never bundle Dart Sass -- the planned [pure-JS embedded
+follow, and Hugo will never bundle Dart Sass: the planned [pure-JS embedded
 mode][dart-sass-2413] targets platforms without prebuilt binaries, not an
 in-binary compiler. Every further LibSass-built release would grow the set of
 sites on a dying pipeline.
 
-<!-- TODO(hold, own-warnings PR): warnings-expected clause lands here -- exact
+<!-- TODO(hold, own-warnings PR): warnings-expected clause lands here: exact
   wording to come from the css-closeout lane once Docsy's own Sass
   function-class warnings are zeroed. When adding it, confirm the 1.74.0 floor
   rationale under Actions reads coherently against it (the floor cites the
@@ -80,7 +80,7 @@ sites on a dying pipeline.
 
 ### Actions {#dart-sass-actions}
 
-{{% _param BREAKING %}} **Applies to all sites** -- every install mode uses the
+{{% _param BREAKING %}} **Applies to all sites**: every install mode uses the
 theme's default Sass pipeline.
 
 Provide Dart Sass in each environment that builds your site, before the theme
@@ -114,9 +114,9 @@ update in the [order of steps][]:
 
 ### What to recheck after upgrading {#dart-sass-recheck}
 
-Dart Sass serializes some Sass-computed colors differently than LibSass did --
-for example, `rgb(81.02%, 88.63%, 99.84%)` where LibSass emitted `#cfe2ff` --
-across Bootstrap-computed custom properties such as `--bs-*-bg-subtle` and
+Dart Sass serializes some Sass-computed colors differently than LibSass did (for
+example, `rgb(81.02%, 88.63%, 99.84%)` where LibSass emitted `#cfe2ff`), across
+Bootstrap-computed custom properties such as `--bs-*-bg-subtle` and
 `--bs-table-*`. **Rendered colors are unchanged**; this was verified with a
 zero-threshold visual regression suite.
 
@@ -126,7 +126,7 @@ zero-threshold visual regression suite.
   tests, and update the expected strings.
 - Custom Chroma style sheets (`assets/scss/td/chroma/_light.scss` and
   `_dark.scss`) are now loaded as isolated Sass modules. Raw
-  `hugo gen chromastyles` dumps -- the documented form -- are unaffected, but a
+  `hugo gen chromastyles` dumps (the documented form) are unaffected, but a
   hand-tuned dump that references theme or Bootstrap variables such as
   `$primary` now fails with "Undefined variable": inline the color values
   instead.
@@ -148,7 +148,7 @@ The three are an atomic set. In particular, overriding `head-css.html` alone
 **builds green but ships an unstyled site**: LibSass passes the shipped entry
 point's `@use` through as an unknown at-rule instead of failing.
 
-This hatch is terminal -- it dies when Hugo removes LibSass. For binary-less
+This hatch is terminal: it dies when Hugo removes LibSass. For binary-less
 platforms, the durable path is Dart Sass's planned [pure-JS embedded
 mode][dart-sass-2413].
 
@@ -161,7 +161,7 @@ one below.
 
 <!-- TODO(#2727): once merged, link "semantic classes" in the intro above to
   the user guide's consumer-contract section
-  (/docs/content/lookandfeel/#semantic-classes -- audience split: the
+  (/docs/content/lookandfeel/#semantic-classes; audience split: the
   contributor page /project/implementation/semantic-classes/ is for
   maintainer-facing links only), and in the SCSS bullet below, replace the
   @extend mechanism clause with that link (mechanism is page-owned; the post
@@ -181,8 +181,8 @@ the ARIA-mandated `aria-current="page"` attribute, so visual state and
 accessibility state can't drift apart.
 
 One related fix: breadcrumbs in taxonomy-term page summaries now render without
-ARIA attributes -- a page summary isn't the current page -- and with the
-attribute gone, its styling drops too, by design.
+ARIA attributes (a page summary isn't the current page), and with the attribute
+gone, its styling drops too, by design.
 
 ### Actions {#semantic-classes-actions}
 
@@ -196,7 +196,7 @@ the breadcrumb `.active`.
 {{% _param BREAKING %}} **Applies if** you override `breadcrumb.html` or
 `term.html`.
 
-- Refresh your overridden copies from the 0.17 theme -- partial overrides are
+- Refresh your overridden copies from the 0.17 theme: partial overrides are
   version-coupled ([review your theme overrides][overrides]). A pre-0.17
   `breadcrumb.html` copy also leaks the stale `active` class into term-page
   summaries, since `term.html`'s summary sanitizer now strips ARIA attributes
@@ -204,7 +204,7 @@ the breadcrumb `.active`.
 
 **Applies if** your project's Sass styles the old Bootstrap class names.
 
-- Your rules keep working for now -- the theme binds the new classes to
+- Your rules keep working for now: the theme binds the new classes to
   Bootstrap's styles, which incidentally rewrites `.breadcrumb`-family Sass
   rules to also match the `td-` classes. This keep-alive is an accident of the
   transition mechanism, **not a compatibility promise**: it ends when the
@@ -215,8 +215,8 @@ the breadcrumb `.active`.
 The command that installs the theme's npm dependencies is renamed:
 `npm run postinstall` is now `npm run install:theme-deps`. Docsy's packages no
 longer declare npm lifecycle install hooks, so installs behave the same with or
-without `--ignore-scripts` -- one less place where a dependency can run
-unreviewed code.
+without `--ignore-scripts` (one less place where a dependency can run unreviewed
+code).
 
 ### Actions {#install-command-actions}
 
@@ -241,10 +241,10 @@ Hugo-module and `@docsy/theme` registry installs are unaffected.
 
 ## Default Mermaid version pinned {#mermaid}
 
-Docsy now pins the default [Mermaid][mermaid-docs] version -- 11.16.1 for this
-release -- instead of loading whatever `latest` resolves to on the CDN, so
-diagram rendering no longer changes when an upstream major ships. The pin
-advances with each theme release.
+Docsy now pins the default [Mermaid][mermaid-docs] version (11.16.1 for this
+release) instead of loading whatever `latest` resolves to on the CDN, so diagram
+rendering no longer changes when an upstream major ships. The pin advances with
+each theme release.
 
 ### Actions {#mermaid-actions}
 
@@ -254,8 +254,8 @@ advances with each theme release.
 
 ## Other notable changes
 
-- **Footer copyright**: a same-year range now renders as the single year --
-  `© 2026` instead of `© 2026–2026`. See the [footer copyright docs][].
+- **Footer copyright**: a same-year range now renders as the single year
+  (`© 2026` instead of `© 2026–2026`). See the [footer copyright docs][].
 
 For this and all other changes, see the [0.17.0][] release page.
 
@@ -276,7 +276,7 @@ with the full test suite renamed to `test:full`. The changelog's
 ### {{% _param CLEANUP %}} npm trusted publishing {#trusted-publishing}
 
 Stable [`@docsy/theme`][] releases are now published from CI via npm [trusted
-publishing][] (OIDC) -- no long-lived registry tokens. This completes the
+publishing][] (OIDC): no long-lived registry tokens. This completes the
 npm-registry arc announced with 0.16.0.
 
 ### {{% _param NEW %}} Chrome test baselines {#chrome-baselines}
@@ -329,7 +329,7 @@ In addition to the [generic site checks][check], for this release:
 - [ ] If you diff built CSS, the changes are
       [serialization-only](#dart-sass-recheck); spot-check that rendered colors
       are unchanged.
-- [ ] Breadcrumbs render styled -- especially if you had custom breadcrumb CSS,
+- [ ] Breadcrumbs render styled, especially if you had custom breadcrumb CSS,
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).
 - [ ] Mermaid diagrams render at the [pinned version](#mermaid).

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -159,9 +159,11 @@ Docsy-owned `td-` **semantic classes** over the coming releases, and breadcrumbs
 go first. Each migrating release's report will carry a selector table like the
 one below.
 
-<!-- TODO(#2727): once merged, link "semantic-class conventions"
-  (/project/implementation/semantic-classes/) from this intro, and from the
-  SCSS bullet below (§ "What this means for your site"). -->
+<!-- TODO(#2727): once merged, link "semantic classes" in the intro above and
+  the Sass keep-alive mechanism below to the user guide's consumer-contract
+  section (/docs/content/lookandfeel/#semantic-classes -- audience split: the
+  contributor page /project/implementation/semantic-classes/ is for
+  maintainer-facing links only). -->
 
 ### Selector migration table
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -72,13 +72,16 @@ mode][dart-sass-2413] targets platforms without prebuilt binaries, not an
 in-binary compiler. Every further LibSass-built release would grow the set of
 sites on a dying pipeline.
 
-<!-- TODO(hold, own-warnings PR): warnings-expected clause lands here: exact
-  wording to come from the css-closeout lane once Docsy's own Sass
-  function-class warnings are zeroed. When adding it:
-  1. Attach the 1.74.0 floor's rationale to it (1.74.0 is the first release
-     with the toCSS deprecation-silencing options that the clause's silencing
-     override relies on); the floor is stated bare under Actions until then.
-  2. Confirm the Actions bullet and the clause read coherently together. -->
+<!-- prettier-ignore -->
+{{< comment >}} TODO(hold, own-warnings PR): warnings-expected clause lands
+here: exact wording to come from the css-closeout lane once Docsy's own Sass
+function-class warnings are zeroed. When adding it:
+
+1. Attach the 1.74.0 floor's rationale to it (1.74.0 is the first release with
+   the toCSS deprecation-silencing options that the clause's silencing override
+   relies on); the floor is stated bare under Actions until then.
+2. Confirm the Actions bullet and the clause read coherently together.
+   {{< /comment >}}
 
 ### Actions {#dart-sass-actions}
 
@@ -177,16 +180,15 @@ is no longer emitted: state styling keys on the ARIA-mandated
 `aria-current="page"` attribute, so visual state and accessibility state can't
 drift apart.
 
-One related fix: breadcrumbs in taxonomy-term page summaries now render without
-ARIA attributes (a page summary isn't the current page), and with the attribute
-gone, its styling drops too, by design.
+One related change: breadcrumbs in taxonomy-term page summaries render without
+ARIA attributes (a page summary isn't the current page), so current-item styling
+doesn't apply there, as in 0.16.
 
 ### Actions {#semantic-classes-actions}
 
 {{% _param BREAKING %}} **Applies if** you style or script against breadcrumb
 markup from outside the theme's Sass pipeline: plain CSS files, JavaScript
-`querySelector` calls, or tests matching `.breadcrumb`, `.breadcrumb-item`, or
-the breadcrumb `.active`.
+`querySelector` calls, or tests matching the table's 0.16 selectors.
 
 - Update your selectors per the [table above](#selector-migration-table).
 
@@ -200,15 +202,17 @@ the breadcrumb `.active`.
   only.
 
 {{% _param BREAKING %}} **Applies if** your project's Sass styles the old
-Bootstrap class names.
+breadcrumb class names.
 
 - Migrate all your selectors now, per the
   [table above](#selector-migration-table). Rules on the old **structural**
-  names (`.breadcrumb`, `.breadcrumb-item`) keep matching for the moment, an
-  accident of the theme's Bootstrap binding rather than a compatibility promise.
-  Rules involving the **state** class are already broken:
+  Bootstrap names (`.breadcrumb`, `.breadcrumb-item`) keep matching for the
+  moment, an accident of the theme's Bootstrap binding rather than a
+  compatibility promise. Rules involving the **state** class are already broken:
   `.breadcrumb-item.active` no longer matches anything, and a `:not(.active)`
-  now also matches the current item.
+  now also matches the current item. The `td-breadcrumbs__single` rename has no
+  keep-alive at all: the documented [single-breadcrumb display
+  override][single-override] stops matching until renamed.
 
 ## {{% _param BREAKING %}} Install command renamed {#install-command}
 
@@ -391,6 +395,7 @@ About this release:
 [order of steps]: /docs/update/#update-order
 [overrides]: /docs/update/#update-overrides
 [semantic classes]: /docs/content/lookandfeel/#semantic-classes
+[single-override]: /docs/content/navigation/#breadcrumb-navigation
 [trusted publishing]: https://docs.npmjs.com/trusted-publishers
 [Update Docsy]: /docs/update/
 [update-hugo]: /docs/update/#update-hugo

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -159,11 +159,13 @@ Docsy-owned `td-` **semantic classes** over the coming releases, and breadcrumbs
 go first. Each migrating release's report will carry a selector table like the
 one below.
 
-<!-- TODO(#2727): once merged, link "semantic classes" in the intro above and
-  the Sass keep-alive mechanism below to the user guide's consumer-contract
-  section (/docs/content/lookandfeel/#semantic-classes -- audience split: the
+<!-- TODO(#2727): once merged, link "semantic classes" in the intro above to
+  the user guide's consumer-contract section
+  (/docs/content/lookandfeel/#semantic-classes -- audience split: the
   contributor page /project/implementation/semantic-classes/ is for
-  maintainer-facing links only). -->
+  maintainer-facing links only), and in the SCSS bullet below, replace the
+  @extend mechanism clause with that link (mechanism is page-owned; the post
+  keeps only the action and the not-a-promise caveat). -->
 
 ### Selector migration table
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -74,9 +74,11 @@ sites on a dying pipeline.
 
 <!-- TODO(hold, own-warnings PR): warnings-expected clause lands here: exact
   wording to come from the css-closeout lane once Docsy's own Sass
-  function-class warnings are zeroed. When adding it, confirm the 1.74.0 floor
-  rationale under Actions reads coherently against it (the floor cites the
-  toCSS deprecation-silencing options). -->
+  function-class warnings are zeroed. When adding it:
+  1. Attach the 1.74.0 floor's rationale to it (1.74.0 is the first release
+     with the toCSS deprecation-silencing options that the clause's silencing
+     override relies on); the floor is stated bare under Actions until then.
+  2. Confirm the Actions bullet and the clause read coherently together. -->
 
 ### Actions {#dart-sass-actions}
 
@@ -98,19 +100,19 @@ update in the [order of steps][]:
   through npm scripts, the `sass-embedded` dependency above is all you need.
 - **Cloudflare Pages** (and other providers where the build doesn't run through
   npm scripts): install the standalone binary and add it to `PATH`, with
-  `DART_SASS_VERSION` set as an environment variable in your project settings
-  (1.74.0 or later; adapted from [Hugo's Cloudflare hosting guide][cf-hosting]):
+  `DART_SASS_VERSION` set as an environment variable in your project settings to
+  an unprefixed version, 1.74.0 or later (for example, `1.102.0`; snippet
+  adapted from [Hugo's Cloudflare hosting guide][cf-hosting]):
 
   ```sh
-  curl -LJO https://github.com/sass/dart-sass/releases/download/$DART_SASS_VERSION/dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
+  curl -fLJO https://github.com/sass/dart-sass/releases/download/$DART_SASS_VERSION/dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
   tar -xf dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
   export PATH=$PWD/dart-sass:$PATH
   ```
 
-- **Self-provisioned compilers**: use Dart Sass **1.74.0 or later**, the first
-  release with the `toCSS` deprecation-silencing options that override-based
-  noise control relies on. Sites using `sass-embedded` get a validated version
-  through the pin.
+- **Self-provisioned compilers**: use Dart Sass **1.74.0 or later**. Current npm
+  releases of `sass-embedded` are well past this floor; for the officially
+  supported Dart Sass version, see the [official support policy][].
 
 ### What to recheck after upgrading {#dart-sass-recheck}
 
@@ -171,7 +173,9 @@ one below.
      the link (both are docs-owned); the post keeps the action: migrate now.
   3. Table note: consider trimming the "so visual state and accessibility
      state can't drift apart" rationale (owned by the implementation page's
-     State styling section). -->
+     State styling section).
+  4. What's next: drop or re-point "each with a selector table like this
+     post's" (the per-release selector-changes promise is docs-owned). -->
 
 ### Selector migration table
 

--- a/docsy.dev/content/en/docs/update/_index.md
+++ b/docsy.dev/content/en/docs/update/_index.md
@@ -18,9 +18,14 @@ actions, see the [upgrade blog posts](/tags/upgrade/).
 - **Updating from Docsy [0.15](/blog/2026/0.15.0/) or earlier?** First apply the
   theme-path config changes, and only those, from the 0.16.0 post's [theme
   folder actions][tfa]; this page's steps cover the rest.
+- **Updating from Docsy [0.16](/blog/2026/0.16.0/) or earlier?** Before updating
+  the theme, provide the [Dart Sass][] compiler in every environment that builds
+  your site; see the 0.17.0 post's
+  [Dart Sass actions](/blog/2026/0.17.0/#dart-sass-actions).
 
-<!-- TODO(0.18-ish): drop the crossing bullet above once 0.15-to-0.16 upgrade
-     traffic fades; release history lives in the blog posts. (2026-07-28) -->
+<!-- TODO(0.18-ish): drop the 0.15 crossing bullet above once 0.15-to-0.16
+     upgrade traffic fades; release history lives in the blog posts.
+     (2026-07-28) -->
 
 ## Order of steps {#update-order}
 
@@ -114,6 +119,7 @@ Also perform any release-specific checks listed in the release's
 
 <!-- prettier-ignore-start -->
 [Heading self-links]: /docs/content/navigation/#heading-self-links
+[Dart Sass]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass
 [hugo-extended]: /docs/get-started/other-options/#hugo-extended-npm
 [hugo-override]: https://gohugo.io/getting-started/directory-structure/#theme-skeleton
 [lookandfeel]: /docs/content/lookandfeel/#project-style-files

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -157,11 +157,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   [Install Dart Sass][]. Some Sass-computed colors in the built CSS change
   serialization form, with no visible rendering change ([#2724][]).
 
-<!-- TODO(#2727): once merged, link "semantic classes" below to the user
-  guide's consumer-contract section
-  (/docs/content/lookandfeel/#semantic-classes). -->
-
-- Changed breadcrumbs to emit Docsy semantic classes with state keyed on
+- Changed breadcrumbs to emit Docsy [semantic classes][] with state keyed on
   `aria-current="page"` instead of an `active` class. If you customized
   breadcrumbs, see the [selector migration table][] ([#2722][]).
 - Renamed the theme-dependencies install command that clone, submodule, and
@@ -215,6 +211,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [Install Dart Sass]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass
 [mermaid-version-notes]: /project/about/maintainer-notes/#mermaid-version
 [selector migration table]: /blog/2026/0.17.0/#selector-migration-table
+[semantic classes]: /docs/content/lookandfeel/#semantic-classes
 <!-- prettier-ignore-end -->
 
 ## v0.16.0 {#v0.16.0}

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -142,18 +142,27 @@ functionality, depending on scope. Prefer narrow, focused PRs where possible.
 
 </details>
 
-## v0.16.1 or v0.17.0 - UNRELEASED {#next}
+## v0.17.0 - UNRELEASED {#next}
 
 > **UNRELEASED: this planned version is still under development**
 
-For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
+For an introduction to this release, see the [0.17.0 release report][]. For the
+full list of changes, see the [0.17.0][] release page or the [git history since
+0.16.0][].
 
 [**Breaking changes**](#breaking-change):
 
-- Switched the theme's default Sass transpiler from Hugo's embedded LibSass
-  (deprecated) to Dart Sass; see [Install Dart Sass][]. Some Sass-computed
-  colors in the built CSS change serialization form, with rendering unchanged
-  ([#2724][]).
+- **[Dart Sass][0.17.0-blog-dart-sass]**: switched the theme's default Sass
+  transpiler from Hugo's embedded LibSass (deprecated) to Dart Sass; see
+  [Install Dart Sass][]. Some Sass-computed colors in the built CSS change
+  serialization form, with rendering unchanged ([#2724][]).
+
+<!-- TODO(#2727): once merged, link "semantic classes" below to
+  /project/implementation/semantic-classes/. -->
+
+- Changed breadcrumbs to emit Docsy semantic classes with state keyed on
+  `aria-current="page"` instead of an `active` class. If you customized
+  breadcrumbs, see the [selector migration table][] ([#2722][]).
 - Renamed the theme-dependencies install command that clone and submodule
   installs run from `themes/docsy`: `npm run postinstall` →
   `npm run install:theme-deps`. GitHub-npm installs (dev/testing only) must now
@@ -161,22 +170,14 @@ For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
   install hooks, so installs behave the same with or without `--ignore-scripts`
   ([#2712][]).
 
-**New**:
-
-- ...
-
 **Other changes**:
 
 - Fixed and documented footer copyright year handling. See the [footer copyright
   docs][] ([#2047][]).
-- Pinned the default Mermaid version to 11.16.1; pages previously loaded
-  whatever `latest` resolved to on the CDN at page load. Sites can still
-  override the version via [`params.mermaid.version`][mermaid-version]
-  ([#2703][]).
-
-[**Experimental**](#experimental):
-
-- ...
+- **[Pinned the default Mermaid version][0.17.0-blog-mermaid]** to 11.16.1;
+  pages previously loaded whatever `latest` resolved to on the CDN at page load.
+  Sites can still override the version via
+  [`params.mermaid.version`][mermaid-version] ([#2703][]).
 
 **For maintainers**:
 
@@ -190,6 +191,8 @@ For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
 - Inlined npm `pre*`/`post*` run-hooks into their parent scripts, so
   `check:links` still builds the site under user-level `ignore-scripts`
   ([#2726][]).
+- Switched stable `@docsy/theme` publishing to CI-based npm trusted publishing
+  (OIDC). See the [0.17.0 release report][0.17.0-blog-maintainers] ([#2708][]).
 - Moved the default Mermaid version to `theme/hugo.yaml`
   `params.mermaid.version`, guarded by the repo test suite (`test:repo`). See
   [Default Mermaid version][mermaid-version-notes].
@@ -198,16 +201,23 @@ For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
 [#2047]: https://github.com/google/docsy/issues/2047
 [#2700]: https://github.com/google/docsy/pull/2700
 [#2703]: https://github.com/google/docsy/issues/2703
+[#2708]: https://github.com/google/docsy/pull/2708
 [#2712]: https://github.com/google/docsy/pull/2712
+[#2722]: https://github.com/google/docsy/pull/2722
 [#2714]: https://github.com/google/docsy/pull/2714
 [#2724]: https://github.com/google/docsy/pull/2724
 [#2726]: https://github.com/google/docsy/pull/2726
-[0.16.1]: https://github.com/google/docsy/releases/latest?FIXME=v0.16.1
-[0.17.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.17.0
+[0.17.0 release report]: /blog/2026/0.17.0/
+[0.17.0-blog-dart-sass]: /blog/2026/0.17.0/#dart-sass
+[0.17.0-blog-maintainers]: /blog/2026/0.17.0/#for-maintainers
+[0.17.0-blog-mermaid]: /blog/2026/0.17.0/#mermaid
+[0.17.0]: https://github.com/google/docsy/releases/tag/v0.17.0
 [footer copyright docs]: /docs/content/lookandfeel/#footer-copyright
+[git history since 0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main
 [Install Dart Sass]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass
 [mermaid-version-notes]: /project/about/maintainer-notes/#mermaid-version
 [mermaid-version]: /docs/content/diagrams-and-formulae/#diagrams-with-mermaid
+[selector migration table]: /blog/2026/0.17.0/#selector-migration-table
 <!-- prettier-ignore-end -->
 
 ## v0.16.0 {#v0.16.0}

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -155,7 +155,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 - **[Dart Sass][0.17.0-blog-dart-sass]**: switched the theme's default Sass
   transpiler from Hugo's embedded LibSass (deprecated) to Dart Sass; see
   [Install Dart Sass][]. Some Sass-computed colors in the built CSS change
-  serialization form, with rendering unchanged ([#2724][]).
+  serialization form, with no visible rendering change ([#2724][]).
 
 <!-- TODO(#2727): once merged, link "semantic classes" below to the user
   guide's consumer-contract section
@@ -164,21 +164,17 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 - Changed breadcrumbs to emit Docsy semantic classes with state keyed on
   `aria-current="page"` instead of an `active` class. If you customized
   breadcrumbs, see the [selector migration table][] ([#2722][]).
-- Renamed the theme-dependencies install command that clone and submodule
-  installs run from `themes/docsy`: `npm run postinstall` →
-  `npm run install:theme-deps`. GitHub-npm installs (dev/testing only) must now
-  run it too, from `node_modules/docsy`. Docsy's packages no longer declare npm
-  install hooks, so installs behave the same with or without `--ignore-scripts`
-  ([#2712][]).
+- Renamed the theme-dependencies install command that clone, submodule, and
+  GitHub-npm installs run: `npm run postinstall` → `npm run install:theme-deps`;
+  Docsy's packages no longer declare npm install hooks. For per-mode actions,
+  see the [0.17.0 release report][0.17.0-blog-install] ([#2712][]).
 
 **Other changes**:
 
 - Fixed and documented footer copyright year handling. See the [footer copyright
   docs][] ([#2047][]).
 - **[Pinned the default Mermaid version][0.17.0-blog-mermaid]** to 11.16.1;
-  pages previously loaded whatever `latest` resolved to on the CDN at page load.
-  Sites can still override the version via
-  [`params.mermaid.version`][mermaid-version] ([#2703][]).
+  pages previously loaded the CDN's `latest` at page load ([#2703][]).
 
 **For maintainers**:
 
@@ -210,6 +206,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [#2726]: https://github.com/google/docsy/pull/2726
 [0.17.0 release report]: /blog/2026/0.17.0/
 [0.17.0-blog-dart-sass]: /blog/2026/0.17.0/#dart-sass
+[0.17.0-blog-install]: /blog/2026/0.17.0/#install-command
 [0.17.0-blog-maintainers]: /blog/2026/0.17.0/#for-maintainers
 [0.17.0-blog-mermaid]: /blog/2026/0.17.0/#mermaid
 [0.17.0]: https://github.com/google/docsy/releases/tag/v0.17.0
@@ -217,7 +214,6 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [git history since 0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main
 [Install Dart Sass]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass
 [mermaid-version-notes]: /project/about/maintainer-notes/#mermaid-version
-[mermaid-version]: /docs/content/diagrams-and-formulae/#diagrams-with-mermaid
 [selector migration table]: /blog/2026/0.17.0/#selector-migration-table
 <!-- prettier-ignore-end -->
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -157,8 +157,9 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   [Install Dart Sass][]. Some Sass-computed colors in the built CSS change
   serialization form, with rendering unchanged ([#2724][]).
 
-<!-- TODO(#2727): once merged, link "semantic classes" below to
-  /project/implementation/semantic-classes/. -->
+<!-- TODO(#2727): once merged, link "semantic classes" below to the user
+  guide's consumer-contract section
+  (/docs/content/lookandfeel/#semantic-classes). -->
 
 - Changed breadcrumbs to emit Docsy semantic classes with state keyed on
   `aria-current="page"` instead of an `active` class. If you customized

--- a/docsy.dev/lychee.toml
+++ b/docsy.dev/lychee.toml
@@ -39,4 +39,5 @@ exclude = [
   # this cycle (absent on v0.16.0 prod).
   '^https://github\.com/google/docsy/releases/(tag/)?v0\.17\.0$',
   '^https://www\.docsy\.dev/blog/2026/0\.17\.0/$',
+  '^https://main--docsydocs\.netlify\.app/blog/2026/0\.17\.0/$',
 ]

--- a/docsy.dev/lychee.toml
+++ b/docsy.dev/lychee.toml
@@ -34,4 +34,9 @@ exclude = [
   '^https://docsearch\.algolia\.com/',               # bot-wall (403) on the apply page
   '^https://prismjs\.com/download\.html#',           # download-builder state hash, not an anchor
   '^https://portal\.aws\.amazon\.com/',              # SPA signup flow, fragment is a client route
+
+  # Remove after 0.17.0 ships: the release tag and links to pages new/draft in
+  # this cycle (absent on v0.16.0 prod).
+  '^https://github\.com/google/docsy/releases/(tag/)?v0\.17\.0$',
+  '^https://www\.docsy\.dev/blog/2026/0\.17\.0/$',
 ]

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,6 +6,7 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
+- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy now builds with Dart Sass, so the sass CLI joins your build. This release also debuts semantic classes in breadcrumbs, pins the default Mermaid version, and renames the theme-dependencies install command.
 - [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Docsy is now on npm as @docsy/theme. This release also moves the theme into theme/, raises the Hugo minimum, and drops its default favicons in favor of discovery, each with upgrade actions.
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/): What changed in Hugo 0.158.0 through 0.164.x for Docsy sites: breaking changes, deprecations, security fixes, and known regressions, with per-version upgrade actions.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.


### PR DESCRIPTION
- Contributes to #2691
- **Release post** (`draft: true`; publishes at the tag-time undraft): the dart-sass swap, breadcrumb semantic classes (selector table incl. the #2730 rename), the install-command rename, and the Mermaid pin -- per-mode actions, upgrade checklist, sanity checks. No Hugo companion post this cycle (no Hugo change since v0.16.0).
- **Changelog `#next`**: adds the breadcrumb breaking entry and the trusted-publishing maintainers line; weaves release-report and semantic-classes docs links; drops the 0.16.1 placeholders.
- **Update docs**: a 0.16-or-earlier crossing bullet routes upgraders to the post's Dart Sass actions (existing house pattern).
- **One hold remains** (TODO-marked in place): the warnings-expected clause lands via a follow-up PR once the Sass own-warnings PR ships.
- **Reviewed**: two adversarial rounds (grok-4.5, gpt-5.6-sol) plus DRY/one-home and copyedit passes; all confirmed findings applied.
- **Coverage**: all 24 commits in `v0.16.0..765eb62d` are routed -- 4 breaking (post sections + changelog entries), 2 user-facing changes, 6 maintainer-facing (For-maintainers summaries), 12 internal (release-notes/milestone only).
- **Lychee**: draft-cycle excludes per the 0.16 pattern ("Remove after 0.17.0 ships").
- **Preview(s)**:
  - [Release 0.17.0 report](https://deploy-preview-2728--docsydocs.netlify.app/blog/2026/0.17.0/)
  - [Changelog](https://deploy-preview-2728--docsydocs.netlify.app/project/about/changelog/)
