### PR TITLE
Breadcrumb: rename td-breadcrumbs__single to the variant form --single

### DIFF
--- a/docsy.dev/content/en/docs/content/navigation.md
+++ b/docsy.dev/content/en/docs/content/navigation.md
@@ -673,7 +673,7 @@ To also display single-element breadcrumb lists in index pages, add the
 following [style override][] to your project:
 
 ```scss
-.td-breadcrumbs__single {
+.td-breadcrumbs--single {
   display: inline !important;
 }
 ```

--- a/tests/fixture-site/goldens/breadcrumb-single.html
+++ b/tests/fixture-site/goldens/breadcrumb-single.html
@@ -1,4 +1,4 @@
-<nav aria-label="breadcrumb" class="td-breadcrumbs td-breadcrumbs__single">
+<nav aria-label="breadcrumb" class="td-breadcrumbs td-breadcrumbs--single">
   <ol class="td-breadcrumbs__list">
   <li class="td-breadcrumbs__item" aria-current="page">
     Docs</li>

--- a/theme/assets/scss/td/_breadcrumb.scss
+++ b/theme/assets/scss/td/_breadcrumb.scss
@@ -5,7 +5,7 @@
     display: none;
   }
 
-  &__single {
+  &--single {
     display: none;
   }
 

--- a/theme/layouts/_partials/breadcrumb.html
+++ b/theme/layouts/_partials/breadcrumb.html
@@ -3,7 +3,7 @@
   {{ $isSingle = .IsHome -}}
 {{ end -}}
 <nav aria-label="breadcrumb" class="td-breadcrumbs
-    {{- if $isSingle }} td-breadcrumbs__single {{- end }}">
+    {{- if $isSingle }} td-breadcrumbs--single {{- end }}">
   <ol class="td-breadcrumbs__list">
     {{- template "breadcrumbnav" (dict "p1" . "p2" .) }}
   </ol>


### PR DESCRIPTION
- **Renames `td-breadcrumbs__single` → `td-breadcrumbs--single`**: a variant wearing element syntax (predates the convention, 2021); rides 0.17's already-breaking breadcrumb selector changes so the rename never needs its own breaking release
- **Consumer surface**: the class is the documented re-enable hook in the navigation docs (updated here); the 0.17 upgrade post's selector table carries the old → new row
- **Validation**: markup golden refreshed red-first (exactly the one-line class change); visual goldens unchanged (the variant only hides the component)
