### PR TITLE
Add an agent-facing llms.txt directive to page HTML

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -199,6 +199,7 @@ https://github.com/google/docsy/blob/main/docsy.dev/assets/scss/_styles_project.
 https://github.com/google/docsy/blob/main/docsy.dev/config/,200,1782498229
 https://github.com/google/docsy/blob/main/docsy.dev/config/_default/hugo.yaml,200,1782498229
 https://github.com/google/docsy/blob/main/docsy.dev/content/en/_index.md?plain=1,200,1782498243
+https://github.com/google/docsy/blob/main/docsy.dev/layouts/_shortcodes/readfile.markdown.md,200,1787704681
 https://github.com/google/docsy/blob/main/docsy.dev/layouts/docs/content/diagrams-and-formulae/_markup/render-passthrough.html,200,1782498242
 https://github.com/google/docsy/blob/main/docsy.dev/netlify.toml,200,1782563369
 https://github.com/google/docsy/blob/main/docsy.dev/package.json,200,1782563367

--- a/docsy.dev/content/en/docs/content/agent-support/afdocs-scorecard.txt
+++ b/docsy.dev/content/en/docs/content/agent-support/afdocs-scorecard.txt
@@ -1,24 +1,18 @@
 Agent-Friendly Docs Scorecard
 ==============================
 
-http://localhost:1313 · 8/25/2026, 2:24:31 PM
+http://localhost:1313 · 8/25/2026, 4:17:55 PM
 
-  Overall Score: 88 / 100 (B)
+  Overall Score: 96 / 100 (A)
 
   Category Scores:
-    Content Discoverability               85 / 100 (B)
+    Content Discoverability              100 / 100 (A+)
     Markdown Availability                 57 / 100 (F)
-    Page Size and Truncation Risk         93 / 100 (A)
+    Page Size and Truncation Risk        100 / 100 (A+)
     Content Structure                    100 / 100 (A+)
     URL Stability and Redirects          100 / 100 (A+)
     Observability and Content Health     100 / 100 (A+)
     Authentication and Access            100 / 100 (A+)
-
-  Interaction Diagnostics:
-    [!] Your site serves markdown at .md URLs, but agents have no way to discover this
-        Your site serves markdown at .md URLs, but agents have no way to discover this. No agent-facing directive points to your llms.txt, and the server does not support content negotiation. Most agents will default to the HTML path and never benefit from your markdown support.
-
-        Fix: Add a directive near the top of each docs page pointing to your llms.txt, and implement content negotiation for Accept: text/markdown. The directive is the primary discovery mechanism (it reaches all agents); content negotiation provides a fast path for agents that request markdown by default.
 
   Check Results:
 
@@ -28,8 +22,7 @@ http://localhost:1313 · 8/25/2026, 2:24:31 PM
       PASS  llms-txt-size                  llms.txt is 1,129 characters (under 50,000 threshold)
       PASS  llms-txt-links-resolve         All 13 same-origin links resolve (13 total links)
       PASS  llms-txt-links-markdown        13/13 same-origin links point to markdown content (100%)
-      WARN  llms-txt-directive-html        llms.txt directive found in HTML of 2 of 50 sampled pages, but buried deep in the page (past 50%)
-            Fix: An llms.txt directive was found in the HTML of some pages but is missing from others, or is buried deep in the page. Ensure the directive appears near the top of every documentation page.
+      PASS  llms-txt-directive-html        llms.txt directive found in HTML of all 50 sampled pages, near the top of content
       PASS  llms-txt-directive-md          llms.txt directive found in markdown of all 45 sampled pages, near the top of content; 5 had no markdown version
 
     Markdown Availability
@@ -41,13 +34,12 @@ http://localhost:1313 · 8/25/2026, 2:24:31 PM
       PASS  rendering-strategy             All 50 sampled pages contain server-rendered content
       PASS  page-size-markdown             All 45 pages under 50K chars (median 4K, max 47K)
       PASS  page-size-html                 All 50 sampled pages under 50K chars (median 54K HTML → 9K markdown (81% boilerplate))
-      FAIL  content-start-position         12 of 50 sampled pages have content starting past 50% (worst 100%)
-            Fix: 12 of 50 pages have content starting past 50% of the converted output. Agents may never see the documentation content. Reduce navigation, breadcrumb, and sidebar markup that precedes the content area.
+      PASS  content-start-position         Content starts within first 10% on all 50 sampled pages (median 0%)
 
     Content Structure
       PASS  tabbed-content-serialization   8 tab group(s) across 7 of 50 sampled pages; all serialize under 50K chars
       SKIP  section-header-quality         7 page(s) with tabs found, but no section headers inside tab panels to evaluate
-      PASS  markdown-code-fence-validity   All 156 code fences properly closed across 46 pages
+      PASS  markdown-code-fence-validity   All 157 code fences properly closed across 46 pages
 
     URL Stability and Redirects
       PASS  http-status-codes              All 50 sampled pages return proper error codes for bad URLs

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -28,8 +28,7 @@ Docsy enables:
   Markdown version of the page. When `llms.txt` is enabled, each page body also
   opens with a visually-hidden directive pointing agents to the site index and,
   when the page has one, its Markdown version. Sites that override the theme's
-  `baseof` templates need to call the `llms-directive.html` partial themselves
-  to keep the directive.
+  `baseof` templates need to call the `llms-directive.html` partial themselves.
 - **View Markdown**: page meta area includes a **View Markdown** link to the
   Markdown version of the page.
 - **[`llms.txt`](#llms-txt)**: site-root file listing.

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -26,8 +26,10 @@ Docsy enables:
   `outputs` configuration controls which page kinds publish Markdown.
 - **Discovery**: page HTML headers include `rel="alternate"` links to the
   Markdown version of the page. When `llms.txt` is enabled, each page body also
-  opens with a visually-hidden directive pointing agents to the site index and
-  the page's Markdown version.
+  opens with a visually-hidden directive pointing agents to the site index and,
+  when the page has one, its Markdown version. Sites that override the theme's
+  `baseof` templates need to call the `llms-directive.html` partial themselves
+  to keep the directive.
 - **View Markdown**: page meta area includes a **View Markdown** link to the
   Markdown version of the page.
 - **[`llms.txt`](#llms-txt)**: site-root file listing.

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -25,7 +25,9 @@ Docsy enables:
 - **[Markdown output format](#markdown-output)** support. Your project's
   `outputs` configuration controls which page kinds publish Markdown.
 - **Discovery**: page HTML headers include `rel="alternate"` links to the
-  Markdown version of the page.
+  Markdown version of the page. When `llms.txt` is enabled, each page body also
+  opens with a visually-hidden directive pointing agents to the site index and
+  the page's Markdown version.
 - **View Markdown**: page meta area includes a **View Markdown** link to the
   Markdown version of the page.
 - **[`llms.txt`](#llms-txt)**: site-root file listing.

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -24,14 +24,12 @@ Docsy enables:
 
 - **[Markdown output format](#markdown-output)** support. Your project's
   `outputs` configuration controls which page kinds publish Markdown.
-- **Discovery**: page HTML headers include `rel="alternate"` links to the
-  Markdown version of the page. When `llms.txt` is enabled, each page body also
-  opens with a visually-hidden directive pointing agents to the site index and,
-  when the page has one, its Markdown version. Sites that override the theme's
-  `baseof` templates need to call the `llms-directive.html` partial themselves.
+- **[Discovery](#discovery)**: alternate links and a hidden in-body directive
+  lead agents to each page's Markdown version and to `llms.txt`.
 - **View Markdown**: page meta area includes a **View Markdown** link to the
   Markdown version of the page.
-- **[`llms.txt`](#llms-txt)**: site-root file listing.
+- **[`llms.txt`](#llms-txt)**: per-language site index of links to Markdown
+  content.
 
 The remainder of this page explains how to enable each feature, and discusses
 [validation and metrics](#validation-and-metrics) supported with examples.
@@ -108,9 +106,10 @@ to site content. It is designed to be easy for agents to discover and parse, and
 to complement the richer but more complex Markdown outputs. To learn more, see
 [llmstxt.org][].
 
-Docsy generates `llms.txt` at the site root, and includes links to the home
-page, main menu pages, and Markdown alternates where they exist. To enable it,
-add `LLMS` to the Hugo [outputs][] configuration for the home page. For example:
+Docsy generates an `llms.txt` index at each language's site root, and includes
+links to the home page, main menu pages, and Markdown alternates where they
+exist. To enable it, add `LLMS` to the Hugo [outputs][] configuration for the
+home page. For example:
 
 ```yaml
 outputs:
@@ -122,6 +121,18 @@ outputs:
 For an example of the generated `llms.txt` for this site, see
 [/llms.txt](/llms.txt).
 
+## Discovery
+
+Agents find your Markdown content through:
+
+- **Alternate links**: page HTML headers include `rel="alternate"` links to the
+  Markdown version of the page.
+- **In-body directive**: when `llms.txt` is enabled, each page body opens with a
+  visually-hidden directive pointing agents to the language's `llms.txt` index
+  and, when the page has one, its Markdown version. Sites that override the
+  theme's `baseof` templates need to call the `llms-directive.html` partial
+  themselves.
+
 ## Customize output
 
 Docsy renders Markdown output via [layouts/all.md][] and generates `llms.txt`
@@ -132,7 +143,8 @@ via `layouts/index.llms.txt`. You can override these defaults at several levels:
   kinds][].
 - **Per shortcode** — Add [output-format-specific shortcode templates][sof] to
   project-local shortcodes so they emit Markdown-friendly content when
-  appropriate.
+  appropriate. For example, this site's [readfile.markdown.md][] is the
+  Markdown-output variant of the theme's `readfile` shortcode.
 - **Per page** — Provide page-specific content or structure for high-value pages
   that need a curated agent-facing view.
 
@@ -177,6 +189,8 @@ For details on how these checks are configured, see
 [experimental]: /project/about/changelog/#experimental
 [Hugo kinds]: https://gohugo.io/templates/types/
 [layouts/all.md]: https://github.com/google/docsy/blob/main/theme/layouts/all.md
+[readfile.markdown.md]:
+  https://github.com/google/docsy/blob/main/docsy.dev/layouts/_shortcodes/readfile.markdown.md
 [llmstxt.org]: https://llmstxt.org/
 [OpenTelemetry agent score]:
   https://buildwithfern.com/agent-score/company/opentelemetry

--- a/docsy.dev/content/fr/_index.md
+++ b/docsy.dev/content/fr/_index.md
@@ -5,7 +5,7 @@ description: >-
 params:
   body_class: td-navbar-links-all-active
   ui: { navbar_theme: dark }
-outputs: [HTML, markdown]
+outputs: [HTML, markdown, LLMS]
 ---
 
 {{% blocks/cover

--- a/docsy.dev/content/fr/_index.md
+++ b/docsy.dev/content/fr/_index.md
@@ -5,7 +5,6 @@ description: >-
 params:
   body_class: td-navbar-links-all-active
   ui: { navbar_theme: dark }
-outputs: [HTML, markdown, LLMS]
 ---
 
 {{% blocks/cover

--- a/tests/fixture-site/llms-directive.test.mjs
+++ b/tests/fixture-site/llms-directive.test.mjs
@@ -1,0 +1,68 @@
+// The llms-directive partial emits an agent-facing pointer to llms.txt near
+// the top of every page's body, gated on the site actually publishing
+// llms.txt (the LLMS output format on the home page). Two fixture builds pin
+// the gate's both sides; the enabled build also pins position (ahead of the
+// navbar) and the per-page Markdown pointer.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSite } from './lib/build-site.mjs';
+
+const files = {
+  'content/_index.md': '---\ntitle: Home\n---\nHome body\n',
+  'content/docs/_index.md': '---\ntitle: Docs\n---\nDocs landing\n',
+  'content/docs/install.md': '---\ntitle: Install\n---\nLeaf page\n',
+};
+
+const llmsConfig = `outputs:
+  home: [HTML, markdown, LLMS]
+  page: [HTML, markdown]
+  section: [HTML, RSS, markdown]
+`;
+
+function build(name, extraConfig) {
+  const r = buildSite(name, { files, extraConfig });
+  assert.equal(
+    r.status,
+    0,
+    `fixture hugo build succeeds:\n${r.stdout}${r.stderr}`,
+  );
+  return r;
+}
+
+test('llms.txt-enabled site carries the directive on every page kind', () => {
+  const b = build('llms-directive-on', llmsConfig);
+  for (const page of [
+    'index.html',
+    'docs/index.html',
+    'docs/install/index.html',
+  ]) {
+    const html = b.publicFile(page);
+    const at = html.indexOf(
+      'For AI agents: a documentation index is available at /llms.txt',
+    );
+    assert.ok(at > 0, `directive is present in ${page}`);
+    const nav = html.indexOf('td-navbar');
+    assert.ok(at < nav, `directive precedes the navbar in ${page}`);
+  }
+});
+
+test('directive names the page Markdown alternate when one exists', () => {
+  const b = build('llms-directive-on', llmsConfig);
+  assert.ok(
+    b
+      .publicFile('docs/install/index.html')
+      .includes('This page has a Markdown version at /docs/install/index.md'),
+    'leaf page directive links its Markdown version',
+  );
+});
+
+test('site without llms.txt emits no directive', () => {
+  const b = build('llms-directive-off');
+  for (const page of ['index.html', 'docs/install/index.html']) {
+    assert.ok(
+      !b.publicFile(page).includes('For AI agents'),
+      `no directive in ${page}`,
+    );
+  }
+});

--- a/tests/fixture-site/llms-directive.test.mjs
+++ b/tests/fixture-site/llms-directive.test.mjs
@@ -1,8 +1,7 @@
-// The llms-directive partial emits an agent-facing pointer to llms.txt near
-// the top of every page's body, gated on the site actually publishing
-// llms.txt (the LLMS output format on the home page). Two fixture builds pin
-// the gate's both sides; the enabled build also pins position (ahead of the
-// navbar) and the per-page Markdown pointer.
+// Pins the llms-directive partial's contract (rationale and gating:
+// theme/layouts/_partials/llms-directive.html): two fixture builds cover both
+// gate sides; the enabled build also pins position (ahead of the navbar) and
+// the per-page Markdown pointer.
 
 import test from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/fixture-site/llms-directive.test.mjs
+++ b/tests/fixture-site/llms-directive.test.mjs
@@ -11,6 +11,9 @@ const files = {
   'content/_index.md': '---\ntitle: Home\n---\nHome body\n',
   'content/docs/_index.md': '---\ntitle: Docs\n---\nDocs landing\n',
   'content/docs/install.md': '---\ntitle: Install\n---\nLeaf page\n',
+  'content/blog/_index.md': '---\ntitle: Blog\n---\nBlog landing\n',
+  'content/blog/first.md':
+    '---\ntitle: First\ndate: 2026-08-01\n---\nPost body\n',
 };
 
 const llmsConfig = `outputs:
@@ -35,12 +38,13 @@ test('llms.txt-enabled site carries the directive on every page kind', () => {
     'index.html',
     'docs/index.html',
     'docs/install/index.html',
+    'blog/first/index.html',
   ]) {
     const html = b.publicFile(page);
     const at = html.indexOf(
-      'For AI agents: a documentation index is available at /llms.txt',
+      '<div class="visually-hidden" aria-hidden="true">\n    For AI agents: a documentation index is available at /llms.txt',
     );
-    assert.ok(at > 0, `directive is present in ${page}`);
+    assert.ok(at > 0, `hidden directive is present in ${page}`);
     const nav = html.indexOf('td-navbar');
     assert.ok(at < nav, `directive precedes the navbar in ${page}`);
   }

--- a/tests/fixture-site/llms-directive.test.mjs
+++ b/tests/fixture-site/llms-directive.test.mjs
@@ -14,6 +14,8 @@ const files = {
   'content/blog/_index.md': '---\ntitle: Blog\n---\nBlog landing\n',
   'content/blog/first.md':
     '---\ntitle: First\ndate: 2026-08-01\n---\nPost body\n',
+  'content/docs/html-only.md':
+    '---\ntitle: HTML only\noutputs: [HTML]\n---\nNo markdown output\n',
 };
 
 const llmsConfig = `outputs:
@@ -42,7 +44,7 @@ test('llms.txt-enabled site carries the directive on every page kind', () => {
   ]) {
     const html = b.publicFile(page);
     const at = html.indexOf(
-      '<div class="visually-hidden" aria-hidden="true">\n    For AI agents: a documentation index is available at /llms.txt',
+      '<div class="visually-hidden" aria-hidden="true" data-pagefind-ignore>\n    For AI agents: a documentation index is available at /llms.txt',
     );
     assert.ok(at > 0, `hidden directive is present in ${page}`);
     const nav = html.indexOf('td-navbar');
@@ -57,6 +59,15 @@ test('directive names the page Markdown alternate when one exists', () => {
       .publicFile('docs/install/index.html')
       .includes('This page has a Markdown version at /docs/install/index.md'),
     'leaf page directive links its Markdown version',
+  );
+  const htmlOnly = b.publicFile('docs/html-only/index.html');
+  assert.ok(
+    htmlOnly.includes('For AI agents'),
+    'HTML-only page still carries the directive',
+  );
+  assert.ok(
+    !htmlOnly.includes('Markdown version at'),
+    'HTML-only page directive omits the Markdown pointer',
   );
 });
 

--- a/tests/fixture-site/llms-directive.test.mjs
+++ b/tests/fixture-site/llms-directive.test.mjs
@@ -76,7 +76,7 @@ test('site without llms.txt emits no directive', () => {
   for (const page of ['index.html', 'docs/install/index.html']) {
     assert.ok(
       !b.publicFile(page).includes('For AI agents'),
-      `no directive in ${page}`,
+      `${page} omits the directive`,
     );
   }
 });

--- a/theme/layouts/_partials/llms-directive.html
+++ b/theme/layouts/_partials/llms-directive.html
@@ -1,0 +1,13 @@
+{{/* Agent-facing pointer to the site's llms.txt index, emitted only when the
+  site publishes one (the LLMS output format on the home page). The element is
+  hidden from visual and assistive presentation; agents reading the page HTML
+  find the directive near the top of the document, ahead of any navigation.
+*/ -}}
+{{ with site.Home.OutputFormats.Get "LLMS" -}}
+  <div class="visually-hidden" aria-hidden="true">
+    For AI agents: a documentation index is available at {{ .RelPermalink }}.
+    {{- with $.OutputFormats.Get "markdown" }}
+    This page has a Markdown version at {{ .RelPermalink }}.
+    {{- end }}
+  </div>
+{{ end -}}

--- a/theme/layouts/_partials/llms-directive.html
+++ b/theme/layouts/_partials/llms-directive.html
@@ -4,7 +4,7 @@
   find the directive near the top of the document, ahead of any navigation.
 */ -}}
 {{ with site.Home.OutputFormats.Get "LLMS" -}}
-  <div class="visually-hidden" aria-hidden="true">
+  <div class="visually-hidden" aria-hidden="true" data-pagefind-ignore>
     For AI agents: a documentation index is available at {{ .RelPermalink }}.
     {{- with $.OutputFormats.Get "markdown" }}
     This page has a Markdown version at {{ .RelPermalink }}.

--- a/theme/layouts/baseof.html
+++ b/theme/layouts/baseof.html
@@ -9,6 +9,7 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    {{ partial "llms-directive.html" . -}}
     <header>
       {{ partial "navbar.html" . }}
     </header>

--- a/theme/layouts/blog/baseof.html
+++ b/theme/layouts/blog/baseof.html
@@ -9,6 +9,7 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }} td-blog {{- with .Page.Params.body_class }} {{ . }}{{ end }}">
+    {{ partial "llms-directive.html" . -}}
     <header>
       {{ partial "navbar.html" . }}
     </header>

--- a/theme/layouts/blog/baseof.print.html
+++ b/theme/layouts/blog/baseof.print.html
@@ -9,6 +9,7 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }} td-blog">
+    {{ partial "llms-directive.html" . -}}
     <header>
       {{ partial "navbar.html" . }}
     </header>

--- a/theme/layouts/docs/baseof.html
+++ b/theme/layouts/docs/baseof.html
@@ -9,6 +9,7 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    {{ partial "llms-directive.html" . -}}
     <header>
       {{ partial "navbar.html" . }}
     </header>

--- a/theme/layouts/docs/baseof.print.html
+++ b/theme/layouts/docs/baseof.print.html
@@ -9,6 +9,7 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    {{ partial "llms-directive.html" . -}}
     <header>
       {{ partial "navbar.html" . }}
     </header>

--- a/theme/layouts/swagger/baseof.html
+++ b/theme/layouts/swagger/baseof.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.21.0/swagger-ui.css" integrity="sha384-WoOxtFhjrhn23jYeguEcSJkYdgSIer0UxZkoMKKEqROW+TDEmHEPwckfxWmZXSIw" crossorigin="anonymous">
   </head>
   <body class="td-{{ .Kind }}">
+    {{ partial "llms-directive.html" . -}}
     <header>
       {{ partial "navbar.html" . }}
     </header>


### PR DESCRIPTION
- Contributes to #2614 (phase 2 opener).
- **Emits a hidden llms.txt directive** at the top of every page body, the primary discovery mechanism agents use to find a site's Markdown path (afdocs: the directive reaches all agents, unlike content negotiation).
- **Free for every Docsy site**: gated on the site already publishing llms.txt (the LLMS output format), no new configuration; non-opted sites render byte-identically. Sites overriding the theme's baseof templates must call the new partial themselves (documented on the agent-support page).
- **docsy.dev adoption**: drops the fr home's stale outputs override (it masked the site config's LLMS output, so fr pages emitted no directive) and refreshes the published scorecard: 88 (B) -> 96 (A). Two causes: the directive check passes on all sampled pages, and content-start-position flips to PASS because the checker counts the directive itself as first content; the underlying nav-before-content DOM order is unchanged and stays tracked under #2614.
- **Preview**:
  - [Agent support](https://deploy-preview-2741--docsydocs.netlify.app/docs/content/agent-support/) (page docs + embedded scorecard)
  - [Docs landing](https://deploy-preview-2741--docsydocs.netlify.app/docs/): view-source for the directive

