### PR TITLE
SCSS: replace deprecated Sass functions with sass: module forms

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -337,6 +337,7 @@ https://github.com/google/docsy/issues/2683,200,1785081670
 https://github.com/google/docsy/issues/2689,200,1785081670
 https://github.com/google/docsy/issues/2691,200,1785178993
 https://github.com/google/docsy/issues/2703,200,1786216878
+https://github.com/google/docsy/issues/2732,200,1787323021
 https://github.com/google/docsy/issues/331,200,1782498237
 https://github.com/google/docsy/issues/349,200,1782498234
 https://github.com/google/docsy/issues/375,200,1782498235

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -172,11 +172,12 @@ commit it.
 
 ### Sass deprecation warnings
 
-Hugo builds silence all dependency deprecation warnings -- Docsy's tree,
-vendored Bootstrap and Font Awesome, and a site's own project Sass alike
-(`theme/layouts/_partials/head-css.html`; under Hugo's importer, only the entry
-stub is first-party) -- so a quiet build log does not mean the sources are
-deprecation-clean. Two probes guard Docsy's theme sources:
+Hugo builds silence all dependency deprecation warnings
+(`theme/layouts/_partials/head-css.html`), and under Hugo's importer everything
+but the entry stub is a dependency: Docsy's tree, vendored Bootstrap and Font
+Awesome, and a site's own project Sass are all silenced. A quiet build log
+therefore does not mean the sources are deprecation-clean. Two probes guard
+Docsy's theme sources:
 
 - `docsy.dev/tests/hugo-build/no-deprecations.test.mjs`: the real site build
   stays free of deprecation notices (Hugo API deprecations, and any deprecation

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -177,8 +177,8 @@ included (`theme/layouts/_partials/head-css.html`), so a quiet build log does
 not mean the sources are deprecation-clean. Two probes split the guard:
 
 - `docsy.dev/tests/hugo-build/no-deprecations.test.mjs`: the real site build
-  stays free of deprecation notices (Hugo API deprecations, and anything that
-  escapes the silencing).
+  stays free of deprecation notices (Hugo API deprecations, and any deprecation
+  warning that escapes the silencing).
 - `tests/sass-deprecations.test.mjs`: Docsy's own Sass stays clean, via a direct
   dart-sass compile that build-level silencing can't blind. Import-class
   warnings are tolerated until the `@use` refactor ([#2732][]).

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -172,9 +172,11 @@ commit it.
 
 ### Sass deprecation warnings
 
-Hugo builds silence all dependency deprecation warnings, Docsy's own tree
-included (`theme/layouts/_partials/head-css.html`), so a quiet build log does
-not mean the sources are deprecation-clean. Two probes split the guard:
+Hugo builds silence all dependency deprecation warnings -- Docsy's tree,
+vendored Bootstrap and Font Awesome, and a site's own project Sass alike
+(`theme/layouts/_partials/head-css.html`; under Hugo's importer, only the entry
+stub is first-party) -- so a quiet build log does not mean the sources are
+deprecation-clean. Two probes guard Docsy's theme sources:
 
 - `docsy.dev/tests/hugo-build/no-deprecations.test.mjs`: the real site build
   stays free of deprecation notices (Hugo API deprecations, and any deprecation

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -170,6 +170,19 @@ files. When a golden test reports intended drift, run `npm run update:goldens`
 to rebuild the site and refresh both suites' goldens, then review the diff and
 commit it.
 
+### Sass deprecation warnings
+
+Hugo builds silence all dependency deprecation warnings, Docsy's own tree
+included (`theme/layouts/_partials/head-css.html`), so a quiet build log does
+not mean the sources are deprecation-clean. Two probes split the guard:
+
+- `docsy.dev/tests/hugo-build/no-deprecations.test.mjs`: the real site build
+  stays free of deprecation notices (Hugo API deprecations, and anything that
+  escapes the silencing).
+- `tests/sass-deprecations.test.mjs`: Docsy's own Sass stays clean, via a direct
+  dart-sass compile that build-level silencing can't blind. Import-class
+  warnings are tolerated until the `@use` refactor ([#2732][]).
+
 ## Link checking and the refcache
 
 `test:website` checks docsy.dev's links with Lychee, caching external-link
@@ -774,6 +787,7 @@ To test a Docsy branch or release from a consumer site, for each site:
   help for usage.
 
 <!-- prettier-ignore-start -->
+[#2732]: <{{% param github_repo %}}/issues/2732>
 [breaking change]: /project/about/changelog/#breaking-change
 [changelog]: /project/about/changelog/
 [contributing]: /docs/contributing/

--- a/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
+++ b/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
@@ -16,8 +16,8 @@ function buildSite() {
   const destDir = mkdtempSync(join(tmpDir, 'no-deprecations-'));
   try {
     // The trailing --logLevel info makes today's script chain run Hugo at
-    // info (last flag wins); the INFO-records assertion below proves the
-    // executed process really did, so a chain change that swallows the flag
+    // info (last flag wins); the Hugo-INFO-records assertion below proves the
+    // executed Hugo really did, so a chain change that swallows the flag
     // fails red instead of silently muting deprecations. The probe does not
     // depend on (or enforce) the _hugo script's own level.
     const res = spawnSync(
@@ -28,7 +28,7 @@ function buildSite() {
         encoding: 'utf8',
       },
     );
-    const output = `${res.stdout ?? ''}${res.stderr ?? ''}`;
+    const output = `${res.stdout ?? ''}\n${res.stderr ?? ''}`;
     // Catches Hugo API deprecations and any deprecation warning that escapes
     // the theme's silencing, e.g. through a config regression (guard split:
     // see maintainer notes, "Sass deprecation warnings"). Non-deprecation
@@ -46,8 +46,8 @@ test('site build logs no deprecation notices', (t) => {
   const { res, output, deprecations } = buildSite();
   assert.equal(res.status, 0, `site build exits 0; output:\n${output}`);
   assert.ok(
-    /^INFO /m.test(output),
-    'the executed Hugo ran at info level (INFO records present)',
+    /^INFO {2}(build|static):/m.test(output),
+    'the executed Hugo ran at info level (Hugo INFO records present)',
   );
   assert.deepEqual(
     deprecations,

--- a/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
+++ b/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
@@ -15,9 +15,11 @@ function buildSite() {
   mkdirSync(tmpDir, { recursive: true });
   const destDir = mkdtempSync(join(tmpDir, 'no-deprecations-'));
   try {
-    // The trailing --logLevel info pins the effective level (Hugo's last
-    // flag wins): `info` is where Hugo first reports deprecated API usage,
-    // and no upstream script change can silently lower it under this probe.
+    // The trailing --logLevel info makes today's script chain run Hugo at
+    // info (last flag wins); the INFO-records assertion below proves the
+    // executed process really did, so a chain change that swallows the flag
+    // fails red instead of silently muting deprecations. The probe does not
+    // depend on (or enforce) the _hugo script's own level.
     const res = spawnSync(
       'npm run build -- -d ' + destDir + ' --logLevel info',
       {
@@ -43,6 +45,10 @@ function buildSite() {
 test('site build logs no deprecation notices', (t) => {
   const { res, output, deprecations } = buildSite();
   assert.equal(res.status, 0, `site build exits 0; output:\n${output}`);
+  assert.ok(
+    /^INFO /m.test(output),
+    'the executed Hugo ran at info level (INFO records present)',
+  );
   assert.deepEqual(
     deprecations,
     [],

--- a/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
+++ b/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
@@ -22,11 +22,9 @@ function buildSite() {
     });
     const output = `${res.stdout ?? ''}${res.stderr ?? ''}`;
     // Catches Hugo API deprecations and any Dart Sass warning that escapes
-    // the theme's silencing (head-css.html silences dependency deprecations;
-    // Docsy-origin regressions are guarded by the repo-root
-    // tests/sass-deprecations.test.mjs). An escape here -- a config
-    // regression, or a vendor @warn, which silencing never covers -- fails
-    // red instead of being filtered.
+    // the theme's silencing (head-css.html): a config regression, or a vendor
+    // @warn, fails red instead of being filtered. Docsy-origin regressions
+    // are guarded by the repo-root tests/sass-deprecations.test.mjs.
     const deprecations = output
       .split('\n')
       .filter((line) => /deprecated/i.test(line));

--- a/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
+++ b/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
@@ -22,9 +22,9 @@ function buildSite() {
     });
     const output = `${res.stdout ?? ''}${res.stderr ?? ''}`;
     // Catches Hugo API deprecations and any Dart Sass warning that escapes
-    // the theme's silencing (head-css.html): a config regression, or a vendor
-    // @warn, fails red instead of being filtered. Docsy-origin regressions
-    // are guarded by the repo-root tests/sass-deprecations.test.mjs.
+    // the theme's silencing: a config regression, or a vendor @warn, fails
+    // red instead of being filtered (guard split: see maintainer notes,
+    // "Sass deprecation warnings").
     const deprecations = output
       .split('\n')
       .filter((line) => /deprecated/i.test(line));

--- a/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
+++ b/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
@@ -21,17 +21,15 @@ function buildSite() {
       encoding: 'utf8',
     });
     const output = `${res.stdout ?? ''}${res.stderr ?? ''}`;
+    // Catches Hugo API deprecations and any Dart Sass warning that escapes
+    // the theme's silencing (head-css.html silences dependency deprecations;
+    // Docsy-origin regressions are guarded by the repo-root
+    // tests/sass-deprecations.test.mjs). An escape here -- a config
+    // regression, or a vendor @warn, which silencing never covers -- fails
+    // red instead of being filtered.
     const deprecations = output
       .split('\n')
-      .filter((line) => /deprecated/i.test(line))
-      // Dart Sass language deprecations are handled at the theme layer:
-      // head-css.html silences the known vendor-owned classes plus Docsy's
-      // import-class (gated on docsy#2279), and the repo-root
-      // tests/sass-deprecations.test.mjs keeps Docsy-origin regressions red.
-      // This probe guards Hugo API deprecations only. The exclusion keys on
-      // Hugo's `Dart Sass:` line prefix; a prefix change fails this gate
-      // red rather than widening it silently.
-      .filter((line) => !/Dart Sass/.test(line));
+      .filter((line) => /deprecated/i.test(line));
     return { res, output, deprecations };
   } finally {
     rmSync(destDir, { recursive: true, force: true });

--- a/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
+++ b/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -15,16 +15,22 @@ function buildSite() {
   mkdirSync(tmpDir, { recursive: true });
   const destDir = mkdtempSync(join(tmpDir, 'no-deprecations-'));
   try {
-    const res = spawnSync('npm run build -- -d ' + destDir, {
-      cwd: siteDir,
-      shell: true,
-      encoding: 'utf8',
-    });
+    // The trailing --logLevel info pins the effective level (Hugo's last
+    // flag wins): `info` is where Hugo first reports deprecated API usage,
+    // and no upstream script change can silently lower it under this probe.
+    const res = spawnSync(
+      'npm run build -- -d ' + destDir + ' --logLevel info',
+      {
+        cwd: siteDir,
+        shell: true,
+        encoding: 'utf8',
+      },
+    );
     const output = `${res.stdout ?? ''}${res.stderr ?? ''}`;
-    // Catches Hugo API deprecations and any Dart Sass warning that escapes
-    // the theme's silencing: a config regression, or a vendor @warn, fails
-    // red instead of being filtered (guard split: see maintainer notes,
-    // "Sass deprecation warnings").
+    // Catches Hugo API deprecations and any deprecation warning that escapes
+    // the theme's silencing, e.g. through a config regression (guard split:
+    // see maintainer notes, "Sass deprecation warnings"). Non-deprecation
+    // vendor @warn messages pass: they are log noise, not a regression.
     const deprecations = output
       .split('\n')
       .filter((line) => /deprecated/i.test(line));
@@ -34,9 +40,7 @@ function buildSite() {
   }
 }
 
-test('site build logs no Hugo deprecation notices', (t) => {
-  // The `_hugo` script builds with `--logLevel info`, the level at which
-  // Hugo first reports deprecated API usage.
+test('site build logs no deprecation notices', (t) => {
   const { res, output, deprecations } = buildSite();
   assert.equal(res.status, 0, `site build exits 0; output:\n${output}`);
   assert.deepEqual(
@@ -45,23 +49,4 @@ test('site build logs no Hugo deprecation notices', (t) => {
     'build log is free of deprecation notices',
   );
   t.diagnostic(`Scanned ${output.split('\n').length} build-log lines`);
-});
-
-// The check above can only catch deprecations if the build runs at a log level
-// where Hugo surfaces them (`info` or more verbose). Rather than re-derive that
-// with a second build that seeds a deprecated API call -- which would have to
-// mutate tracked source -- assert the invariant statically against the `_hugo`
-// script. If someone raises the level (e.g. to `warn`), this fails fast.
-test('the site build runs at a log level that surfaces deprecations', () => {
-  const pkg = JSON.parse(
-    readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
-  );
-  const hugoScript = pkg.scripts?._hugo ?? '';
-  const match = hugoScript.match(/--logLevel\s+(\w+)/);
-  assert.ok(match, `_hugo script has no --logLevel flag: ${hugoScript}`);
-  assert.ok(
-    ['info', 'debug'].includes(match[1]),
-    `_hugo --logLevel ${match[1]} is too quiet to surface Hugo deprecation ` +
-      'notices; use info (or more verbose)',
-  );
 });

--- a/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
+++ b/docsy.dev/tests/hugo-build/no-deprecations.test.mjs
@@ -24,9 +24,11 @@ function buildSite() {
     const deprecations = output
       .split('\n')
       .filter((line) => /deprecated/i.test(line))
-      // Dart Sass language deprecations (Bootstrap's and Docsy's Sass) are
-      // deliberately left visible as fix-me reminders (docsy#2724); this
-      // probe guards Hugo API deprecations only. The exclusion keys on
+      // Dart Sass language deprecations are handled at the theme layer:
+      // head-css.html silences the known vendor-owned classes plus Docsy's
+      // import-class (gated on docsy#2279), and the repo-root
+      // tests/sass-deprecations.test.mjs keeps Docsy-origin regressions red.
+      // This probe guards Hugo API deprecations only. The exclusion keys on
       // Hugo's `Dart Sass:` line prefix; a prefix change fails this gate
       // red rather than widening it silently.
       .filter((line) => !/Dart Sass/.test(line));

--- a/tests/sass-deprecations.test.mjs
+++ b/tests/sass-deprecations.test.mjs
@@ -2,7 +2,10 @@
 // deprecation warnings beyond the tolerated import class. Hugo builds
 // silence these warnings (see maintainer notes, "Sass deprecation
 // warnings"), so the probe compiles the theme directly with the pinned
-// dart-sass, verbose so warning dedup can't hide occurrences.
+// dart-sass, verbose so warning dedup can't hide occurrences. Loading a
+// file does not evaluate its conditional branches, so the probe compiles
+// the fixture matrix below and aggregates: a deprecation hidden behind
+// either polarity of a supported Boolean flag stays red.
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -28,9 +31,9 @@ const vendors = {
 };
 
 // Compile a copy of the theme tree laid out as Hugo mounts it (scss/ and
-// vendor/ as siblings), with project stubs that pull in the opt-in surface
-// so warnings from opt-in partials are caught too.
-function compileTheme() {
+// vendor/ as siblings). `stubs`, when given, overwrites the project stub
+// files; null keeps the repo's stock (comment-only) stubs.
+function compileTheme(stubs) {
   const tmpBase = path.join(repoRoot, 'tmp');
   fs.mkdirSync(tmpBase, { recursive: true });
   const dir = fs.realpathSync(
@@ -45,21 +48,16 @@ function compileTheme() {
       // other platforms.
       fs.symlinkSync(target, path.join(dir, 'vendor', name), 'junction');
     }
-    fs.writeFileSync(
-      path.join(scssDir, '_variables_project.scss'),
-      '$td-enable-google-fonts: true;\n$enable-dark-mode: true;\n',
-    );
-    fs.writeFileSync(
-      path.join(scssDir, '_styles_project.scss'),
-      [
-        "@import 'td/extra/index';",
-        "@import 'td/extra/bs-defaults';",
-        "@import 'td/color-adjustments-dark';",
-        "@import 'td/code-dark';",
-        "@import 'td/gcs-search-dark';",
-        '',
-      ].join('\n'),
-    );
+    if (stubs) {
+      fs.writeFileSync(
+        path.join(scssDir, '_variables_project.scss'),
+        stubs.variables,
+      );
+      fs.writeFileSync(
+        path.join(scssDir, '_styles_project.scss'),
+        stubs.styles,
+      );
+    }
 
     const warnings = [];
     const result = compile(path.join(scssDir, 'main.scss'), {
@@ -86,36 +84,66 @@ function compileTheme() {
   }
 }
 
+// Fixture matrix: both polarities of each supported Boolean flag
+// ($td-enable-google-fonts defaults false, Bootstrap's $enable-dark-mode
+// defaults true), plus the full opt-in import surface on `maximal` so every
+// partial compiles somewhere.
+const fixtures = {
+  default: null,
+  minimal: { variables: '$enable-dark-mode: false;\n', styles: '' },
+  maximal: {
+    variables: '$td-enable-google-fonts: true;\n$enable-dark-mode: true;\n',
+    styles: [
+      "@import 'td/extra/index';",
+      "@import 'td/extra/bs-defaults';",
+      "@import 'td/color-adjustments-dark';",
+      "@import 'td/code-dark';",
+      "@import 'td/gcs-search-dark';",
+      '',
+    ].join('\n'),
+  },
+};
+
 test('Docsy Sass sources emit no non-import deprecation warnings', (t) => {
-  const { warnings, loadedCount, unreached, scssDir } = compileTheme();
-  const scssUrl = pathToFileURL(scssDir + path.sep).href;
-  const docsy = warnings.filter(
-    (w) => w.deprecation && w.url?.startsWith(scssUrl),
-  );
+  const offending = [];
+  let tdImportSeen = false;
+  for (const [name, stubs] of Object.entries(fixtures)) {
+    const { warnings, loadedCount, unreached, scssDir } = compileTheme(stubs);
+    const scssUrl = pathToFileURL(scssDir + path.sep).href;
+    // Shipped-source scope: td/ only, so the synthetic stubs' own @import
+    // warnings can't satisfy the canary below or pollute attribution.
+    const tdUrl = scssUrl + 'td/';
+    for (const w of warnings) {
+      if (!w.deprecation || !w.url?.startsWith(tdUrl)) continue;
+      if (w.id === 'import') tdImportSeen = true;
+      else offending.push({ fixture: name, id: w.id, url: w.url });
+    }
+    if (name === 'maximal') {
+      // Sanity: this fixture's opt-in stubs compile the whole Docsy tree, so
+      // no partial escapes the guard.
+      assert.deepEqual(
+        unreached,
+        [],
+        'every theme Sass partial is loaded by the maximal fixture',
+      );
+    }
+    t.diagnostic(
+      `${name}: ${warnings.length} warnings, ${loadedCount} loaded files`,
+    );
+  }
 
   // Sanity: origin attribution provably works (Docsy's own import-class
-  // warnings exist). When the @use refactor (docsy#2732) zeroes the import
-  // class, this goes red: tighten the probe to "no Docsy warnings at all".
+  // warnings exist in td/). When the @use refactor (docsy#2732) zeroes the
+  // import class, this goes red: tighten the probe to "no Docsy warnings at
+  // all".
   assert.ok(
-    docsy.some((w) => w.id === 'import'),
+    tdImportSeen,
     'warning attribution resolves Docsy-origin (import-class) warnings',
   );
 
-  const offending = docsy.filter((w) => w.id !== 'import');
   assert.deepEqual(
     offending,
     [],
     'Docsy Sass sources are free of non-import deprecation warnings',
-  );
-
-  // Sanity: the probe's opt-in stubs compile the whole Docsy tree, so no
-  // partial escapes the guard.
-  assert.deepEqual(
-    unreached,
-    [],
-    'every theme Sass partial is loaded by the probe compile',
-  );
-  t.diagnostic(
-    `Scanned ${warnings.length} warnings across ${loadedCount} loaded files`,
   );
 });

--- a/tests/sass-deprecations.test.mjs
+++ b/tests/sass-deprecations.test.mjs
@@ -1,9 +1,8 @@
 // Guards the docsy#2731 outcome: Docsy's own Sass sources emit no
-// deprecation warnings other than import-class ones (which stay until the
-// @use refactor, docsy#2732). Hugo builds silence all dependency
-// deprecations (see head-css.html), so a Docsy-origin regression would
-// otherwise be invisible; this probe compiles the theme directly with the
-// pinned dart-sass, verbose so warning dedup can't hide occurrences.
+// deprecation warnings beyond the tolerated import class. Hugo builds
+// silence these warnings (see maintainer notes, "Sass deprecation
+// warnings"), so the probe compiles the theme directly with the pinned
+// dart-sass, verbose so warning dedup can't hide occurrences.
 
 import test from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/sass-deprecations.test.mjs
+++ b/tests/sass-deprecations.test.mjs
@@ -1,10 +1,11 @@
 // Guards the docsy#2731 outcome: Docsy's own Sass sources emit no
 // deprecation warnings other than import-class ones (which stay until the
-// @use refactor; gated on Bootstrap shipping a Sass module system). Hugo
-// builds silence all dependency deprecations (see head-css.html), so a
-// Docsy-origin regression would otherwise be invisible; this probe compiles
-// the theme directly with the pinned dart-sass, verbose so warning dedup
-// can't hide occurrences, and attributes every warning to its source file.
+// @use refactor, docsy#2732; gated on Bootstrap shipping a Sass module
+// system). Hugo builds silence all dependency deprecations (see
+// head-css.html), so a Docsy-origin regression would otherwise be invisible;
+// this probe compiles the theme directly with the pinned dart-sass, verbose
+// so warning dedup can't hide occurrences, and attributes every warning to
+// its source file.
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -102,8 +103,8 @@ test('Docsy Sass sources emit no non-import deprecation warnings', (t) => {
 
   // Sanity: the verbose compile surfaces warnings (vendor deprecations exist),
   // and origin attribution works (Docsy's own import-class warnings exist).
-  // When the @use refactor zeroes the import class, the second assertion goes
-  // red: tighten this probe to "no Docsy warnings at all".
+  // When the @use refactor (docsy#2732) zeroes the import class, the second
+  // assertion goes red: tighten this probe to "no Docsy warnings at all".
   assert.ok(warnings.length > 0, 'verbose compile captures warnings');
   assert.ok(
     docsy.some((w) => w.id === 'import'),

--- a/tests/sass-deprecations.test.mjs
+++ b/tests/sass-deprecations.test.mjs
@@ -1,10 +1,10 @@
 // Guards the docsy#2731 outcome: Docsy's own Sass sources emit no
 // deprecation warnings other than import-class ones (which stay until the
-// @use refactor, docsy#2279). Hugo builds silence the known deprecation
-// classes (see head-css.html), so a Docsy-origin regression would otherwise
-// be invisible; this probe compiles the theme directly with the pinned
-// dart-sass, verbose so warning dedup can't hide occurrences, and attributes
-// every warning to its source file.
+// @use refactor; gated on Bootstrap shipping a Sass module system). Hugo
+// builds silence all dependency deprecations (see head-css.html), so a
+// Docsy-origin regression would otherwise be invisible; this probe compiles
+// the theme directly with the pinned dart-sass, verbose so warning dedup
+// can't hide occurrences, and attributes every warning to its source file.
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -102,8 +102,8 @@ test('Docsy Sass sources emit no non-import deprecation warnings', (t) => {
 
   // Sanity: the verbose compile surfaces warnings (vendor deprecations exist),
   // and origin attribution works (Docsy's own import-class warnings exist).
-  // When the @use refactor (docsy#2279) zeroes the import class, the second
-  // assertion goes red: tighten this probe to "no Docsy warnings at all".
+  // When the @use refactor zeroes the import class, the second assertion goes
+  // red: tighten this probe to "no Docsy warnings at all".
   assert.ok(warnings.length > 0, 'verbose compile captures warnings');
   assert.ok(
     docsy.some((w) => w.id === 'import'),

--- a/tests/sass-deprecations.test.mjs
+++ b/tests/sass-deprecations.test.mjs
@@ -1,0 +1,130 @@
+// Guards the docsy#2731 outcome: Docsy's own Sass sources emit no
+// deprecation warnings other than import-class ones (which stay until the
+// @use refactor, docsy#2279). Hugo builds silence the known deprecation
+// classes (see head-css.html), so a Docsy-origin regression would otherwise
+// be invisible; this probe compiles the theme directly with the pinned
+// dart-sass, verbose so warning dedup can't hide occurrences, and attributes
+// every warning to its source file.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { compile } from 'sass-embedded';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const themeScss = path.join(repoRoot, 'theme', 'assets', 'scss');
+const vendors = {
+  bootstrap: path.join(repoRoot, 'theme', 'node_modules', 'bootstrap'),
+  'Font-Awesome': path.join(
+    repoRoot,
+    'theme',
+    'node_modules',
+    '@fortawesome',
+    'fontawesome-free',
+  ),
+};
+
+// Compile a copy of the theme tree laid out as Hugo mounts it (scss/ and
+// vendor/ as siblings), with project stubs that pull in the opt-in surface
+// (extras, dark mode, Google fonts) so warnings from opt-in partials are
+// caught too.
+function compileTheme() {
+  const tmpBase = path.join(repoRoot, 'tmp');
+  fs.mkdirSync(tmpBase, { recursive: true });
+  const dir = fs.realpathSync(
+    fs.mkdtempSync(path.join(tmpBase, 'sass-deprecations-')),
+  );
+  try {
+    const scssDir = path.join(dir, 'scss');
+    fs.cpSync(themeScss, scssDir, { recursive: true });
+    fs.mkdirSync(path.join(dir, 'vendor'));
+    for (const [name, target] of Object.entries(vendors)) {
+      assert.ok(
+        fs.existsSync(target),
+        `theme dependency ${name} is installed (run npm install)`,
+      );
+      // Junction type: works without privileges on Windows CI; ignored on
+      // other platforms.
+      fs.symlinkSync(target, path.join(dir, 'vendor', name), 'junction');
+    }
+    fs.writeFileSync(
+      path.join(scssDir, '_variables_project.scss'),
+      '$td-enable-google-fonts: true;\n$enable-dark-mode: true;\n',
+    );
+    fs.writeFileSync(
+      path.join(scssDir, '_styles_project.scss'),
+      [
+        "@import 'td/extra/index';",
+        "@import 'td/extra/bs-defaults';",
+        "@import 'td/color-adjustments-dark';",
+        "@import 'td/code-dark';",
+        "@import 'td/gcs-search-dark';",
+        '',
+      ].join('\n'),
+    );
+
+    const warnings = [];
+    const result = compile(path.join(scssDir, 'main.scss'), {
+      verbose: true,
+      logger: {
+        warn(_message, opts) {
+          warnings.push({
+            deprecation: opts.deprecation,
+            id: opts.deprecationType?.id ?? null,
+            url: opts.span?.url?.href ?? null,
+          });
+        },
+      },
+    });
+    const loaded = new Set(result.loadedUrls.map((u) => u.href));
+    const unreached = fs
+      .readdirSync(path.join(scssDir, 'td'), { recursive: true })
+      .filter((f) => f.endsWith('.scss'))
+      .map((f) => pathToFileURL(path.join(scssDir, 'td', f)).href)
+      .filter((u) => !loaded.has(u));
+    return { warnings, loadedCount: loaded.size, unreached, scssDir };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('Docsy Sass sources emit no non-import deprecation warnings', (t) => {
+  const { warnings, loadedCount, unreached, scssDir } = compileTheme();
+  const scssUrl = pathToFileURL(scssDir + path.sep).href;
+  const docsy = warnings.filter(
+    (w) => w.deprecation && w.url?.startsWith(scssUrl),
+  );
+
+  // Sanity: the verbose compile surfaces warnings (vendor deprecations exist),
+  // and origin attribution works (Docsy's own import-class warnings exist).
+  // When the @use refactor (docsy#2279) zeroes the import class, the second
+  // assertion goes red: tighten this probe to "no Docsy warnings at all".
+  assert.ok(warnings.length > 0, 'verbose compile captures warnings');
+  assert.ok(
+    docsy.some((w) => w.id === 'import'),
+    'warning attribution resolves Docsy-origin (import-class) warnings',
+  );
+
+  const offending = docsy.filter((w) => w.id !== 'import');
+  assert.deepEqual(
+    offending,
+    [],
+    'Docsy Sass sources are free of non-import deprecation warnings',
+  );
+
+  // Sanity: the probe's opt-in stubs compile the whole Docsy tree, so no
+  // partial escapes the guard.
+  assert.deepEqual(
+    unreached,
+    [],
+    'every theme Sass partial is loaded by the probe compile',
+  );
+  t.diagnostic(
+    `Scanned ${warnings.length} warnings across ${loadedCount} loaded files`,
+  );
+});

--- a/tests/sass-deprecations.test.mjs
+++ b/tests/sass-deprecations.test.mjs
@@ -105,6 +105,9 @@ const fixtures = {
       "@import 'td/color-adjustments-dark';",
       "@import 'td/code-dark';",
       "@import 'td/gcs-search-dark';",
+      // Exercises the one mixin branch no in-tree call reaches
+      // (link-variant's $underline defaults false everywhere).
+      "@include link-variant('.td-probe-underline', $red, $blue, true);",
       '',
     ].join('\n'),
   },

--- a/tests/sass-deprecations.test.mjs
+++ b/tests/sass-deprecations.test.mjs
@@ -1,11 +1,9 @@
 // Guards the docsy#2731 outcome: Docsy's own Sass sources emit no
 // deprecation warnings other than import-class ones (which stay until the
-// @use refactor, docsy#2732; gated on Bootstrap shipping a Sass module
-// system). Hugo builds silence all dependency deprecations (see
-// head-css.html), so a Docsy-origin regression would otherwise be invisible;
-// this probe compiles the theme directly with the pinned dart-sass, verbose
-// so warning dedup can't hide occurrences, and attributes every warning to
-// its source file.
+// @use refactor, docsy#2732). Hugo builds silence all dependency
+// deprecations (see head-css.html), so a Docsy-origin regression would
+// otherwise be invisible; this probe compiles the theme directly with the
+// pinned dart-sass, verbose so warning dedup can't hide occurrences.
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -32,8 +30,7 @@ const vendors = {
 
 // Compile a copy of the theme tree laid out as Hugo mounts it (scss/ and
 // vendor/ as siblings), with project stubs that pull in the opt-in surface
-// (extras, dark mode, Google fonts) so warnings from opt-in partials are
-// caught too.
+// so warnings from opt-in partials are caught too.
 function compileTheme() {
   const tmpBase = path.join(repoRoot, 'tmp');
   fs.mkdirSync(tmpBase, { recursive: true });

--- a/tests/sass-deprecations.test.mjs
+++ b/tests/sass-deprecations.test.mjs
@@ -4,8 +4,9 @@
 // warnings"), so the probe compiles the theme directly with the pinned
 // dart-sass, verbose so warning dedup can't hide occurrences. Loading a
 // file does not evaluate its conditional branches, so the probe compiles
-// the fixture matrix below and aggregates: a deprecation hidden behind
-// either polarity of a supported Boolean flag stays red.
+// every combination of the supported Boolean flags (the explicit fixture
+// matrix below -- the guarantee covers these configurations, not arbitrary
+// conditional shapes).
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -48,15 +49,16 @@ function compileTheme(stubs) {
       // other platforms.
       fs.symlinkSync(target, path.join(dir, 'vendor', name), 'junction');
     }
+    const stubUrls = new Set();
     if (stubs) {
-      fs.writeFileSync(
-        path.join(scssDir, '_variables_project.scss'),
-        stubs.variables,
-      );
-      fs.writeFileSync(
-        path.join(scssDir, '_styles_project.scss'),
-        stubs.styles,
-      );
+      for (const [file, content] of [
+        ['_variables_project.scss', stubs.variables],
+        ['_styles_project.scss', stubs.styles],
+      ]) {
+        const stubPath = path.join(scssDir, file);
+        fs.writeFileSync(stubPath, content);
+        stubUrls.add(pathToFileURL(stubPath).href);
+      }
     }
 
     const warnings = [];
@@ -78,19 +80,23 @@ function compileTheme(stubs) {
       .filter((f) => f.endsWith('.scss'))
       .map((f) => pathToFileURL(path.join(scssDir, 'td', f)).href)
       .filter((u) => !loaded.has(u));
-    return { warnings, loadedCount: loaded.size, unreached, scssDir };
+    return { warnings, loadedCount: loaded.size, unreached, scssDir, stubUrls };
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 }
 
-// Fixture matrix: both polarities of each supported Boolean flag
+// Fixture matrix: every combination of the supported Boolean flags
 // ($td-enable-google-fonts defaults false, Bootstrap's $enable-dark-mode
-// defaults true), plus the full opt-in import surface on `maximal` so every
-// partial compiles somewhere.
+// defaults true). `maximal` adds the full opt-in import surface so every
+// partial compiles somewhere; `default` keeps the repo's stock stubs.
 const fixtures = {
   default: null,
-  minimal: { variables: '$enable-dark-mode: false;\n', styles: '' },
+  'dark-off': { variables: '$enable-dark-mode: false;\n', styles: '' },
+  'fonts-on': {
+    variables: '$td-enable-google-fonts: true;\n$enable-dark-mode: false;\n',
+    styles: '',
+  },
   maximal: {
     variables: '$td-enable-google-fonts: true;\n$enable-dark-mode: true;\n',
     styles: [
@@ -106,16 +112,18 @@ const fixtures = {
 
 test('Docsy Sass sources emit no non-import deprecation warnings', (t) => {
   const offending = [];
-  let tdImportSeen = false;
+  let importSeen = false;
   for (const [name, stubs] of Object.entries(fixtures)) {
-    const { warnings, loadedCount, unreached, scssDir } = compileTheme(stubs);
+    const { warnings, loadedCount, unreached, scssDir, stubUrls } =
+      compileTheme(stubs);
     const scssUrl = pathToFileURL(scssDir + path.sep).href;
-    // Shipped-source scope: td/ only, so the synthetic stubs' own @import
-    // warnings can't satisfy the canary below or pollute attribution.
-    const tdUrl = scssUrl + 'td/';
     for (const w of warnings) {
-      if (!w.deprecation || !w.url?.startsWith(tdUrl)) continue;
-      if (w.id === 'import') tdImportSeen = true;
+      // Shipped-source scope: every staged theme file (main.scss and the
+      // root partials included) except the fixture-written stubs, whose
+      // synthetic @imports must satisfy neither the canary nor the filter.
+      if (!w.deprecation || !w.url?.startsWith(scssUrl)) continue;
+      if (stubUrls.has(w.url)) continue;
+      if (w.id === 'import') importSeen = true;
       else offending.push({ fixture: name, id: w.id, url: w.url });
     }
     if (name === 'maximal') {
@@ -133,11 +141,10 @@ test('Docsy Sass sources emit no non-import deprecation warnings', (t) => {
   }
 
   // Sanity: origin attribution provably works (Docsy's own import-class
-  // warnings exist in td/). When the @use refactor (docsy#2732) zeroes the
-  // import class, this goes red: tighten the probe to "no Docsy warnings at
-  // all".
+  // warnings exist). When the @use refactor (docsy#2732) zeroes the import
+  // class, this goes red: tighten the probe to "no Docsy warnings at all".
   assert.ok(
-    tdImportSeen,
+    importSeen,
     'warning attribution resolves Docsy-origin (import-class) warnings',
   );
 

--- a/tests/sass-deprecations.test.mjs
+++ b/tests/sass-deprecations.test.mjs
@@ -4,8 +4,8 @@
 // warnings"), so the probe compiles the theme directly with the pinned
 // dart-sass, verbose so warning dedup can't hide occurrences. Loading a
 // file does not evaluate its conditional branches, so the probe compiles
-// every combination of the supported Boolean flags (the explicit fixture
-// matrix below -- the guarantee covers these configurations, not arbitrary
+// every combination of the supported Boolean flags (the fixture matrix
+// below; the guarantee covers these configurations, not arbitrary
 // conditional shapes).
 
 import test from 'node:test';

--- a/tests/sass-deprecations.test.mjs
+++ b/tests/sass-deprecations.test.mjs
@@ -42,10 +42,6 @@ function compileTheme() {
     fs.cpSync(themeScss, scssDir, { recursive: true });
     fs.mkdirSync(path.join(dir, 'vendor'));
     for (const [name, target] of Object.entries(vendors)) {
-      assert.ok(
-        fs.existsSync(target),
-        `theme dependency ${name} is installed (run npm install)`,
-      );
       // Junction type: works without privileges on Windows CI; ignored on
       // other platforms.
       fs.symlinkSync(target, path.join(dir, 'vendor', name), 'junction');
@@ -98,11 +94,9 @@ test('Docsy Sass sources emit no non-import deprecation warnings', (t) => {
     (w) => w.deprecation && w.url?.startsWith(scssUrl),
   );
 
-  // Sanity: the verbose compile surfaces warnings (vendor deprecations exist),
-  // and origin attribution works (Docsy's own import-class warnings exist).
-  // When the @use refactor (docsy#2732) zeroes the import class, the second
-  // assertion goes red: tighten this probe to "no Docsy warnings at all".
-  assert.ok(warnings.length > 0, 'verbose compile captures warnings');
+  // Sanity: origin attribution provably works (Docsy's own import-class
+  // warnings exist). When the @use refactor (docsy#2732) zeroes the import
+  // class, this goes red: tighten the probe to "no Docsy warnings at all".
   assert.ok(
     docsy.some((w) => w.id === 'import'),
     'warning attribution resolves Docsy-origin (import-class) warnings',

--- a/theme/assets/scss/td/_blog.scss
+++ b/theme/assets/scss/td/_blog.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 .td-blog {
   .td-rss-button {
     @extend .btn;
@@ -13,12 +14,12 @@
 
   &-posts-list {
     @extend .list-unstyled;
-    margin-top: map-get($spacers, 4) !important;
+    margin-top: map.get($spacers, 4) !important;
 
     &__item {
       display: flex;
       align-items: flex-start;
-      margin-bottom: map-get($spacers, 4) !important;
+      margin-bottom: map.get($spacers, 4) !important;
 
       &__body {
         flex: 1;

--- a/theme/assets/scss/td/_boxes.scss
+++ b/theme/assets/scss/td/_boxes.scss
@@ -1,13 +1,15 @@
+@use 'sass:color';
+@use 'sass:list';
 // Boxes on the home page and similar: .td-box
 
 // box-variant creates the main style for a colored section
 @mixin box-variant($parent, $color-name, $color-value) {
   $text-color: color-contrast($color-value);
-  $link-color: mix($blue, $text-color, lightness($color-value));
+  $link-color: color.mix($blue, $text-color, color.channel($color-value, 'lightness', $space: hsl));
   $link-hover-color: if(
-    color-contrast($link-color) == $color-contrast-light,
-    shade-color($link-color, $link-shade-percentage),
-    tint-color($link-color, $link-shade-percentage)
+    sass(color-contrast($link-color) == $color-contrast-light):
+      shade-color($link-color, $link-shade-percentage);
+    else: tint-color($link-color, $link-shade-percentage)
   );
 
   #{$parent} {
@@ -98,8 +100,8 @@
 }
 
 // This allows "painting by numbers"
-@for $i from 1 through length($td-box-colors) {
-  $c: nth($td-box-colors, $i);
+@for $i from 1 through list.length($td-box-colors) {
+  $c: list.nth($td-box-colors, $i);
   $name: $i - 1;
 
   @include box-variant('.td-box', $name, $c);

--- a/theme/assets/scss/td/_boxes.scss
+++ b/theme/assets/scss/td/_boxes.scss
@@ -5,11 +5,17 @@
 // box-variant creates the main style for a colored section
 @mixin box-variant($parent, $color-name, $color-value) {
   $text-color: color-contrast($color-value);
-  $link-color: color.mix($blue, $text-color, color.channel($color-value, 'lightness', $space: hsl));
+  $link-color: color.mix(
+    $blue,
+    $text-color,
+    color.channel($color-value, 'lightness', $space: hsl)
+  );
   $link-hover-color: if(
-    sass(color-contrast($link-color) == $color-contrast-light):
-      shade-color($link-color, $link-shade-percentage);
-    else: tint-color($link-color, $link-shade-percentage)
+    sass(color-contrast($link-color) == $color-contrast-light): shade-color(
+        $link-color,
+        $link-shade-percentage
+      );
+      else: tint-color($link-color, $link-shade-percentage)
   );
 
   #{$parent} {

--- a/theme/assets/scss/td/_code.scss
+++ b/theme/assets/scss/td/_code.scss
@@ -1,7 +1,8 @@
+@use 'sass:color';
 // Code formatting.
 
 @include color-mode(dark, true) {
-  --td-pre-bg: #{adjust-color($gray-900, $lightness: -2.5%)};
+  --td-pre-bg: #{color.adjust($gray-900, $lightness: -2.5%)};
 }
 
 .td-content {

--- a/theme/assets/scss/td/_color-adjustments-dark.scss
+++ b/theme/assets/scss/td/_color-adjustments-dark.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 // =============================================================================
 // Color adjustments for dark mode, mainly to improve color contrast.
 //
@@ -11,7 +12,7 @@
 // The following value makes sense for the Bootstrap base theme. Projects will
 // likely need to adjust this.
 $lighten-amount-for-dark-color-variant: 22% !default;
-$secondary-lighter: lighten($secondary, 30%) !default;
+$secondary-lighter: color.adjust($secondary, $lightness: 30%) !default;
 
 // Make box-shadow color contrast more obvious in dark mode.
 // https://github.com/twbs/bootstrap/issues/39053 reports this issue.

--- a/theme/assets/scss/td/_colors.scss
+++ b/theme/assets/scss/td/_colors.scss
@@ -3,7 +3,11 @@
 // Add some local palette classes so you can do -bg-warning -text-warning etc. Even -bg-1 if you want to paint by numbers.
 @mixin palette-variant($color-name, $color-value) {
   $text-color: color-contrast($color-value);
-  $link-color: color.mix($blue, $text-color, color.channel($color-value, 'lightness', $space: hsl));
+  $link-color: color.mix(
+    $blue,
+    $text-color,
+    color.channel($color-value, 'lightness', $space: hsl)
+  );
 
   $link-hover-color: rgba($link-color, 0.5) !default;
 

--- a/theme/assets/scss/td/_colors.scss
+++ b/theme/assets/scss/td/_colors.scss
@@ -1,7 +1,9 @@
+@use 'sass:color';
+@use 'sass:list';
 // Add some local palette classes so you can do -bg-warning -text-warning etc. Even -bg-1 if you want to paint by numbers.
 @mixin palette-variant($color-name, $color-value) {
   $text-color: color-contrast($color-value);
-  $link-color: mix($blue, $text-color, lightness($color-value));
+  $link-color: color.mix($blue, $text-color, color.channel($color-value, 'lightness', $space: hsl));
 
   $link-hover-color: rgba($link-color, 0.5) !default;
 
@@ -36,8 +38,8 @@
 }
 
 // This allows "painting by numbers", i.e. picking colors by a shortcode Ordinal.
-@for $i from 1 through length($td-box-colors) {
-  $value: nth($td-box-colors, $i);
+@for $i from 1 through list.length($td-box-colors) {
+  $value: list.nth($td-box-colors, $i);
   $name: $i - 1;
   $text-color: color-contrast($value);
 

--- a/theme/assets/scss/td/_content.scss
+++ b/theme/assets/scss/td/_content.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 //
 // Style Markdown content
 //
@@ -119,7 +120,7 @@
 
   // Always visible on touch devices and small screens
   @media (hover: none) and (pointer: coarse),
-    (max-width: map-get($grid-breakpoints, sm)) {
+    (max-width: map.get($grid-breakpoints, sm)) {
     visibility: visible;
   }
 }

--- a/theme/assets/scss/td/_footer.scss
+++ b/theme/assets/scss/td/_footer.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 .td-footer {
   --td-footer-border-color: var(--bs-border-color);
   --td-footer-border: 1px solid var(--td-footer-border-color);
@@ -16,7 +17,7 @@
   }
 
   min-height: var(--td-footer-min-height);
-  padding-top: map-get($spacers, 5);
+  padding-top: map.get($spacers, 5);
   border-top: var(--td-footer-border);
 
   /* &__left { } */
@@ -42,7 +43,7 @@
 
     &-item {
       @extend .list-inline-item;
-      @include font-size(map-get($font-sizes, 4));
+      @include font-size(map.get($font-sizes, 4));
 
       a {
         color: inherit !important;
@@ -52,7 +53,7 @@
 
   &__authors,
   &__all_rights_reserved {
-    padding-left: map-get($spacers, 1);
+    padding-left: map.get($spacers, 1);
   }
 
   &__all_rights_reserved {

--- a/theme/assets/scss/td/_pageinfo.scss
+++ b/theme/assets/scss/td/_pageinfo.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 .pageinfo {
   font-weight: $font-weight-medium;
   background: var(--bs-alert-bg);
@@ -18,7 +19,7 @@
   &__lastmod {
     @extend .text-body-secondary;
     @extend .border-top;
-    margin-top: map-get($spacers, 5) !important;
-    padding-top: map-get($spacers, 3) !important;
+    margin-top: map.get($spacers, 5) !important;
+    padding-top: map.get($spacers, 3) !important;
   }
 }

--- a/theme/assets/scss/td/_sidebar-toc.scss
+++ b/theme/assets/scss/td/_sidebar-toc.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 //
 // Right side toc
 //
@@ -79,7 +80,7 @@
 
       // Always visible on touch devices and small screens
       @media (hover: none) and (pointer: coarse),
-        (max-width: map-get($grid-breakpoints, sm)) {
+        (max-width: map.get($grid-breakpoints, sm)) {
         opacity: 1;
         visibility: visible;
       }

--- a/theme/assets/scss/td/_variables.scss
+++ b/theme/assets/scss/td/_variables.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 // Bootstrap options
 
 :root,
@@ -26,7 +27,7 @@ $td-google-font-family: 'Open+Sans:300,300i,400,400i,700,700i' !default;
 $td-web-font-path: 'https://fonts.googleapis.com/css?family=#{$td-google-font-family}&display=swap';
 
 @if $td-enable-google-fonts {
-  $td-fonts-serif: join('#{$td-google-font-name}', $td-fonts-serif);
+  $td-fonts-serif: list.join('#{$td-google-font-name}', $td-fonts-serif);
 }
 
 $font-family-sans-serif: null !default;

--- a/theme/assets/scss/td/extra/_navbar.scss
+++ b/theme/assets/scss/td/extra/_navbar.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 // Navbar styles: use underline decoration for active and hover nav-link states.
 
 .td-navbar {
@@ -10,7 +11,7 @@
         var(--bs-link-underline-opacity)
       ) !important;
       text-decoration-thickness: 3px;
-      text-underline-offset: map-get($td-link-underline-offsets, 3);
+      text-underline-offset: map.get($td-link-underline-offsets, 3);
     }
 
     &:hover {
@@ -18,7 +19,7 @@
         var(--bs-secondary-rgb),
         var(--bs-link-underline-opacity)
       ) !important;
-      text-underline-offset: map-get($td-link-underline-offsets, 4);
+      text-underline-offset: map.get($td-link-underline-offsets, 4);
     }
   }
 

--- a/theme/assets/scss/td/support/_mixins.scss
+++ b/theme/assets/scss/td/support/_mixins.scss
@@ -1,3 +1,4 @@
+@use 'sass:selector';
 // Mixins
 
 @mixin link-decoration($base: none, $focus_or_hover: initial) {
@@ -30,7 +31,7 @@
 }
 
 @mixin optional-at-root($sel) {
-  @at-root #{if(not &, $sel, selector-append(&, $sel))} {
+  @at-root #{if(sass(not &): $sel; else: selector.append(&, $sel))} {
     @content;
   }
 }

--- a/theme/layouts/_partials/head-css.html
+++ b/theme/layouts/_partials/head-css.html
@@ -1,8 +1,14 @@
 {{ $scssMain := "scss/main.scss" -}}
+{{/* silenceDeprecations: the remaining warning classes are vendor-owned
+(Bootstrap, Font Awesome) plus Docsy's own import-class, gated on the @use
+refactor (docsy#2279); Docsy-origin regressions in the silenced classes stay
+red via tests/sass-deprecations.test.mjs. */ -}}
 {{ $css := resources.Get $scssMain
       | toCSS (dict
           "transpiler" "dartsass"
-          "enableSourceMap" (not hugo.IsProduction)) -}}
+          "enableSourceMap" (not hugo.IsProduction)
+          "silenceDeprecations" (slice
+              "import" "global-builtin" "color-functions" "if-function")) -}}
 
 {{/* postCSS runs for RTL languages (rtlcss) and, in production, only when the
 site opts in with a project-root postcss.config.*; dev skips it for speed. */ -}}

--- a/theme/layouts/_partials/head-css.html
+++ b/theme/layouts/_partials/head-css.html
@@ -1,10 +1,9 @@
 {{ $scssMain := "scss/main.scss" -}}
 {{/* Dart Sass sees only the stdin-fed entry file as first-party: Hugo's
-importer loads everything else -- Docsy's tree, vendored Bootstrap and
-Font Awesome, and site SCSS alike -- as dependencies, so
+importer loads everything else (Docsy's tree, vendored Bootstrap and
+Font Awesome, and site SCSS alike) as dependencies, so
 silenceDependencyDeprecations quiets them all. Docsy-origin regressions stay
-red via tests/sass-deprecations.test.mjs, which compiles the theme directly
-and attributes warnings per file. */ -}}
+red via tests/sass-deprecations.test.mjs. */ -}}
 {{ $css := resources.Get $scssMain
       | toCSS (dict
           "transpiler" "dartsass"

--- a/theme/layouts/_partials/head-css.html
+++ b/theme/layouts/_partials/head-css.html
@@ -1,14 +1,15 @@
 {{ $scssMain := "scss/main.scss" -}}
-{{/* silenceDeprecations: the remaining warning classes are vendor-owned
-(Bootstrap, Font Awesome) plus Docsy's own import-class, gated on the @use
-refactor (docsy#2279); Docsy-origin regressions in the silenced classes stay
-red via tests/sass-deprecations.test.mjs. */ -}}
+{{/* Dart Sass sees only the stdin-fed entry file as first-party: Hugo's
+importer loads everything else -- Docsy's tree, vendored Bootstrap and
+Font Awesome, and site SCSS alike -- as dependencies, so
+silenceDependencyDeprecations quiets them all. Docsy-origin regressions stay
+red via tests/sass-deprecations.test.mjs, which compiles the theme directly
+and attributes warnings per file. */ -}}
 {{ $css := resources.Get $scssMain
       | toCSS (dict
           "transpiler" "dartsass"
           "enableSourceMap" (not hugo.IsProduction)
-          "silenceDeprecations" (slice
-              "import" "global-builtin" "color-functions" "if-function")) -}}
+          "silenceDependencyDeprecations" true) -}}
 
 {{/* postCSS runs for RTL languages (rtlcss) and, in production, only when the
 site opts in with a project-root postcss.config.*; dev skips it for speed. */ -}}

--- a/theme/layouts/_partials/head-css.html
+++ b/theme/layouts/_partials/head-css.html
@@ -1,9 +1,8 @@
 {{ $scssMain := "scss/main.scss" -}}
-{{/* Dart Sass sees only the stdin-fed entry file as first-party: Hugo's
-importer loads everything else (Docsy's tree, vendored Bootstrap and
-Font Awesome, and site SCSS alike) as dependencies, so
-silenceDependencyDeprecations quiets them all. Docsy-origin regressions stay
-red via tests/sass-deprecations.test.mjs. */ -}}
+{{/* Dart Sass sees only the stdin-fed entry file as first-party, so
+silenceDependencyDeprecations quiets everything else Hugo's importer loads,
+Docsy's own tree included (regression guards: see maintainer notes, "Sass
+deprecation warnings"). */ -}}
 {{ $css := resources.Get $scssMain
       | toCSS (dict
           "transpiler" "dartsass"


### PR DESCRIPTION
- **Zeroes Docsy's own function-class Sass deprecation warnings**: every remaining non-import warning now originates in vendor sources (Bootstrap and Font Awesome).
- **Leaves import-class warnings in place**: gated on the `@use` refactor (#2732).
- **Raises the effective Dart Sass floor to 1.95.0**: the new `if()` conditional syntax parses only from 1.95.0; the pinned `sass-embedded` (1.102.0) already satisfies it.
- **Restores #2724's dependency-deprecation silencing** (`head-css.html`): with the theme's warnings zeroed, quiet build logs no longer hide anything actionable in Docsy's sources; the entry-level `import` silencing stays dropped as obsolete (`main.scss` is `@use` since #2724).
- **Guards against Docsy-origin regressions**: a direct-compile probe fails on theme-source non-import deprecations across a supported-configuration fixture matrix, keeping regressions red despite the silencing; the docsy.dev build probe drops its `Dart Sass` exclusion and pins and proves its own log level, so escaped deprecation warnings fail red too.
- **Proves the compiled CSS byte-identical**: direct dart-sass compile pre vs post, `main.scss` plus the opt-in `td/extra/_navbar.scss`, `cmp`-clean.
- **Also**:
  - Maps the guard split in the maintainer notes (§ Test suites).
  - Re-wraps two touched files per Prettier (second commit).
