### PR TITLE
Blog 0.17.0: warnings clause, 1.95.0 Sass floor, drop LibSass hatch

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -533,6 +533,7 @@ https://github.com/google/docsy/pull/2714,200,1786628621
 https://github.com/google/docsy/pull/2722,200,1787153684
 https://github.com/google/docsy/pull/2724,200,1787076569
 https://github.com/google/docsy/pull/2726,200,1787137876
+https://github.com/google/docsy/pull/2731,200,1787331617
 https://github.com/google/docsy/pull/941,200,1782498225
 https://github.com/google/docsy/pulls,200,1782563369
 https://github.com/google/docsy/releases,200,1782563368

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -110,7 +110,7 @@ update in the [order of steps][]:
   export PATH=$PWD/dart-sass:$PATH
   ```
 
-- **Self-provisioned compilers**: use Dart Sass **1.95.0 or later**: the theme's
+- **Self-provisioned compilers**: use Dart Sass **1.95.0 or later**. The theme's
   stylesheets rely on Sass's new `if()` conditional syntax, which older releases
   can't parse. Current npm releases of `sass-embedded` are well past this floor;
   for the officially supported Dart Sass version, see the [official support

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -73,7 +73,8 @@ in-binary compiler. Every further LibSass-built release would grow the set of
 sites on a dying pipeline.
 
 Build logs stay quiet: the theme silences Sass deprecation warnings from
-dependencies, which as a side effect covers your project's own Sass too. A quiet
+dependencies, which as a side effect covers your own [project style files][] too
+(though not a custom `main.scss` entry point, which stays first-party). A quiet
 build log is therefore not evidence that your own Sass is deprecation-free.
 
 ### Actions {#dart-sass-actions}
@@ -381,6 +382,7 @@ About this release:
 [official support policy]: /project/about/changelog/#official-support
 [order of steps]: /docs/update/#update-order
 [overrides]: /docs/update/#update-overrides
+[Project style files]: /docs/content/lookandfeel/#project-style-files
 [semantic classes]: /docs/content/lookandfeel/#semantic-classes
 [single-override]: /docs/content/navigation/#breadcrumb-navigation
 [trusted publishing]: https://docs.npmjs.com/trusted-publishers

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -72,16 +72,13 @@ mode][dart-sass-2413] targets platforms without prebuilt binaries, not an
 in-binary compiler. Every further LibSass-built release would grow the set of
 sites on a dying pipeline.
 
-<!-- prettier-ignore -->
-{{< comment >}} TODO(hold, own-warnings PR): warnings-expected clause lands
-here: exact wording to come from the css-closeout lane once Docsy's own Sass
-function-class warnings are zeroed. When adding it:
-
-1. Attach the 1.74.0 floor's rationale to it (1.74.0 is the first release with
-   the toCSS deprecation-silencing options that the clause's silencing override
-   relies on); the floor is stated bare under Actions until then.
-2. Confirm the Actions bullet and the clause read coherently together.
-   {{< /comment >}}
+Build logs stay quiet: the theme silences Sass dependency-deprecation warnings,
+and its own stylesheets are kept deprecation-clean by a regression test. One
+side effect to know about: under Hugo's importer, everything but the entry
+stylesheet counts as a dependency, **including your site's own project Sass**,
+so its deprecation warnings are silenced too. To audit your own Sass for
+deprecated constructs, compile it directly with the `sass` CLI, or temporarily
+override `head-css.html` with `silenceDependencyDeprecations` unset.
 
 ### Actions {#dart-sass-actions}
 
@@ -106,7 +103,7 @@ update in the [order of steps][]:
   below covers Linux x64 builders such as Cloudflare Pages; on other platforms,
   substitute the matching [dart-sass release asset][dart-sass releases]. Set
   `DART_SASS_VERSION` as an environment variable in your project settings, to an
-  unprefixed version, 1.74.0 or later (for example, `1.102.0`; snippet adapted
+  unprefixed version, 1.95.0 or later (for example, `1.102.0`; snippet adapted
   from [Hugo's Cloudflare hosting guide][cf-hosting]):
 
   ```sh
@@ -115,9 +112,10 @@ update in the [order of steps][]:
   export PATH=$PWD/dart-sass:$PATH
   ```
 
-- **Self-provisioned compilers**: use Dart Sass **1.74.0 or later**. Current npm
-  releases of `sass-embedded` are well past this floor; for the officially
-  supported Dart Sass version, see the [official support policy][].
+- **Self-provisioned compilers**: use Dart Sass **1.95.0 or later** -- the theme
+  uses Sass's `if()` conditional syntax, which older releases can't parse.
+  Current npm releases of `sass-embedded` are well past this floor; for the
+  officially supported Dart Sass version, see the [official support policy][].
 
 ### What to recheck after upgrading {#dart-sass-recheck}
 
@@ -139,26 +137,17 @@ dozen pixels per page.
   `$primary` now fails with "Undefined variable": inline the color values
   instead.
 
-### LibSass escape hatch {#libsass-escape-hatch}
+### No LibSass fallback {#libsass-escape-hatch}
 
 **Applies if** your build platform has no Dart Sass distribution (for example,
 the BSDs).
 
-You can restore the LibSass pipeline for as long as your Hugo build still
-bundles LibSass, by overriding **all three** of these theme files with their
-0.16 versions:
-
-1. `layouts/_partials/head-css.html`: a plain `toCSS` call.
-2. `assets/scss/main.scss`: back to `@import 'td/main';`.
-3. `assets/scss/td/_code-dark.scss`: back to its nested-`@import` form.
-
-The three are an atomic set. In particular, overriding `head-css.html` alone
-**builds green but ships an unstyled site**: LibSass passes the shipped entry
-point's `@use` through as an unknown at-rule instead of failing.
-
-This hatch is terminal: it dies when Hugo removes LibSass. For binary-less
-platforms, the durable path is Dart Sass's planned [pure-JS embedded
-mode][dart-sass-2413].
+There is no way to keep building this release with Hugo's embedded LibSass: the
+theme's stylesheets now use `sass:` modules and Sass's `if()` conditional
+syntax, which LibSass never implemented. Worse, LibSass fails silently on them
+(a green build that ships broken CSS), so partial rollbacks by overriding theme
+files are a trap. For binary-less platforms, the durable path is Dart Sass's
+planned [pure-JS embedded mode][dart-sass-2413].
 
 ## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -73,9 +73,8 @@ in-binary compiler. Every further LibSass-built release would grow the set of
 sites on a dying pipeline.
 
 Build logs stay quiet: the theme silences Sass deprecation warnings from
-dependencies, which as a side effect covers your project's own Sass too. To
-audit your Sass for deprecated constructs, compile it directly with the `sass`
-CLI.
+dependencies, which as a side effect covers your project's own Sass too. A quiet
+build log is therefore not evidence that your own Sass is deprecation-free.
 
 ### Actions {#dart-sass-actions}
 
@@ -141,11 +140,12 @@ dozen pixels per page.
 the BSDs).
 
 There is no way to keep building this release with Hugo's embedded LibSass: the
-theme's stylesheets now use `sass:` modules and Sass's `if()` conditional
-syntax, which LibSass never implemented. Worse, LibSass fails silently on them
-(a green build that ships broken CSS), so partial rollbacks by overriding theme
-files are a trap. For binary-less platforms, the durable path is Dart Sass's
-planned [pure-JS embedded mode][dart-sass-2413].
+theme's stylesheets now use `sass:` modules and Sass's new `if()` conditional
+syntax (`if(condition: value; else: value)`), which LibSass does not implement.
+A 0.16-style rollback through theme-file overrides now fails to compile, and
+overriding `head-css.html` alone builds green but ships an unstyled site. For
+binary-less platforms, the durable path is Dart Sass's planned [pure-JS embedded
+mode][dart-sass-2413].
 
 ## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -74,8 +74,9 @@ sites on a dying pipeline.
 
 Build logs stay quiet: the theme silences Sass deprecation warnings from
 dependencies, which as a side effect covers your own [project style files][] too
-(though not a custom `main.scss` entry point, which stays first-party). A quiet
-build log is therefore not evidence that your own Sass is deprecation-free.
+(though not a custom `main.scss` entry point, whose warnings stay visible). A
+quiet build log is therefore not evidence that your own Sass is
+deprecation-free.
 
 ### Actions {#dart-sass-actions}
 
@@ -110,7 +111,7 @@ update in the [order of steps][]:
   ```
 
 - **Self-provisioned compilers**: use Dart Sass **1.95.0 or later**: the theme's
-  stylesheets rely on Sass's `if()` conditional syntax, which older releases
+  stylesheets rely on Sass's new `if()` conditional syntax, which older releases
   can't parse. Current npm releases of `sass-embedded` are well past this floor;
   for the officially supported Dart Sass version, see the [official support
   policy][].

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -72,13 +72,10 @@ mode][dart-sass-2413] targets platforms without prebuilt binaries, not an
 in-binary compiler. Every further LibSass-built release would grow the set of
 sites on a dying pipeline.
 
-Build logs stay quiet: the theme silences Sass dependency-deprecation warnings,
-and its own stylesheets are kept deprecation-clean by a regression test. One
-side effect to know about: under Hugo's importer, everything but the entry
-stylesheet counts as a dependency, **including your site's own project Sass**,
-so its deprecation warnings are silenced too. To audit your own Sass for
-deprecated constructs, compile it directly with the `sass` CLI, or temporarily
-override `head-css.html` with `silenceDependencyDeprecations` unset.
+Build logs stay quiet: the theme silences Sass deprecation warnings from
+dependencies, which as a side effect covers your project's own Sass too. To
+audit your Sass for deprecated constructs, compile it directly with the `sass`
+CLI.
 
 ### Actions {#dart-sass-actions}
 
@@ -112,10 +109,11 @@ update in the [order of steps][]:
   export PATH=$PWD/dart-sass:$PATH
   ```
 
-- **Self-provisioned compilers**: use Dart Sass **1.95.0 or later** -- the theme
-  uses Sass's `if()` conditional syntax, which older releases can't parse.
-  Current npm releases of `sass-embedded` are well past this floor; for the
-  officially supported Dart Sass version, see the [official support policy][].
+- **Self-provisioned compilers**: use Dart Sass **1.95.0 or later**: the theme's
+  stylesheets use Sass's `if()` conditional syntax, which older releases can't
+  parse. Current npm releases of `sass-embedded` are well past this floor; for
+  the officially supported Dart Sass version, see the [official support
+  policy][].
 
 ### What to recheck after upgrading {#dart-sass-recheck}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -110,9 +110,9 @@ update in the [order of steps][]:
   ```
 
 - **Self-provisioned compilers**: use Dart Sass **1.95.0 or later**: the theme's
-  stylesheets use Sass's `if()` conditional syntax, which older releases can't
-  parse. Current npm releases of `sass-embedded` are well past this floor; for
-  the officially supported Dart Sass version, see the [official support
+  stylesheets rely on Sass's `if()` conditional syntax, which older releases
+  can't parse. Current npm releases of `sass-embedded` are well past this floor;
+  for the officially supported Dart Sass version, see the [official support
   policy][].
 
 ### What to recheck after upgrading {#dart-sass-recheck}

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -169,12 +169,10 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 
 - Fixed and documented footer copyright year handling. See the [footer copyright
   docs][] ([#2047][]).
-- Replaced deprecated Sass functions with their `sass:` module forms, and
-  silenced Sass dependency-deprecation warnings in site builds -- which covers a
-  site's own project Sass too; see the [release report][0.17.0-blog-dart-sass]
-  ([#2731][]).
 - **[Pinned the default Mermaid version][0.17.0-blog-mermaid]** to 11.16.1;
   pages previously loaded the CDN's `latest` at page load ([#2703][]).
+- Silenced Sass deprecation warnings in site builds, your project's own
+  included; see the [release report][0.17.0-blog-dart-sass] ([#2731][]).
 
 **For maintainers**:
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -171,7 +171,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   docs][] ([#2047][]).
 - **[Pinned the default Mermaid version][0.17.0-blog-mermaid]** to 11.16.1;
   pages previously loaded the CDN's `latest` at page load ([#2703][]).
-- Silenced Sass deprecation warnings in site builds, your project's own
+- Silenced Sass deprecation warnings in site builds, project style files
   included; see the [release report][0.17.0-blog-dart-sass] ([#2731][]).
 
 **For maintainers**:

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -169,6 +169,10 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 
 - Fixed and documented footer copyright year handling. See the [footer copyright
   docs][] ([#2047][]).
+- Replaced deprecated Sass functions with their `sass:` module forms, and
+  silenced Sass dependency-deprecation warnings in site builds -- which covers a
+  site's own project Sass too; see the [release report][0.17.0-blog-dart-sass]
+  ([#2731][]).
 - **[Pinned the default Mermaid version][0.17.0-blog-mermaid]** to 11.16.1;
   pages previously loaded the CDN's `latest` at page load ([#2703][]).
 
@@ -200,6 +204,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [#2714]: https://github.com/google/docsy/pull/2714
 [#2724]: https://github.com/google/docsy/pull/2724
 [#2726]: https://github.com/google/docsy/pull/2726
+[#2731]: https://github.com/google/docsy/pull/2731
 [0.17.0 release report]: /blog/2026/0.17.0/
 [0.17.0-blog-dart-sass]: /blog/2026/0.17.0/#dart-sass
 [0.17.0-blog-install]: /blog/2026/0.17.0/#install-command


### PR DESCRIPTION
Follow-up to #2731, clearing the 0.17.0 release post's last content hold (the post stays `draft: true`; the undraft is tag-time).

- **Warnings-expected clause** (replaces the post's TODO hold): build logs are quiet by default post-#2731, and project style files are silenced too (a custom `main.scss` entry stays first-party) -- so a quiet log is not a clean bill for a site's own Sass debt.
- **Dart Sass floor 1.74.0 → 1.95.0** (both stated floors): the parse floor for #2731's new `if()` conditional syntax; the old silencing-options rationale is superseded.
- **LibSass escape hatch removed** (kept anchor): #2731's `sass:` modules and new `if()` syntax break the documented three-file rollback (it no longer compiles; a head-css-only override still builds green but ships an unstyled site), so the section now states there is no LibSass fallback and points at Dart Sass's pure-JS embedded mode.
- **Changelog `#next`**: adds a #2731 line (dependency-deprecation silencing, project style files included).

