### PR TITLE
afdocs: bump to 0.19, migrate config, refresh scorecard

### DIFF
--- a/docsy.dev/agent-docs.config.yml
+++ b/docsy.dev/agent-docs.config.yml
@@ -53,6 +53,6 @@ checks:
 #     pass: 50000
 #     fail: 100000
 options:
-  # Deterministic sampling keeps the committed scorecard artifact reproducible
-  # across runs (random sampling shifts scores by a few points per run).
+  # Deterministic sampling keeps the sampled page set, and with it the scores,
+  # stable across runs (random sampling shifts scores by a few points per run).
   samplingStrategy: deterministic

--- a/docsy.dev/agent-docs.config.yml
+++ b/docsy.dev/agent-docs.config.yml
@@ -9,7 +9,8 @@ checks:
   - llms-txt-size
   - llms-txt-links-resolve
   - llms-txt-links-markdown
-  - llms-txt-directive
+  - llms-txt-directive-html
+  - llms-txt-directive-md
 
   # --- Markdown Availability ---
   - markdown-url-support
@@ -19,7 +20,7 @@ checks:
   - rendering-strategy
   - page-size-markdown
   - page-size-html
-  # - content-start-position
+  - content-start-position
 
   # --- Content Structure ---
   - tabbed-content-serialization
@@ -31,8 +32,8 @@ checks:
   - redirect-behavior
 
   # --- Observability and Content Health ---
-  # - llms-txt-freshness
-  # - markdown-content-parity
+  - llms-txt-coverage
+  - markdown-content-parity
   - cache-header-hygiene
 
   # --- Authentication and Access ---
@@ -48,3 +49,24 @@ checks:
 #   thresholds:
 #     pass: 50000
 #     fail: 100000
+options:
+  # Deterministic sampling keeps the committed scorecard artifact reproducible
+  # across runs (random sampling shifts scores by a few points per run).
+  samplingStrategy: deterministic
+  # llms-txt-coverage: the site's llms.txt is deliberately curated (it indexes
+  # sections, not every page), so run the check as informational (thresholds 0)
+  # per https://afdocs.dev/checks/observability.html#llms-txt-coverage. The
+  # exclusions keep the reported coverage rate meaningful by removing
+  # non-documentation pages (test fixtures, taxonomy terms) from the
+  # denominator.
+  coveragePassThreshold: 0
+  coverageWarnThreshold: 0
+  coverageExclusions:
+    - /tests/**
+    - /tags/**
+    - /categories/**
+  # markdown-content-parity: strip theme-generated page chrome that is
+  # intentionally HTML-only before comparing formats.
+  parityExclusions:
+    - .td-byline
+    - .td-page-meta__lastmod

--- a/docsy.dev/agent-docs.config.yml
+++ b/docsy.dev/agent-docs.config.yml
@@ -45,7 +45,7 @@ checks:
 
 # options:
 #   maxLinksToTest: 50
-#   samplingStrategy: random # random | deterministic | none
+#   samplingStrategy: random # random | deterministic | curated | none
 #   maxConcurrency: 3
 #   requestDelay: 200
 #   requestTimeout: 30000

--- a/docsy.dev/agent-docs.config.yml
+++ b/docsy.dev/agent-docs.config.yml
@@ -32,8 +32,11 @@ checks:
   - redirect-behavior
 
   # --- Observability and Content Health ---
-  - llms-txt-coverage
-  - markdown-content-parity
+  # Disabled by choice: llms.txt is a deliberately curated section index, so
+  # coverage vs the sitemap isn't the goal; parity flags mostly non-actionable
+  # diffs for this site (code-fence/tab segmentation artifacts).
+  # - llms-txt-coverage
+  # - markdown-content-parity
   - cache-header-hygiene
 
   # --- Authentication and Access ---
@@ -53,20 +56,3 @@ options:
   # Deterministic sampling keeps the committed scorecard artifact reproducible
   # across runs (random sampling shifts scores by a few points per run).
   samplingStrategy: deterministic
-  # llms-txt-coverage: the site's llms.txt is deliberately curated (it indexes
-  # sections, not every page), so run the check as informational (thresholds 0)
-  # per https://afdocs.dev/checks/observability.html#llms-txt-coverage. The
-  # exclusions keep the reported coverage rate meaningful by removing
-  # non-documentation pages (test fixtures, taxonomy terms) from the
-  # denominator.
-  coveragePassThreshold: 0
-  coverageWarnThreshold: 0
-  coverageExclusions:
-    - /tests/**
-    - /tags/**
-    - /categories/**
-  # markdown-content-parity: strip theme-generated page chrome that is
-  # intentionally HTML-only before comparing formats.
-  parityExclusions:
-    - .td-byline
-    - .td-page-meta__lastmod

--- a/docsy.dev/content/en/docs/content/agent-support/afdocs-scorecard.txt
+++ b/docsy.dev/content/en/docs/content/agent-support/afdocs-scorecard.txt
@@ -1,54 +1,67 @@
-Running in docsy.dev...
 
 Agent-Friendly Docs Scorecard
 ==============================
 
-http://localhost:1313 · 4/26/2026, 5:43:59 AM
+http://localhost:1313 · 8/25/2026, 9:15:07 AM
 
-  Overall Score: 100 / 100 (A+)
+  Overall Score: 85 / 100 (B)
 
   Category Scores:
-    Content Discoverability              100 / 100 (A+)
-    Markdown Availability                100 / 100 (A+)
-    Page Size and Truncation Risk        100 / 100 (A+)
+    Content Discoverability               85 / 100 (B)
+    Markdown Availability                 57 / 100 (F)
+    Page Size and Truncation Risk         93 / 100 (A)
     Content Structure                    100 / 100 (A+)
     URL Stability and Redirects          100 / 100 (A+)
-    Observability and Content Health     100 / 100 (A+)
+    Observability and Content Health      48 / 100 (F)
     Authentication and Access            100 / 100 (A+)
+
+  Interaction Diagnostics:
+    [!] Your site serves markdown at .md URLs, but agents have no way to discover this
+        Your site serves markdown at .md URLs, but agents have no way to discover this. No agent-facing directive points to your llms.txt, and the server does not support content negotiation. Most agents will default to the HTML path and never benefit from your markdown support.
+
+        Fix: Add a directive near the top of each docs page pointing to your llms.txt, and implement content negotiation for Accept: text/markdown. The directive is the primary discovery mechanism (it reaches all agents); content negotiation provides a fast path for agents that request markdown by default.
 
   Check Results:
 
     Content Discoverability
-      PASS  llms-txt-exists                llms.txt found at 1 location(s)
+      PASS  llms-txt-exists                llms.txt found at http://localhost:1313/llms.txt
       PASS  llms-txt-valid                 llms.txt follows the proposed structure (H1, blockquote, heading-delimited link sections)
-      PASS  llms-txt-size                  llms.txt is 1,131 characters (under 50,000 threshold)
+      PASS  llms-txt-size                  llms.txt is 1,129 characters (under 50,000 threshold)
       PASS  llms-txt-links-resolve         All 13 same-origin links resolve (13 total links)
       PASS  llms-txt-links-markdown        13/13 same-origin links point to markdown content (100%)
-      PASS  llms-txt-directive             llms.txt directive found in all 13 pages, near the top of content
+      WARN  llms-txt-directive-html        llms.txt directive found in HTML of 2 of 50 sampled pages, but buried deep in the page (past 50%)
+            Fix: An llms.txt directive was found in the HTML of some pages but is missing from others, or is buried deep in the page. Ensure the directive appears near the top of every documentation page.
+      PASS  llms-txt-directive-md          llms.txt directive found in markdown of all 45 sampled pages, near the top of content; 5 had no markdown version
 
     Markdown Availability
-      PASS  markdown-url-support           13/13 pages support .md URLs (100%)
-      PASS  content-negotiation            13/13 pages support content negotiation (100%)
+      PASS  markdown-url-support           45/50 sampled pages support .md URLs (90%)
+      FAIL  content-negotiation            Server ignores Accept: text/markdown header (0/50 sampled pages return markdown)
+            Fix: Your server ignores Accept: text/markdown and returns HTML. Some agents (Claude Code, Cursor, OpenCode) request markdown this way. Configure your server to honor content negotiation.
 
     Page Size and Truncation Risk
-      PASS  rendering-strategy             All 13 pages contain server-rendered content
-      PASS  page-size-markdown             All 13 pages under 50K chars (median 2K, max 9K)
-      PASS  page-size-html                 All 13 pages convert under 50K chars (median 2K, 0% boilerplate)
+      PASS  rendering-strategy             All 50 sampled pages contain server-rendered content
+      PASS  page-size-markdown             All 45 pages under 50K chars (median 4K, max 47K)
+      PASS  page-size-html                 All 50 sampled pages under 50K chars (median 54K HTML → 9K markdown (81% boilerplate))
+      FAIL  content-start-position         12 of 50 sampled pages have content starting past 50% (worst 100%)
+            Fix: 12 of 50 pages have content starting past 50% of the converted output. Agents may never see the documentation content. Reduce navigation, breadcrumb, and sidebar markup that precedes the content area.
 
     Content Structure
-      PASS  tabbed-content-serialization   No tabbed content detected across 13 pages
-      PASS  section-header-quality         No tabbed content found; header quality check not applicable
-      PASS  markdown-code-fence-validity   All 1 code fences properly closed across 14 pages
+      PASS  tabbed-content-serialization   8 tab group(s) across 7 of 50 sampled pages; all serialize under 50K chars
+      SKIP  section-header-quality         7 page(s) with tabs found, but no section headers inside tab panels to evaluate
+      PASS  markdown-code-fence-validity   All 157 code fences properly closed across 46 pages
 
     URL Stability and Redirects
-      PASS  http-status-codes              All 13 pages return proper error codes for bad URLs
-      PASS  redirect-behavior              No redirects detected across 13 pages
+      PASS  http-status-codes              All 50 sampled pages return proper error codes for bad URLs
+      PASS  redirect-behavior              No redirects detected across 50 sampled pages
 
     Observability and Content Health
-      PASS  cache-header-hygiene           All 14 endpoints have appropriate cache headers
+      PASS  llms-txt-coverage              llms.txt covers 16% of 62 sitemap doc pages; 1 llms.txt links not in sitemap (may indicate stale links or incomplete sitemap)
+      FAIL  markdown-content-parity        16 of 45 pages have substantive content differences between markdown and HTML (avg 14% missing)
+            Fix: 16 pages have substantive content differences between markdown and HTML (avg 14% missing). If unintentional, agents are getting outdated content; regenerate markdown from source or fix the build pipeline. If intentional (audience segmentation), add data-markdown-ignore to human-only HTML elements, or adjust thresholds with --parity-pass-threshold/--parity-warn-threshold.
+      PASS  cache-header-hygiene           All 51 endpoints have appropriate cache headers
 
     Authentication and Access
-      PASS  auth-gate-detection            All 13 pages are publicly accessible
+      PASS  auth-gate-detection            All 50 sampled pages are publicly accessible
       SKIP  auth-alternative-access        All docs pages are publicly accessible; no alternative access paths needed
 
 Full spec: https://agentdocsspec.com/spec/

--- a/docsy.dev/content/en/docs/content/agent-support/afdocs-scorecard.txt
+++ b/docsy.dev/content/en/docs/content/agent-support/afdocs-scorecard.txt
@@ -1,8 +1,7 @@
-
 Agent-Friendly Docs Scorecard
 ==============================
 
-http://localhost:1313 · 8/25/2026, 9:46:47 AM
+http://localhost:1313 · 8/25/2026, 2:24:31 PM
 
   Overall Score: 88 / 100 (B)
 
@@ -48,7 +47,7 @@ http://localhost:1313 · 8/25/2026, 9:46:47 AM
     Content Structure
       PASS  tabbed-content-serialization   8 tab group(s) across 7 of 50 sampled pages; all serialize under 50K chars
       SKIP  section-header-quality         7 page(s) with tabs found, but no section headers inside tab panels to evaluate
-      PASS  markdown-code-fence-validity   All 157 code fences properly closed across 46 pages
+      PASS  markdown-code-fence-validity   All 156 code fences properly closed across 46 pages
 
     URL Stability and Redirects
       PASS  http-status-codes              All 50 sampled pages return proper error codes for bad URLs
@@ -62,4 +61,3 @@ http://localhost:1313 · 8/25/2026, 9:46:47 AM
       SKIP  auth-alternative-access        All docs pages are publicly accessible; no alternative access paths needed
 
 Full spec: https://agentdocsspec.com/spec/
-

--- a/docsy.dev/content/en/docs/content/agent-support/afdocs-scorecard.txt
+++ b/docsy.dev/content/en/docs/content/agent-support/afdocs-scorecard.txt
@@ -2,9 +2,9 @@
 Agent-Friendly Docs Scorecard
 ==============================
 
-http://localhost:1313 · 8/25/2026, 9:15:07 AM
+http://localhost:1313 · 8/25/2026, 9:46:47 AM
 
-  Overall Score: 85 / 100 (B)
+  Overall Score: 88 / 100 (B)
 
   Category Scores:
     Content Discoverability               85 / 100 (B)
@@ -12,7 +12,7 @@ http://localhost:1313 · 8/25/2026, 9:15:07 AM
     Page Size and Truncation Risk         93 / 100 (A)
     Content Structure                    100 / 100 (A+)
     URL Stability and Redirects          100 / 100 (A+)
-    Observability and Content Health      48 / 100 (F)
+    Observability and Content Health     100 / 100 (A+)
     Authentication and Access            100 / 100 (A+)
 
   Interaction Diagnostics:
@@ -55,9 +55,6 @@ http://localhost:1313 · 8/25/2026, 9:15:07 AM
       PASS  redirect-behavior              No redirects detected across 50 sampled pages
 
     Observability and Content Health
-      PASS  llms-txt-coverage              llms.txt covers 16% of 62 sitemap doc pages; 1 llms.txt links not in sitemap (may indicate stale links or incomplete sitemap)
-      FAIL  markdown-content-parity        16 of 45 pages have substantive content differences between markdown and HTML (avg 14% missing)
-            Fix: 16 pages have substantive content differences between markdown and HTML (avg 14% missing). If unintentional, agents are getting outdated content; regenerate markdown from source or fix the build pipeline. If intentional (audience segmentation), add data-markdown-ignore to human-only HTML elements, or adjust thresholds with --parity-pass-threshold/--parity-warn-threshold.
       PASS  cache-header-hygiene           All 51 endpoints have appropriate cache headers
 
     Authentication and Access

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -154,21 +154,17 @@ agent-support goals, including Markdown URLs, llms.txt, and related categories.
 
 ### Scorecard examples
 
-For scorecard examples, see:
+For scorecard examples, see the [OpenTelemetry agent score][] online report, and
+the AFDocs scorecard for this site:
 
-- [OpenTelemetry agent score][] online report
+<details>
+<summary><code>docsy.dev</code> scorecard</summary>
 
-- An AFDocs scorecard for this site:
+The gaps reported in this scorecard are known, and are tracked under [#2614][].
 
-  <details>
-  <summary><code>docsy.dev</code> scorecard</summary>
+{{< readfile file="afdocs-scorecard.txt" code="true" lang="text" >}}
 
-  The gaps reported in this scorecard are known, and are tracked under
-  [#2614][].
-
-  {{< readfile file="afdocs-scorecard.txt" code="true" lang="text" >}}
-
-  </details>
+</details>
 
 For details on how these checks are configured, see
 [Agent-support checks](/project/build/ci-cd/#agent-support-checks).

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -163,6 +163,9 @@ For scorecard examples, see:
   <details>
   <summary><code>docsy.dev</code> scorecard</summary>
 
+  The gaps reported in this scorecard are known, and are tracked under
+  [#2614][].
+
   ```text
   {{< readfile "afdocs-scorecard.txt" >}}
   ```

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -166,9 +166,7 @@ For scorecard examples, see:
   The gaps reported in this scorecard are known, and are tracked under
   [#2614][].
 
-  ```text
-  {{< readfile "afdocs-scorecard.txt" >}}
-  ```
+  {{< readfile file="afdocs-scorecard.txt" code="true" lang="text" >}}
 
   </details>
 

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -154,13 +154,13 @@ agent-support goals, including Markdown URLs, llms.txt, and related categories.
 
 ### Scorecard examples
 
-For scorecard examples, see the [OpenTelemetry agent score][] online report, and
+For scorecard examples, see the [OpenTelemetry agent score][] online report and
 the AFDocs scorecard for this site:
 
 <details>
 <summary><code>docsy.dev</code> scorecard</summary>
 
-The gaps reported in this scorecard are known, and are tracked under [#2614][].
+Known gaps in this scorecard are tracked under [#2614][].
 
 {{< readfile file="afdocs-scorecard.txt" code="true" lang="text" >}}
 

--- a/docsy.dev/layouts/_shortcodes/readfile.markdown.md
+++ b/docsy.dev/layouts/_shortcodes/readfile.markdown.md
@@ -1,0 +1,21 @@
+{{/* Markdown-output variant of the theme's readfile shortcode: emit literal
+  file content (fenced when code=true) instead of falling back to the HTML
+  template, which would inject Chroma markup into the Markdown alternate. */ -}}
+
+{{ $f := cond .IsNamedParams (.Get "file") (.Get 0) -}}
+{{ $filepath := cond (strings.HasPrefix $f "/") $f (printf "/%s%s" .Page.File.Dir $f) -}}
+
+{{ if fileExists $filepath -}}
+{{ $content := os.ReadFile $filepath | strings.TrimRight "\n" -}}
+{{ if eq (.Get "code") "true" -}}
+```{{ .Get "lang" }}
+{{ $content }}
+```
+{{ else -}}
+{{ $content }}
+{{ end -}}
+{{ else if eq (.Get "draft") "true" -}}
+_The file `{{ $filepath }}` was not found._
+{{ else -}}
+{{ errorf "Shortcode %q: file %q not found at %s" .Name $filepath .Position -}}
+{{ end -}}

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies-note": "Dependencies installed from ../theme; see the root install:theme-deps script",
   "devDependencies": {
-    "afdocs": "^0.9.2",
+    "afdocs": "^0.19.0",
     "cross-env": "^10.1.0",
     "hugo-extended": "0.164.0",
     "link-cache": "^0.3.0",

--- a/docsy.dev/tests/md-output/agent-support.test.mjs
+++ b/docsy.dev/tests/md-output/agent-support.test.mjs
@@ -1,0 +1,37 @@
+// The agent-support page embeds the AFDocs scorecard via readfile. The
+// site-local readfile.markdown.md shortcode variant owns the Markdown-side
+// contract: the theme's HTML-only template would inject Chroma markup into
+// the Markdown alternate (the agent-facing variant of this agent-support
+// page). These assertions pin the embed's semantic contract in both output
+// formats.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const publicDir = new URL('../../public/docs/content/agent-support/', import.meta.url);
+const artifact = readFileSync(
+  new URL('../../content/en/docs/content/agent-support/afdocs-scorecard.txt', import.meta.url),
+  'utf8',
+).replace(/\n+$/, '');
+
+test('scorecard artifact carries a score line', () => {
+  assert.ok(artifact.includes('Overall Score:'), 'scorecard artifact has an Overall Score line');
+});
+
+test('markdown alternate embeds the scorecard verbatim in a text fence', () => {
+  const md = readFileSync(new URL('index.md', publicDir), 'utf8');
+  assert.ok(
+    md.includes('```text\n' + artifact + '\n```'),
+    'scorecard appears verbatim inside a text fence in index.md',
+  );
+});
+
+test('HTML page renders the scorecard as highlighted code', () => {
+  const html = readFileSync(new URL('index.html', publicDir), 'utf8');
+  assert.ok(html.includes('data-lang="text"'), 'HTML carries a text-language code block');
+  assert.ok(
+    html.includes('Agent-Friendly Docs Scorecard'),
+    'HTML carries the scorecard title',
+  );
+});

--- a/docsy.dev/tests/md-output/agent-support.test.mjs
+++ b/docsy.dev/tests/md-output/agent-support.test.mjs
@@ -9,14 +9,23 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
-const publicDir = new URL('../../public/docs/content/agent-support/', import.meta.url);
+const publicDir = new URL(
+  '../../public/docs/content/agent-support/',
+  import.meta.url,
+);
 const artifact = readFileSync(
-  new URL('../../content/en/docs/content/agent-support/afdocs-scorecard.txt', import.meta.url),
+  new URL(
+    '../../content/en/docs/content/agent-support/afdocs-scorecard.txt',
+    import.meta.url,
+  ),
   'utf8',
 ).replace(/\n+$/, '');
 
 test('scorecard artifact carries a score line', () => {
-  assert.ok(artifact.includes('Overall Score:'), 'scorecard artifact has an Overall Score line');
+  assert.ok(
+    artifact.includes('Overall Score:'),
+    'scorecard artifact has an Overall Score line',
+  );
 });
 
 test('markdown alternate embeds the scorecard verbatim in a text fence', () => {
@@ -29,7 +38,10 @@ test('markdown alternate embeds the scorecard verbatim in a text fence', () => {
 
 test('HTML page renders the scorecard as highlighted code', () => {
   const html = readFileSync(new URL('index.html', publicDir), 'utf8');
-  assert.ok(html.includes('data-lang="text"'), 'HTML carries a text-language code block');
+  assert.ok(
+    html.includes('data-lang="text"'),
+    'HTML carries a text-language code block',
+  );
   assert.ok(
     html.includes('Agent-Friendly Docs Scorecard'),
     'HTML carries the scorecard title',

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
     "docsy.dev": {
       "name": "www.docsy.dev",
       "devDependencies": {
-        "afdocs": "^0.9.2",
+        "afdocs": "^0.19.0",
         "cross-env": "^10.1.0",
         "hugo-extended": "0.164.0",
         "link-cache": "^0.3.0",
@@ -783,16 +783,18 @@
       }
     },
     "node_modules/afdocs": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/afdocs/-/afdocs-0.9.2.tgz",
-      "integrity": "sha512-PdSV1YertZ+rz9IIiOQez2MdIdAxfYTDfABTrRbX13tV2mB7LmSwvd3GN24bci4V58G6GwdkW6R/weTFbWtj1g==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/afdocs/-/afdocs-0.19.0.tgz",
+      "integrity": "sha512-r9WhOOgf4hyDKFpipQD/lcuLB+HLM22CYeYdZWDfBV477FA4uJxaNyzQHBVQs8m2Yfav+P1UDBjZYp4D6OKwEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
         "node-html-parser": "^7.1.0",
+        "picomatch": "^4.0.4",
         "turndown": "^7.2.2",
+        "turndown-plugin-gfm": "^1.0.2",
         "yaml": "^2.7.0"
       },
       "bin": {
@@ -810,6 +812,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/afdocs/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/ansi-regex": {
@@ -3483,6 +3498,13 @@
         "node": ">=18",
         "npm": ">=9"
       }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typed-query-selector": {
       "version": "2.12.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "_test:full:common": "npm run _test:fix-clean && npm run test:repo",
     "_test:full:pre": "npm run _prepare && npm run -s is:clean",
     "build": "npm run -C docsy.dev build --",
-    "check:afdocs:dev": "npm run -s _check:afdocs -- http://localhost:1313 | tee docsy.dev/content/en/docs/content/agent-support/afdocs-scorecard.txt",
+    "check:afdocs:dev": "npm run -s _check:afdocs -- http://localhost:1313 | awk '/./{if(s)printf \"%s\",b; b=\"\"; print; s=1; next} s{b=b RS}' | tee docsy.dev/content/en/docs/content/agent-support/afdocs-scorecard.txt",
     "check:format": "npm list prettier && npm run _check:format || (echo '[help] Run: npm run fix:format'; exit 1)",
     "check:links": "npm run -C docsy.dev check:links",
     "check:markdown": "npm run _check:markdown -- '**/*.md'",


### PR DESCRIPTION
- Contributes to #2614 (phase 1b).
- **Bumps afdocs** to the latest cooldown-clean release; 0.20.0 (2 days old) can be retargeted at review. `npm audit` clean.
- **Migrates the config** to the 0.17 renamed and split check IDs (old IDs now fail config load); coverage and parity checks stay disabled, rationale in the config comments.
- **Regenerates the scorecard** under deterministic sampling: 100 (A+) -> 88 (B) is expected (wider page sample, upstream false-green fixes, and the re-enabled content-start check); further score work is follow-up under #2614.
- **Fixes the scorecard embed** on the agent-support page (was Markdown-rendered inside its fence) and adds a known-gaps caption.
- **Preview**:
  - [Agent support](https://deploy-preview-2740--docsydocs.netlify.app/docs/content/agent-support/)
