### PR TITLE
Move markdownlint rule deps from git pins to registry versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,10 @@
       },
       "devDependencies": {
         "@cspell/dict-fr-fr": "^2.3.2",
+        "@pchalin/markdownlint-rule-link-pattern": "^0.3.0",
         "jsdom": "^29.1.1",
         "markdownlint-cli2": "^0.23.2",
-        "markdownlint-rule-link-pattern": "github:chalin/markdownlint-rule-link-pattern#v0.2.0",
-        "markdownlint-rule-no-shortcut-ref-link": "github:chalin/markdownlint-rule-no-shortcut-ref-link#v0.3.1",
+        "markdownlint-rule-no-shortcut-ref-link": "^0.3.1",
         "pixelmatch": "7.2.0",
         "pngjs": "7.0.0",
         "prettier": "^3.9.3",
@@ -676,6 +676,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@pchalin/markdownlint-rule-link-pattern": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@pchalin/markdownlint-rule-link-pattern/-/markdownlint-rule-link-pattern-0.3.0.tgz",
+      "integrity": "sha512-TL6xosTy0g/QaVEQ8ltp8fbUaJOLAEb6qKddiJ53kcN0VG8rIiriVhcnr379YmY6T1JxlJevLyvnvgtcDVuTLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "markdownlint-rule-helpers": ">=0.27.0"
       }
     },
     "node_modules/@popperjs/core": {
@@ -1824,18 +1834,10 @@
         "url": "https://github.com/sponsors/DavidAnson"
       }
     },
-    "node_modules/markdownlint-rule-link-pattern": {
-      "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/chalin/markdownlint-rule-link-pattern.git#c35d613ea9b883777816a81a59fa069072bb9d50",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "markdownlint-rule-helpers": ">=0.27.0"
-      }
-    },
     "node_modules/markdownlint-rule-no-shortcut-ref-link": {
       "version": "0.3.1",
-      "resolved": "git+ssh://git@github.com/chalin/markdownlint-rule-no-shortcut-ref-link.git#ded30f98e20f9dda69f956103fe54670411af8e8",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-no-shortcut-ref-link/-/markdownlint-rule-no-shortcut-ref-link-0.3.1.tgz",
+      "integrity": "sha512-cgeeU9YZ3mPL85lQGCTGNUIhkSe+yaVMpAXyy8oL42k9Mg4dbM0I9I96S7E+ZPSqApBRic52ql9H1RgqGdX9Xg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -89,10 +89,10 @@
   },
   "devDependencies": {
     "@cspell/dict-fr-fr": "^2.3.2",
+    "@pchalin/markdownlint-rule-link-pattern": "^0.3.0",
     "jsdom": "^29.1.1",
     "markdownlint-cli2": "^0.23.2",
-    "markdownlint-rule-link-pattern": "github:chalin/markdownlint-rule-link-pattern#v0.2.0",
-    "markdownlint-rule-no-shortcut-ref-link": "github:chalin/markdownlint-rule-no-shortcut-ref-link#v0.3.1",
+    "markdownlint-rule-no-shortcut-ref-link": "^0.3.1",
     "pixelmatch": "7.2.0",
     "pngjs": "7.0.0",
     "prettier": "^3.9.3",

--- a/scripts/_md-rules/link-rules.mjs
+++ b/scripts/_md-rules/link-rules.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { createLinkPatternRule } from 'markdownlint-rule-link-pattern';
+import { createLinkPatternRule } from '@pchalin/markdownlint-rule-link-pattern';
 import noShortcutRefLink from 'markdownlint-rule-no-shortcut-ref-link';
 
 export default [

--- a/tests/npm-audit.test.mjs
+++ b/tests/npm-audit.test.mjs
@@ -14,14 +14,8 @@ const repoRoot = path.resolve(
   '..',
 );
 
-// No advisories are currently accepted: GHSA-q3xp-j858-q9xf stopped matching
-// when the link-pattern dep moved to its scoped registry name,
-// @pchalin/markdownlint-rule-link-pattern (the advisory covers the unscoped
-// name, where malware was once published under the project's name). The
-// gate mechanism stays for future reviewed exceptions.
 const acceptedAdvisories = new Map();
 
-// Helper: gate the npm audit report schema and accepted advisories.
 function validateAuditGate(report, accepted) {
   // Fail-closed on npm audit format changes (currently v2).
   assert.equal(report.auditReportVersion, 2, 'npm audit report format is v2');
@@ -51,7 +45,6 @@ function validateAuditGate(report, accepted) {
           `via entries are advisory objects or chain strings; got ${typeof via} on ${name} (${JSON.stringify(via)})`,
         );
       }
-      // Advisory object: extract GHSA and check acceptance.
       const ghsa = via.url?.match(/GHSA-[a-z0-9-]+$/)?.[0] ?? via.url;
       reported.set(ghsa, via.name ?? name);
       assert.ok(
@@ -61,7 +54,6 @@ function validateAuditGate(report, accepted) {
     }
   }
 
-  // Every accepted advisory must still be reported (exceptions are stale).
   for (const [ghsa, pkg] of accepted) {
     assert.equal(
       reported.get(ghsa),
@@ -96,7 +88,7 @@ test('audit: reported advisories are reviewed and accepted', () => {
 
 // Fixture: validate the parser against mock report shapes, with a
 // fixture-local accepted map so the checks don't depend on the live
-// (currently empty) exception list.
+// exception list.
 const fixtureAccepted = new Map([['GHSA-aaaa-bbbb-cccc', 'accepted-package']]);
 
 test('audit gate: parser rejects unreviewed advisories', () => {

--- a/tests/npm-audit.test.mjs
+++ b/tests/npm-audit.test.mjs
@@ -14,15 +14,12 @@ const repoRoot = path.resolve(
   '..',
 );
 
-// GHSA-q3xp-j858-q9xf flags every version of the registry package
-// markdownlint-rule-link-pattern, where malware was once published under
-// the project's name. This repo installs the package from its author's
-// GitHub tag, so the flagged registry code is never fetched; the
-// advisory matches on name only. Remove once the advisory is scoped to
-// the malicious registry version.
-const acceptedAdvisories = new Map([
-  ['GHSA-q3xp-j858-q9xf', 'markdownlint-rule-link-pattern'],
-]);
+// No advisories are currently accepted: GHSA-q3xp-j858-q9xf stopped matching
+// when the link-pattern dep moved to its scoped registry name,
+// @pchalin/markdownlint-rule-link-pattern (the advisory covers the unscoped
+// name, where malware was once published under the project's name). The
+// gate mechanism stays for future reviewed exceptions.
+const acceptedAdvisories = new Map();
 
 // Helper: gate the npm audit report schema and accepted advisories.
 function validateAuditGate(report, accepted) {
@@ -97,7 +94,11 @@ test('audit: reported advisories are reviewed and accepted', () => {
   validateAuditGate(report, acceptedAdvisories);
 });
 
-// Fixture: validate the parser against mock report shapes.
+// Fixture: validate the parser against mock report shapes, with a
+// fixture-local accepted map so the checks don't depend on the live
+// (currently empty) exception list.
+const fixtureAccepted = new Map([['GHSA-aaaa-bbbb-cccc', 'accepted-package']]);
+
 test('audit gate: parser rejects unreviewed advisories', () => {
   const validReport = {
     auditReportVersion: 2,
@@ -108,16 +109,16 @@ test('audit gate: parser rejects unreviewed advisories', () => {
         name: 'package-a',
         via: [
           {
-            url: 'https://github.com/advisories/GHSA-q3xp-j858-q9xf',
+            url: 'https://github.com/advisories/GHSA-aaaa-bbbb-cccc',
             severity: 'critical',
-            name: 'markdownlint-rule-link-pattern',
+            name: 'accepted-package',
             title: 'Malware',
           },
         ],
       },
     },
   };
-  validateAuditGate(validReport, acceptedAdvisories);
+  validateAuditGate(validReport, fixtureAccepted);
 });
 
 test('audit gate: parser rejects unaccepted advisories', () => {
@@ -140,7 +141,7 @@ test('audit gate: parser rejects unaccepted advisories', () => {
     },
   };
   assert.throws(
-    () => validateAuditGate(reportWithNewGHSA, acceptedAdvisories),
+    () => validateAuditGate(reportWithNewGHSA, fixtureAccepted),
     /GHSA-xxxx-yyyy-zzzz.*reviewed, accepted advisory/,
   );
 });
@@ -153,8 +154,8 @@ test('audit gate: parser rejects stale exceptions (missing report)', () => {
     vulnerabilities: {},
   };
   assert.throws(
-    () => validateAuditGate(reportWithoutAcceptedGHSA, acceptedAdvisories),
-    /accepted advisory GHSA-q3xp-j858-q9xf remains reported/,
+    () => validateAuditGate(reportWithoutAcceptedGHSA, fixtureAccepted),
+    /accepted advisory GHSA-aaaa-bbbb-cccc remains reported/,
   );
 });
 
@@ -166,7 +167,7 @@ test('audit gate: parser rejects format version changes', () => {
     vulnerabilities: {},
   };
   assert.throws(
-    () => validateAuditGate(reportV3, acceptedAdvisories),
+    () => validateAuditGate(reportV3, fixtureAccepted),
     /report format is v2/,
   );
 });
@@ -184,7 +185,7 @@ test('audit gate: parser rejects string via without chain target', () => {
     },
   };
   assert.throws(
-    () => validateAuditGate(reportWithDanglingStringVia, acceptedAdvisories),
+    () => validateAuditGate(reportWithDanglingStringVia, fixtureAccepted),
     /string via "nonexistent-key".*resolves to a reported vulnerability/,
   );
 });
@@ -199,9 +200,9 @@ test('audit gate: parser catches unreviewed advisory alongside accepted one', ()
         name: 'package-a',
         via: [
           {
-            url: 'https://github.com/advisories/GHSA-q3xp-j858-q9xf',
+            url: 'https://github.com/advisories/GHSA-aaaa-bbbb-cccc',
             severity: 'critical',
-            name: 'markdownlint-rule-link-pattern',
+            name: 'accepted-package',
             title: 'Malware',
           },
         ],
@@ -220,7 +221,7 @@ test('audit gate: parser catches unreviewed advisory alongside accepted one', ()
     },
   };
   assert.throws(
-    () => validateAuditGate(reportWithMixedAdvisories, acceptedAdvisories),
+    () => validateAuditGate(reportWithMixedAdvisories, fixtureAccepted),
     /GHSA-xxxx-yyyy-zzzz.*reviewed, accepted advisory/,
   );
 });
@@ -239,14 +240,14 @@ test('audit gate: parser accepts valid transitive advisory chain', () => {
         name: 'package-b',
         via: [
           {
-            url: 'https://github.com/advisories/GHSA-q3xp-j858-q9xf',
+            url: 'https://github.com/advisories/GHSA-aaaa-bbbb-cccc',
             severity: 'critical',
-            name: 'markdownlint-rule-link-pattern',
+            name: 'accepted-package',
             title: 'Malware',
           },
         ],
       },
     },
   };
-  validateAuditGate(reportWithTransitiveChain, acceptedAdvisories);
+  validateAuditGate(reportWithTransitiveChain, fixtureAccepted);
 });

--- a/tests/supply-chain-audit.test.mjs
+++ b/tests/supply-chain-audit.test.mjs
@@ -31,10 +31,8 @@ const locks = {
 // link entry must point back into one: local code, not a registry fetch.
 const workspaceDirs = new Set(['docsy.dev', 'theme']);
 
-// The only dependencies allowed to bypass the npm registry: none since the
-// markdownlint rules moved to registry pins (#2725 follow-up); the allowlist
-// mechanism stays for reviewed exceptions. Every package must carry a
-// registry URL and an integrity hash.
+// Git deps allowed to bypass the npm registry: lock key -> reviewed
+// owner/repo.
 const gitDependencyRepos = {};
 
 // Known-poisoned package@version pairs from the 2026-08 npm-worm campaign

--- a/tests/supply-chain-audit.test.mjs
+++ b/tests/supply-chain-audit.test.mjs
@@ -207,20 +207,30 @@ test('locks and manifests: install scripts stay inventoried and version-pinned',
   }
 });
 
-test('manifests: no git-sourced dependencies', () => {
-  for (const relPath of ['package.json', 'theme/package.json']) {
+// A git-spec denylist would miss npm's other non-registry forms (owner/repo
+// shorthand, URLs, aliases): require the registry semver shape instead, so
+// unknown bypass classes fail closed.
+test('manifests: every dependency spec is a registry semver range', () => {
+  let specs = 0;
+  for (const relPath of [
+    'package.json',
+    'docsy.dev/package.json',
+    'theme/package.json',
+  ]) {
     const { dependencies = {}, devDependencies = {} } = readJSON(relPath);
     for (const [name, spec] of [
       ...Object.entries(dependencies),
       ...Object.entries(devDependencies),
     ]) {
-      assert.doesNotMatch(
+      specs += 1;
+      assert.match(
         spec,
-        /^(github:|git\+|git:)/,
-        `${relPath} ${name} resolves through the npm registry`,
+        /^[~^]?\d/,
+        `${relPath} ${name} uses a registry semver spec`,
       );
     }
   }
+  assert.ok(specs > 0, 'manifest dependency specs were audited');
 });
 
 // npm applies overrides only while re-resolving and trusts an in-sync

--- a/tests/supply-chain-audit.test.mjs
+++ b/tests/supply-chain-audit.test.mjs
@@ -31,15 +31,11 @@ const locks = {
 // link entry must point back into one: local code, not a registry fetch.
 const workspaceDirs = new Set(['docsy.dev', 'theme']);
 
-// The only dependencies allowed to bypass the npm registry: two reviewed
-// markdownlint rules, commit-pinned from their author's repos. Everything
-// else must carry a registry URL and an integrity hash.
-const gitDependencyRepos = {
-  'node_modules/markdownlint-rule-link-pattern':
-    'chalin/markdownlint-rule-link-pattern',
-  'node_modules/markdownlint-rule-no-shortcut-ref-link':
-    'chalin/markdownlint-rule-no-shortcut-ref-link',
-};
+// The only dependencies allowed to bypass the npm registry: none since the
+// markdownlint rules moved to registry pins (#2725 follow-up); the allowlist
+// mechanism stays for reviewed exceptions. Every package must carry a
+// registry URL and an integrity hash.
+const gitDependencyRepos = {};
 
 // Known-poisoned package@version pairs from the 2026-08 npm-worm campaign
 // (Datadog Security Labs). A denylist only ever samples: the structural
@@ -213,15 +209,19 @@ test('locks and manifests: install scripts stay inventoried and version-pinned',
   }
 });
 
-test('manifests: git dependencies are tag-pinned to their reviewed repos', () => {
-  const { devDependencies } = readJSON('package.json');
-  for (const repo of Object.values(gitDependencyRepos)) {
-    const name = repo.split('/')[1];
-    assert.match(
-      devDependencies[name] ?? '',
-      new RegExp(`^github:${repo}#v\\d+\\.\\d+\\.\\d+$`),
-      `${name} is tag-pinned to ${repo}`,
-    );
+test('manifests: no git-sourced dependencies', () => {
+  for (const relPath of ['package.json', 'theme/package.json']) {
+    const { dependencies = {}, devDependencies = {} } = readJSON(relPath);
+    for (const [name, spec] of [
+      ...Object.entries(dependencies),
+      ...Object.entries(devDependencies),
+    ]) {
+      assert.doesNotMatch(
+        spec,
+        /^(github:|git\+|git:)/,
+        `${relPath} ${name} resolves through the npm registry`,
+      );
+    }
   }
 });
 


### PR DESCRIPTION
- **Registry migration**: `markdownlint-rule-link-pattern` now publishes as [`@pchalin/markdownlint-rule-link-pattern`](https://www.npmjs.com/package/@pchalin/markdownlint-rule-link-pattern) (the unscoped registry name is npm-security-held after a malicious squat and is not the project's); the version jump over the git pin is the rename release (packaging, docs, CI), with the rule source unchanged. `markdownlint-rule-no-shortcut-ref-link` moves to its registry version at the same pinned content.
- **Retires the GHSA-q3xp-j858-q9xf audit exception** (follow-up to #2725): with the unscoped name out of the manifest, the advisory no longer matches; `npm audit` on this branch reports 0 vulnerabilities. Audit-gate fixtures now use synthetic data.
- **Empties the git-dep allowlist**: the lock check now proves no dependency bypasses the registry, and the manifest check requires registry semver specs, failing closed on non-registry spec forms.
