### PR TITLE
0.17.0 prep: artifacts refresh, one-home version pins, terminology sweep

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -828,7 +828,7 @@ https://main--docsydocs.netlify.app/project/build/,200,1782563367
 https://main--docsydocs.netlify.app/project/build/ci-cd/,200,1782498244
 https://main--docsydocs.netlify.app/project/build/git-repo/,200,1782498244
 https://main--docsydocs.netlify.app/project/design/,206,1787249523
-https://main--docsydocs.netlify.app/project/design/semantic-classes/,206,1787150440
+https://main--docsydocs.netlify.app/project/design/semantic-classes/,200,1787669024
 https://main--docsydocs.netlify.app/project/implementation/,200,1782563367
 https://main--docsydocs.netlify.app/project/implementation/scrollspy-patch/,200,1782498244
 https://main--docsydocs.netlify.app/project/repo/,200,1782563367

--- a/docsy.dev/config/_default/hugo.yaml
+++ b/docsy.dev/config/_default/hugo.yaml
@@ -190,6 +190,10 @@ module:
       sites: *sites
     - source: ../CONTRIBUTING.md
       target: content/project/repo/CONTRIBUTING.md
+    # Root package config, for docs that cite its pins (sass-embedded-version)
+    - source: ../package.json
+      target: data/package.json
+      sites: *sites
     # Tests
     # cSpell:ignore quang nguyen vinh therato
     - source: &bg-img content/en/background-pexels-quang-nguyen-vinh-222549-2131841.jpg

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -246,9 +246,9 @@ Hugo-module and `@docsy/theme` registry installs are unaffected.
 
 ## Default script-dependency versions pinned {#script-dep-pins}
 
-Docsy now pins the default versions of its CDN-loaded script dependencies
-instead of loading whatever `latest` resolves to on the CDN, so rendering no
-longer changes when an upstream major ships. Pinned in this release:
+Docsy now pins the default versions of its CDN-loaded script dependencies (see
+the table) instead of loading whatever `latest` resolves to on the CDN, so
+rendering no longer changes when an upstream major ships.
 
 | Dependency                         | Pinned version               | Loaded as                                     | Version param            |
 | ---------------------------------- | ---------------------------- | --------------------------------------------- | ------------------------ |

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -97,11 +97,13 @@ theme's default Sass pipeline.
 Provide Dart Sass in each environment that builds your site, before the theme
 update in the [order of steps][]:
 
-- Follow [Install Dart Sass][]: npm-based sites install the Docsy-tested
-  [`sass-embedded`][] version; for other setups, it links Hugo's installation
-  guide. GitHub Pages and Netlify CI builds are covered in the [deployment
-  docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]); if your build runs
-  through npm scripts, the `sass-embedded` dependency is all you need.
+- Follow [Install Dart Sass][]:
+  - **npm-based sites**: install the Docsy-tested [`sass-embedded`][] package
+    version. CI builds that run through npm scripts need nothing more; GitHub
+    Pages and Netlify setups are covered in the [deployment docs][] ([GitHub
+    Pages][gh-pages-deploy], [Netlify][]).
+  - **Other setups**: follow the guide's pointer to Hugo's Dart Sass
+    installation instructions.
 - Where your platform dictates a Dart Sass version of its own, it must be at
   least {{% param dartSassMinVersion %}}: the theme's stylesheets rely on Sass's
   new `if()` conditional syntax, which older releases can't parse. Only the

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -165,10 +165,8 @@ path is Dart Sass's planned [pure-JS embedded mode][dart-sass-2413].
 ## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
 
 Docsy's chrome markup is moving from Bootstrap utility and component classes to
-Docsy-owned `td-` [semantic classes][] over the coming releases. Breadcrumbs go
-first, and alone, by design: one small component settles the class contract and
-the migration pattern, and keeps this release's changes easy to absorb, before
-more of the chrome moves.
+Docsy-owned `td-` [semantic classes][] over the coming releases. In this
+release: breadcrumbs.
 
 ### Selector migration table
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -250,22 +250,19 @@ Docsy now pins the default versions of its CDN-loaded script dependencies
 instead of loading whatever `latest` resolves to on the CDN, so rendering no
 longer changes when an upstream major ships. Pinned in this release:
 
-- [Mermaid][mermaid-docs] {{% param mermaidVersion %}} (page-load script)
-- [KaTeX][katex-docs] {{% param katexVersion %}} (build-time stylesheet and
-  fonts, self-hosted)
-- [markmap-autoloader][markmap-docs] {{% param markmapVersion %}} (page-load
-  script)
-- [Redoc][redoc-docs] {{% param redocVersion %}} (page-load script for the
-  `redoc` shortcode)
+| Dependency                         | Pinned version               | Loaded as                                     | Version param            |
+| ---------------------------------- | ---------------------------- | --------------------------------------------- | ------------------------ |
+| [KaTeX][katex-docs]                | {{% param katexVersion %}}   | Build-time stylesheet and fonts (self-hosted) | `params.katex.version`   |
+| [markmap-autoloader][markmap-docs] | {{% param markmapVersion %}} | Page-load script                              | `params.markmap.version` |
+| [Mermaid][mermaid-docs]            | {{% param mermaidVersion %}} | Page-load script                              | `params.mermaid.version` |
+| [Redoc][redoc-docs]                | {{% param redocVersion %}}   | Page-load script (`redoc` shortcode)          | `params.redoc.version`   |
 
 ### Actions {#script-dep-pins-actions}
 
 **Applies if** you want a different version of one of these dependencies.
 
-- Set [`params.mermaid.version`][mermaid-docs],
-  [`params.katex.version`][katex-docs],
-  [`params.markmap.version`][markmap-docs], or
-  [`params.redoc.version`][redoc-docs] in your site config.
+- Set the dependency's version param (last column above) in your site config;
+  for details, see the dependency's Docsy docs (first column).
 
 ## Other notable changes
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -104,9 +104,7 @@ update in the [order of steps][]:
   npm install --save-dev sass-embedded@{{% param sassEmbeddedVersion %}}
   ```
 
-  The pinned version is the [officially supported][official support policy] one;
-  other releases meeting the {{% param dartSassMinVersion %}} floor (last bullet
-  below) are supported on a best-effort basis.
+  Docsy is tested with, and officially supports, only this pinned version.
 
 - **CI providers**: GitHub Actions and Netlify are covered in the [deployment
   docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]); if your build runs
@@ -115,10 +113,9 @@ update in the [order of steps][]:
   npm scripts): install the standalone binary and add it to `PATH`. The snippet
   below covers Linux x64 builders such as Cloudflare Pages; on other platforms,
   substitute the matching [dart-sass release asset][dart-sass releases]. Set
-  `DART_SASS_VERSION` as an environment variable in your project settings, to an
-  unprefixed version, {{% param dartSassMinVersion %}} or later (for example,
-  `{{% param sassEmbeddedVersion %}}`; snippet adapted from [Hugo's Cloudflare
-  hosting guide][cf-hosting]):
+  `DART_SASS_VERSION` as an environment variable in your project settings, to
+  `{{% param sassEmbeddedVersion %}}` (unprefixed), the Docsy-tested version
+  (snippet adapted from [Hugo's Cloudflare hosting guide][cf-hosting]):
 
   ```sh
   curl -fLJO https://github.com/sass/dart-sass/releases/download/$DART_SASS_VERSION/dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
@@ -126,11 +123,11 @@ update in the [order of steps][]:
   export PATH=$PWD/dart-sass:$PATH
   ```
 
-- **Self-provisioned compilers**: use Dart Sass
-  **{{% param dartSassMinVersion %}} or later**. The theme's stylesheets rely on
-  Sass's new `if()` conditional syntax, which older releases can't parse.
-  Current npm releases of `sass-embedded` are well past this floor; for the
-  officially supported Dart Sass version, see the [official support policy][].
+- **Self-provisioned compilers**: use the Docsy-tested Dart Sass version,
+  **{{% param sassEmbeddedVersion %}}**, per the [official support policy][].
+  Where your platform dictates another version, it must be at least
+  {{% param dartSassMinVersion %}}: the theme's stylesheets rely on Sass's new
+  `if()` conditional syntax, which older releases can't parse.
 
 ### What to recheck after upgrading {#dart-sass-recheck}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -14,6 +14,7 @@ body_class: release-highlights
 tags: [release, upgrade]
 params:
   hugoSupportedVersion: 0.164.0
+  sassEmbeddedVersion: 1.102.0
 ---
 
 <!-- markdownlint-disable descriptive-link-text no-space-in-emphasis -->
@@ -92,7 +93,7 @@ update in the [order of steps][]:
   your project root, per [Install Dart Sass][]:
 
   ```sh
-  npm install --save-dev sass-embedded@1.102.0
+  npm install --save-dev sass-embedded@{{% param sassEmbeddedVersion %}}
   ```
 
   The pinned version is the one this release is tested with; any release meeting
@@ -106,8 +107,9 @@ update in the [order of steps][]:
   below covers Linux x64 builders such as Cloudflare Pages; on other platforms,
   substitute the matching [dart-sass release asset][dart-sass releases]. Set
   `DART_SASS_VERSION` as an environment variable in your project settings, to an
-  unprefixed version, 1.95.0 or later (for example, `1.102.0`; snippet adapted
-  from [Hugo's Cloudflare hosting guide][cf-hosting]):
+  unprefixed version, 1.95.0 or later (for example,
+  `{{% param sassEmbeddedVersion %}}`; snippet adapted from [Hugo's Cloudflare
+  hosting guide][cf-hosting]):
 
   ```sh
   curl -fLJO https://github.com/sass/dart-sass/releases/download/$DART_SASS_VERSION/dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -5,7 +5,7 @@ date: 2026-08-19
 draft: true
 description: >-
   Docsy now builds with Dart Sass, so the sass CLI joins your build. This
-  release also debuts semantic classes in breadcrumbs, pins default script
+  release also moves breadcrumbs to semantic classes, pins default script
   versions, and renames the theme-dependencies install command.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
@@ -33,8 +33,9 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   moves off Hugo's deprecated embedded LibSass (one new build
   prerequisite)</span>
 - {{% _param FAS_LG tags info %}}
-  <span>**[Semantic classes](#semantic-classes)**: Docsy chrome starts getting
-  its own `td-` class names, beginning with breadcrumbs</span>
+  <span>**[Semantic classes](#semantic-classes)**: Docsy chrome markup starts
+  moving from Bootstrap to Docsy's own `td-` classes, beginning with
+  breadcrumbs</span>
 - {{% _param FAS_LG thumbtack warning %}}
   <span>**[Pinned script versions](#script-dep-pins)**: Mermaid, KaTeX, markmap,
   and Redoc no longer resolve from the CDN's `latest`</span>
@@ -45,8 +46,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
 
 - **[Dart Sass replaces LibSass](#dart-sass)**: the `sass` CLI becomes a build
   prerequisite
-- **[Semantic classes](#semantic-classes)**: breadcrumbs debut Docsy's own `td-`
-  chrome classes
+- **[Semantic classes](#semantic-classes)**: breadcrumb markup moves from
+  Bootstrap to `td-` classes
 - **Install and defaults**:
   - [Theme-dependencies install command renamed](#install-command)
   - [Default script-dependency versions pinned](#script-dep-pins): Mermaid,
@@ -164,8 +165,10 @@ path is Dart Sass's planned [pure-JS embedded mode][dart-sass-2413].
 ## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
 
 Docsy's chrome markup is moving from Bootstrap utility and component classes to
-Docsy-owned `td-` [semantic classes][] over the coming releases, and breadcrumbs
-go first.
+Docsy-owned `td-` [semantic classes][] over the coming releases. Breadcrumbs go
+first, and alone, by design: one small component settles the class contract and
+the migration pattern, and keeps this release's changes easy to absorb, before
+more of the chrome moves.
 
 ### Selector migration table
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -16,7 +16,6 @@ params:
   # Frozen at publication; until tag time, the release-prep refresh keeps
   # these aligned with the repo pins (package.json, theme/hugo.yaml).
   hugoSupportedVersion: 0.164.0
-  sassEmbeddedVersion: 1.102.0
   dartSassMinVersion: 1.95.0
   mermaidVersion: 11.17.0
   katexVersion: 0.18.4
@@ -98,37 +97,15 @@ theme's default Sass pipeline.
 Provide Dart Sass in each environment that builds your site, before the theme
 update in the [order of steps][]:
 
-- **Local and npm-managed builds**: install the [`sass-embedded`][] package from
-  your project root, per [Install Dart Sass][]:
-
-  ```sh
-  npm install --save-exact --save-dev sass-embedded@{{% param sassEmbeddedVersion %}}
-  ```
-
-  Docsy is tested with, and officially supports, only this pinned version.
-
-- **CI providers**: GitHub Actions and Netlify are covered in the [deployment
+- Follow [Install Dart Sass][]: npm-based sites install the Docsy-tested
+  [`sass-embedded`][] version; for other setups, it links Hugo's installation
+  guide. GitHub Pages and Netlify CI builds are covered in the [deployment
   docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]); if your build runs
-  through npm scripts, the `sass-embedded` dependency above is all you need.
-- **Cloudflare Pages** (and other providers where the build doesn't run through
-  npm scripts): install the standalone binary and add it to `PATH`. The snippet
-  below covers Linux x64 builders such as Cloudflare Pages; on other platforms,
-  substitute the matching [dart-sass release asset][dart-sass releases]. Set
-  `DART_SASS_VERSION` as an environment variable in your project settings, to
-  `{{% param sassEmbeddedVersion %}}` (unprefixed), the Docsy-tested version
-  (snippet adapted from [Hugo's Cloudflare hosting guide][cf-hosting]):
-
-  ```sh
-  curl -fLJO https://github.com/sass/dart-sass/releases/download/$DART_SASS_VERSION/dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
-  tar -xf dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
-  export PATH=$PWD/dart-sass:$PATH
-  ```
-
-- **Self-provisioned compilers**: use the Docsy-tested Dart Sass version,
-  **{{% param sassEmbeddedVersion %}}**, per the [official support policy][].
-  Where your platform dictates another version, it must be at least
-  {{% param dartSassMinVersion %}}: the theme's stylesheets rely on Sass's new
-  `if()` conditional syntax, which older releases can't parse.
+  through npm scripts, the `sass-embedded` dependency is all you need.
+- Where your platform dictates a Dart Sass version of its own, it must be at
+  least {{% param dartSassMinVersion %}}: the theme's stylesheets rely on Sass's
+  new `if()` conditional syntax, which older releases can't parse. Only the
+  Docsy-tested version is [officially supported][official support policy].
 
 ### What to recheck after upgrading {#dart-sass-recheck}
 
@@ -388,12 +365,10 @@ About this release:
   <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoSupportedVersion %}}>
 [`@docsy/theme`]: https://www.npmjs.com/package/@docsy/theme
 [`sass-embedded`]: https://www.npmjs.com/package/sass-embedded
-[cf-hosting]: https://gohugo.io/host-and-deploy/host-on-cloudflare/
 [check]: /docs/update/#check
 [CL@0.17.0]: /project/about/changelog/#next
 [compare-0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main
 [Dart Sass]: https://sass-lang.com/dart-sass/
-[dart-sass releases]: https://github.com/sass/dart-sass/releases
 [dart-sass-2413]: https://github.com/sass/dart-sass/pull/2413
 [deployment docs]: /docs/deployment/
 [footer copyright docs]: /docs/content/lookandfeel/#footer-copyright

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -146,10 +146,9 @@ the BSDs).
 There is no way to keep building this release with Hugo's embedded LibSass: the
 theme's stylesheets now use `sass:` modules and Sass's new `if()` conditional
 syntax (`if(condition: value; else: value)`), which LibSass does not implement.
-A 0.16-style rollback through theme-file overrides now fails to compile, and
-overriding `head-css.html` alone builds green but ships an unstyled site. For
-binary-less platforms, the durable path is Dart Sass's planned [pure-JS embedded
-mode][dart-sass-2413].
+In particular, overriding `head-css.html` to restore a LibSass `toCSS` call
+builds green but ships an unstyled site. For binary-less platforms, the durable
+path is Dart Sass's planned [pure-JS embedded mode][dart-sass-2413].
 
 ## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -102,7 +102,7 @@ update in the [order of steps][]:
   your project root, per [Install Dart Sass][]:
 
   ```sh
-  npm install --save-dev sass-embedded@{{% param sassEmbeddedVersion %}}
+  npm install --save-exact --save-dev sass-embedded@{{% param sassEmbeddedVersion %}}
   ```
 
   Docsy is tested with, and officially supports, only this pinned version.

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -149,15 +149,15 @@ release: breadcrumbs.
 
 ### Selector migration table
 
-| 0.16 emitted                 | 0.17 emitted                                   |
+| 0.16 selector                | 0.17 selector                                  |
 | ---------------------------- | ---------------------------------------------- |
 | `ol.breadcrumb`              | `ol.td-breadcrumbs__list`                      |
 | `li.breadcrumb-item`         | `li.td-breadcrumbs__item`                      |
 | `li.breadcrumb-item.active`  | `li.td-breadcrumbs__item[aria-current="page"]` |
 | `nav.td-breadcrumbs__single` | `nav.td-breadcrumbs--single`                   |
 
-Unchanged: the `td-breadcrumbs` class on the `<nav>` element. The `active` class
-is no longer emitted: state styling keys on the ARIA-mandated
+Unchanged: the `td-breadcrumbs` class on the `<nav>` element. The markup no
+longer carries an `active` class: state styling keys on the ARIA-mandated
 `aria-current="page"` attribute, so visual state and accessibility state can't
 drift apart.
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -13,8 +13,16 @@ author: >-
 body_class: release-highlights
 tags: [release, upgrade]
 params:
+  # Frozen at publication; until tag time, the release-prep refresh keeps
+  # these aligned with the repo pins (package.json, theme/hugo.yaml).
   hugoSupportedVersion: 0.164.0
   sassEmbeddedVersion: 1.102.0
+  dartSassMinVersion: 1.95.0
+  mermaidVersion: 11.17.0
+  katexVersion: 0.18.4
+  markmapVersion: 0.18.12
+  redocVersion: 2.5.3
+cSpell:ignore: autoloader markmap linux chromastyles libsass katex
 ---
 
 <!-- markdownlint-disable descriptive-link-text no-space-in-emphasis -->
@@ -96,8 +104,9 @@ update in the [order of steps][]:
   npm install --save-dev sass-embedded@{{% param sassEmbeddedVersion %}}
   ```
 
-  The pinned version is the one this release is tested with; any release meeting
-  the 1.95.0 floor (last bullet below) works.
+  The pinned version is the [officially supported][official support policy] one;
+  other releases meeting the {{% param dartSassMinVersion %}} floor (last bullet
+  below) are supported on a best-effort basis.
 
 - **CI providers**: GitHub Actions and Netlify are covered in the [deployment
   docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]); if your build runs
@@ -107,7 +116,7 @@ update in the [order of steps][]:
   below covers Linux x64 builders such as Cloudflare Pages; on other platforms,
   substitute the matching [dart-sass release asset][dart-sass releases]. Set
   `DART_SASS_VERSION` as an environment variable in your project settings, to an
-  unprefixed version, 1.95.0 or later (for example,
+  unprefixed version, {{% param dartSassMinVersion %}} or later (for example,
   `{{% param sassEmbeddedVersion %}}`; snippet adapted from [Hugo's Cloudflare
   hosting guide][cf-hosting]):
 
@@ -117,11 +126,11 @@ update in the [order of steps][]:
   export PATH=$PWD/dart-sass:$PATH
   ```
 
-- **Self-provisioned compilers**: use Dart Sass **1.95.0 or later**. The theme's
-  stylesheets rely on Sass's new `if()` conditional syntax, which older releases
-  can't parse. Current npm releases of `sass-embedded` are well past this floor;
-  for the officially supported Dart Sass version, see the [official support
-  policy][].
+- **Self-provisioned compilers**: use Dart Sass
+  **{{% param dartSassMinVersion %}} or later**. The theme's stylesheets rely on
+  Sass's new `if()` conditional syntax, which older releases can't parse.
+  Current npm releases of `sass-embedded` are well past this floor; for the
+  officially supported Dart Sass version, see the [official support policy][].
 
 ### What to recheck after upgrading {#dart-sass-recheck}
 
@@ -244,10 +253,13 @@ Docsy now pins the default versions of its CDN-loaded script dependencies
 instead of loading whatever `latest` resolves to on the CDN, so rendering no
 longer changes when an upstream major ships. Pinned in this release:
 
-- [Mermaid][mermaid-docs] 11.17.0 (page-load script)
-- [KaTeX][katex-docs] 0.18.4 (build-time stylesheet and fonts, self-hosted)
-- [markmap-autoloader][markmap-docs] 0.18.12 (page-load script)
-- [Redoc][redoc-docs] 2.5.3 (page-load script for the `redoc` shortcode)
+- [Mermaid][mermaid-docs] {{% param mermaidVersion %}} (page-load script)
+- [KaTeX][katex-docs] {{% param katexVersion %}} (build-time stylesheet and
+  fonts, self-hosted)
+- [markmap-autoloader][markmap-docs] {{% param markmapVersion %}} (page-load
+  script)
+- [Redoc][redoc-docs] {{% param redocVersion %}} (page-load script for the
+  `redoc` shortcode)
 
 ### Actions {#script-dep-pins-actions}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -92,8 +92,11 @@ update in the [order of steps][]:
   your project root, per [Install Dart Sass][]:
 
   ```sh
-  npm install --save-dev sass-embedded
+  npm install --save-dev sass-embedded@1.102.0
   ```
+
+  The pinned version is the one this release is tested with; any release meeting
+  the 1.95.0 floor (last bullet below) works.
 
 - **CI providers**: GitHub Actions and Netlify are covered in the [deployment
   docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]); if your build runs
@@ -239,7 +242,7 @@ Docsy now pins the default versions of its CDN-loaded script dependencies
 instead of loading whatever `latest` resolves to on the CDN, so rendering no
 longer changes when an upstream major ships. Pinned in this release:
 
-- [Mermaid][mermaid-docs] 11.16.1 (page-load script)
+- [Mermaid][mermaid-docs] 11.17.0 (page-load script)
 - [KaTeX][katex-docs] 0.18.4 (build-time stylesheet and fonts, self-hosted)
 - [markmap-autoloader][markmap-docs] 0.18.12 (page-load script)
 - [Redoc][redoc-docs] 2.5.3 (page-load script for the `redoc` shortcode)

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -142,7 +142,7 @@ via `layouts/index.llms.txt`. You can override these defaults at several levels:
   `layouts/` in your project to tailor Markdown output for specific [Hugo
   kinds][].
 - **Per shortcode** — Add [output-format-specific shortcode templates][sof] to
-  project-local shortcodes so they emit Markdown-friendly content when
+  project-local shortcodes so they render Markdown-friendly content when
   appropriate. For example, this site's [readfile.markdown.md][] is the
   Markdown-output variant of the theme's `readfile` shortcode.
 - **Per page** — Provide page-specific content or structure for high-value pages

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -341,13 +341,13 @@ $td-google-font-family: 'Roboto:300,300i,400,400i,700,700i';
 
 ## Semantic classes
 
-Chrome components that have adopted Docsy's **semantic classes** emit
-theme-owned `td-` classes, with component state carried by semantic attributes
-(such as `aria-current="page"`) rather than state classes. These selectors are
-part of Docsy's [public customization surface][public]; how the theme styles
-them is [private][] and can change in any release. Each such component's own
-documentation describes the selectors it emits: see, for example, [breadcrumb
-navigation][breadcrumb-styling].
+Chrome components that have adopted Docsy's **semantic classes** render markup
+carrying theme-owned `td-` classes, with component state keyed on semantic
+attributes (such as `aria-current="page"`) rather than state classes. These
+selectors are part of Docsy's [public customization surface][public]; how the
+theme styles them is [private][] and can change in any release. Each such
+component's own documentation describes the selectors it exposes: see, for
+example, [breadcrumb navigation][breadcrumb-styling].
 
 Selectors of components that haven't adopted semantic classes (a mix of
 Bootstrap classes and pre-existing `td-` names) can change; [upgrade posts][]

--- a/docsy.dev/content/en/docs/content/navigation.md
+++ b/docsy.dev/content/en/docs/content/navigation.md
@@ -737,13 +737,13 @@ cascade:
 
 ### Styling {#breadcrumb-styling}
 
-The breadcrumb emits Docsy [semantic classes][]: `td-breadcrumbs` on the
-`<nav>`, containing a `td-breadcrumbs__list` of `td-breadcrumbs__item` entries,
-with `aria-current="page"` marking the current page's item. On single-element
-lists, the `<nav>` also carries `td-breadcrumbs--single` (hidden by default; see
-the override above). Target these classes and the attribute to restyle it. In
-taxonomy results pages, breadcrumbs render without ARIA attributes: no
-current-item styling applies in that summary context.
+The breadcrumb markup carries Docsy [semantic classes][]: `td-breadcrumbs` on
+the `<nav>`, containing a `td-breadcrumbs__list` of `td-breadcrumbs__item`
+entries, with `aria-current="page"` marking the current page's item. On
+single-element lists, the `<nav>` also carries `td-breadcrumbs--single` (hidden
+by default; see the override above). Target these classes and the attribute to
+restyle it. In taxonomy results pages, breadcrumbs render without ARIA
+attributes: no current-item styling applies in that summary context.
 
 [semantic classes]: /docs/content/lookandfeel/#semantic-classes
 

--- a/docsy.dev/content/en/docs/deployment/chrome.md
+++ b/docsy.dev/content/en/docs/deployment/chrome.md
@@ -1,21 +1,21 @@
 ---
 title: Chrome build modes
 description: >-
-  Choose how Docsy emits repeated navigation chrome: on every page, or shared
+  Choose how Docsy renders repeated navigation chrome: on every page, or shared
   across pages and restored client-side for smaller, faster-to-check output.
 cSpell:ignore: pagelinks
 ---
 
-A docs site re-emits the same auto-generated _[chrome][]_ &mdash; the navbar,
+A docs site repeats the same auto-generated _[chrome][]_ &mdash; the navbar,
 footer, and left-nav &mdash; on _every_ page, even though those regions are
 usually identical site-wide.
 
 Use the `td.chrome` parameter to select one of two **build modes**:
 
-- **`full`** (default) emits each page's chrome on the page itself, ready for
+- **`full`** (default) renders each page's chrome on the page itself, ready for
   any client. Any `td.chrome` value other than `shared` is treated as `full`, so
   a typo fails safe.
-- **`shared`** emits each region on just **one** _donor_ page per locale and
+- **`shared`** renders each region on just **one** _donor_ page per locale and
   restores it on the other pages in the browser with a small script. The output
   stays lean, while readers still get the full navigation once the page loads.
 
@@ -70,7 +70,7 @@ link.
 > Two known cases:
 >
 > - A navbar [version menu][version-menu] with `version_menu_pagelinks` enabled
->   emits per-page links that the single kept navbar won't cover yet.
+>   renders per-page links that the single kept navbar won't cover yet.
 > - A [scoped sidebar][sidebar-root] (`sidebar_root_for`) restores the right
 >   links and active state, but its re-rooted subtree can differ structurally
 >   from a full build (an extra wrapper element, deeper `ul` nesting). The

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -80,10 +80,11 @@ Hugo-module setups.
 
 Hugo compiles Docsy's [SCSS][] using the [Dart Sass][] transpiler, which Hugo
 looks up as the `sass` CLI on its `PATH`. For npm-based sites, install the
-[`sass-embedded`][sass-embedded] package from your project root:
+[`sass-embedded`][sass-embedded] package from your project root, at the version
+Docsy is tested with:
 
 ```bash
-npm install --save-dev sass-embedded
+npm install --save-exact --save-dev sass-embedded@{{% sass-embedded-version %}}
 ```
 
 The `sass` CLI is then on `PATH` for every npm-run script, so run Hugo through

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -157,8 +157,8 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   [Install Dart Sass][]. Some Sass-computed colors in the built CSS change
   serialization form, with no visible rendering change ([#2724][]).
 
-- Changed breadcrumbs to emit Docsy [semantic classes][] with state keyed on
-  `aria-current="page"` instead of an `active` class. If you customized
+- Changed breadcrumb markup to carry Docsy [semantic classes][] with state keyed
+  on `aria-current="page"` instead of an `active` class. If you customized
   breadcrumbs, see the [selector migration table][] ([#2722][]).
 - Renamed the theme-dependencies install command that clone, submodule, and
   GitHub-npm installs run: `npm run postinstall` → `npm run install:theme-deps`;

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -39,6 +39,14 @@ restating them:
 - **Test and code comments**: implementation rationale and regression
   background.
 
+**Version values** follow the same ownership rule. An evergreen doc that cites a
+pinned or supported version reads it from the pin's source of truth: a config
+param (for example, `params.mermaid.version`), or a repo manifest surfaced
+through a data mount and shortcode (`sass-embedded-version` reads the root
+`package.json` pin), so the page can't drift from the pin. A dated post freezes
+its release-specific versions as page front-matter params, and delegates install
+and override mechanics to the docs instead of restating commands.
+
 ## PR descriptions
 
 Generally speaking, a PR opening comment should be a Markdown list that explains

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -362,13 +362,10 @@ If not adjust accordingly.
       npm run test:smoke
       ```
 
-    - **Test consumer sites**:
-      - Run the [consumer-site test procedure](#consumer-site-test) over
-        selected sites listed below.
-      - Sites to test, ideally covering each install mode:
-        - Hugo module: [docsy-example][]
-        - npm package: [docsy-starter][]
-        - Git submodule: [opentelemetry.io][] or another large production site
+    - **Test consumer sites**: run the
+      [consumer-site test procedure](#consumer-site-test) over its validation
+      schedule's pre-release site(s); the schedule assigns the other install
+      modes their own later validation points.
 
 9.  **Get PR approved and merged**.
 
@@ -713,7 +710,26 @@ before any further changes are merged into the `main` branch:
 
 5. **Get PR approved and merged**.
 
+6. **Validate the published release from [docsy-starter][]** (npm package mode),
+   per the [consumer-site test procedure](#consumer-site-test), and follow with
+   the starter's own Docsy-update PR. Post-tag; doesn't block `main`.
+
 ## Consumer-site test procedure {#consumer-site-test}
+
+**Validation schedule** — each install mode has a known consumer that validates
+the release at its natural point in the cycle:
+
+- **Pre-release**, on the release-PR branch
+  ([Publishing a release](#publishing-a-release), step 8): [opentelemetry.io][]
+  or another large production **git submodule** site.
+- **At the [Docsy example release](#docsy-example-release)**: [docsy-example][],
+  the **Hugo module** template.
+- **Post-tag**, against the published release
+  ([post-release followup](#post-docsy-release-followup)): [docsy-starter][],
+  the **npm package** mode.
+
+Track run outcomes in the release-prep audit's working doc; report guide gaps as
+feedback on the release post (step 3 below doubles as its dry run).
 
 To test a Docsy branch or release from a consumer site, for each site:
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -759,7 +759,7 @@ To test a Docsy branch or release from a consumer site, for each site:
    preview:
    - Confirm each **page** renders with intact chrome, styles, and favicons:
      - Home page: also confirm that the `generator` meta element reports the
-       expected Hugo version (Docsy's version isn't emitted)
+       expected Hugo version (Docsy's version isn't included)
      - Docs landing page, and a random docs page
      - Blog landing page and a random blog post, when the site has a blog
      - Some other random page

--- a/docsy.dev/layouts/_shortcodes/sass-embedded-version.html
+++ b/docsy.dev/layouts/_shortcodes/sass-embedded-version.html
@@ -1,0 +1,5 @@
+{{ with index site.Data.package.devDependencies "sass-embedded" -}}
+  {{ . -}}
+{{ else -}}
+  {{ errorf "%s: sass-embedded pin not found in the root package.json data mount" .Position -}}
+{{ end -}}

--- a/docsy.dev/layouts/_shortcodes/sass-embedded-version.html
+++ b/docsy.dev/layouts/_shortcodes/sass-embedded-version.html
@@ -1,4 +1,4 @@
-{{ with index site.Data.package.devDependencies "sass-embedded" -}}
+{{ with index hugo.Data.package.devDependencies "sass-embedded" -}}
   {{ . -}}
 {{ else -}}
   {{ errorf "%s: sass-embedded pin not found in the root package.json data mount" .Position -}}

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,7 +6,7 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
-- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy now builds with Dart Sass, so the sass CLI joins your build. This release also debuts semantic classes in breadcrumbs, pins default script versions, and renames the theme-dependencies install command.
+- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy now builds with Dart Sass, so the sass CLI joins your build. This release also moves breadcrumbs to semantic classes, pins default script versions, and renames the theme-dependencies install command.
 - [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Docsy is now on npm as @docsy/theme. This release also moves the theme into theme/, raises the Hugo minimum, and drops its default favicons in favor of discovery, each with upgrade actions.
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/): What changed in Hugo 0.158.0 through 0.164.x for Docsy sites: breaking changes, deprecations, security fixes, and known regressions, with per-version upgrade actions.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.


### PR DESCRIPTION
- Contributes to #2691
- **Refresh through the post-groom pin merges** (#2736, #2738, #2735): coverage audit walked; only the release post needed edits. Also folds in the wording refinement stranded from #2734's review.
- **One home for version values**: the docs' `sass-embedded` install command now reads the repo pin (root `package.json` data mount + a tiny shortcode) and saves exact; the post freezes its remaining release-specific versions as page params and presents the script-dependency pins as a name-sorted table. Rule recorded in maintainer notes, Content placement.
- **The post delegates Dart Sass install mechanics to the docs**, dropping its per-provider snippets (Docsy documents the main path; Hugo and Dart Sass docs own provider mechanics); it keeps only the release-specific compatibility floor.
- **Consumer-validation schedule** in maintainer notes: which known consumer validates each install mode, and when (pre-release, example release, post-tag); the release-PR test step now defers to it.
- **Terminology sweep**: reader-facing "emit" becomes render/carry/expose for markup, classes, and selectors; "emit" stays for compilers, warnings, and events.
- Two cross-model adversarial review rounds: r1 found one Low (fixed in-branch), r2 clean.
- **Previews**:
  - https://deploy-preview-2739--docsydocs.netlify.app/blog/2026/0.17.0/
  - https://deploy-preview-2739--docsydocs.netlify.app/docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass
  - https://deploy-preview-2739--docsydocs.netlify.app/project/about/maintainer-notes/#consumer-site-test
