### PR TITLE
Blog+CL 0.17.0: cover the agent llms.txt directive; fix nav-page anchor

### DIFF
--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -51,8 +51,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   - [Theme-dependencies install command renamed](#install-command)
   - [Default script-dependency versions pinned](#script-dep-pins): Mermaid,
     KaTeX, markmap, and Redoc no longer resolve from the CDN's `latest`
-- **[Agent directive in page HTML](#llms-directive)** (experimental): pages of
-  `llms.txt`-publishing sites point agents to the index
+- **[Agent directive in page HTML](#llms-directive)** (experimental):
+  `llms.txt`-enabled sites point agents to the index
 - **[Other notable changes](#other-notable-changes)**, and
   [for maintainers](#for-maintainers): supply-chain hardening and npm trusted
   publishing
@@ -249,21 +249,22 @@ rendering no longer changes when an upstream major ships.
 
 ## {{% _param NEW %}} Agent directive in page HTML {#llms-directive}
 
-Sites that publish [`llms.txt`][agent-support-llms] now also point AI agents to
-it from every page: a new theme partial, called from the theme's `baseof`
+Sites that enable [`llms.txt`][agent-support-llms] now also point AI agents to
+it from their page HTML: a new theme partial, called from the theme's `baseof`
 templates, opens each page body with a hidden agent-facing directive. For what
 the directive carries and how it is hidden, see
 [Discovery][agent-support-discovery]. This feature is [experimental][], part of
 the agent-support arc tracked in [#2614][].
 
-Sites that don't publish `llms.txt` are unaffected: the partial emits nothing.
+Sites that don't enable `llms.txt` are unaffected: the partial emits nothing.
 
 ### Actions {#llms-directive-actions}
 
-**Applies if** your site publishes `llms.txt` **and** overrides any of the
+**Applies if** your site enables `llms.txt` **and** overrides any of the
 theme's `baseof` templates (print variants included).
 
-- Call the new partial from each override, as the first element of `<body>`:
+- Call the new partial (it expects the page context) from each overridden
+  template, as the first element of `<body>`:
 
   ```go-html-template
   {{ partial "llms-directive.html" . -}}
@@ -351,9 +352,9 @@ In addition to the [generic site checks][check], for this release:
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).
 - [ ] Mermaid diagrams render at the [pinned version](#script-dep-pins).
-- [ ] If your site publishes `llms.txt`, view-source on any page shows the
+- [ ] If your site enables `llms.txt`, view-source shows the
       [agent directive](#llms-directive) (`For AI agents:`) at the top of
-      `<body>` -- especially if you override `baseof` templates.
+      `<body>` -- check one page per overridden `baseof` template.
 
 </section>
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -264,8 +264,8 @@ Sites that don't enable `llms.txt` are unaffected: the partial emits nothing.
 {{% _param NEW %}} **Applies if** your site enables `llms.txt` **and** overrides
 any of the theme's `baseof` templates ([print][print-docs] variants included).
 
-- Call the new partial (it expects the page context) from each overridden
-  template, as the first element of `<body>`:
+- Call the new partial from each overridden template, as the first element of
+  `<body>`, passing it the page context:
 
   ```go-html-template
   {{ partial "llms-directive.html" . -}}
@@ -355,7 +355,7 @@ In addition to the [generic site checks][check], for this release:
 - [ ] Mermaid diagrams render at the [pinned version](#script-dep-pins).
 - [ ] If your site enables `llms.txt`, view-source shows the
       [agent directive](#llms-directive) (`For AI agents:`) at the top of
-      `<body>` -- check one page per overridden `baseof` template.
+      `<body>`; check one page per overridden `baseof` template.
 
 </section>
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -51,6 +51,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   - [Theme-dependencies install command renamed](#install-command)
   - [Default script-dependency versions pinned](#script-dep-pins): Mermaid,
     KaTeX, markmap, and Redoc no longer resolve from the CDN's `latest`
+- **[Agent directive in page HTML](#llms-directive)**: pages of
+  `llms.txt`-publishing sites point agents to the index
 - **[Other notable changes](#other-notable-changes)**, and
   [for maintainers](#for-maintainers): supply-chain hardening and npm trusted
   publishing
@@ -66,6 +68,7 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   unchanged too.
 - Optionally skim:
   - [Default script-dependency versions pinned](#script-dep-pins)
+  - [Agent directive in page HTML](#llms-directive)
   - [Other notable changes](#other-notable-changes), and
     [for maintainers](#for-maintainers)
 - {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.17.0](#upgrade)
@@ -244,6 +247,25 @@ rendering no longer changes when an upstream major ships.
 - Set the dependency's version param (last column above) in your site config;
   for details, see the dependency's Docsy docs (first column).
 
+## {{% _param NEW %}} Agent directive in page HTML {#llms-directive}
+
+For sites that publish [`llms.txt`][agent-support-llms], each page body now
+opens with a visually-hidden directive pointing AI agents to the language's
+`llms.txt` index and, when the page has one, its Markdown version. Agents
+reading the page HTML find the pointer near the top of the document, ahead of
+any navigation; the directive is hidden from visual and assistive presentation.
+This continues the agent-support arc tracked in [#2614][].
+
+The directive is emitted by a new theme partial called from the theme's `baseof`
+templates; see [Discovery][agent-support-discovery].
+
+### Actions {#llms-directive-actions}
+
+**Applies if** your site overrides any of the theme's `baseof` templates.
+
+- Call the new `llms-directive.html` partial from your overrides; see
+  [Discovery][agent-support-discovery].
+
 ## Other notable changes
 
 - **Footer copyright**: a same-year range now renders as the single year
@@ -325,6 +347,9 @@ In addition to the [generic site checks][check], for this release:
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).
 - [ ] Mermaid diagrams render at the [pinned version](#script-dep-pins).
+- [ ] If your site publishes `llms.txt`, view-source on a page shows the
+      [agent directive](#llms-directive) near the top of the body -- especially
+      if you override `baseof` templates.
 
 </section>
 
@@ -359,6 +384,7 @@ About this release:
 
 <!-- prettier-ignore-start -->
 [#2691]: https://github.com/google/docsy/issues/2691
+[#2614]: https://github.com/google/docsy/issues/2614
 [0.16.0]: https://github.com/google/docsy/releases/v0.16.0
 [0.17.0]: https://github.com/google/docsy/releases/v0.17.0
 [0.18.0 milestone]: https://github.com/google/docsy/milestone/27
@@ -366,6 +392,8 @@ About this release:
 [hugo-supported-version]:
   <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoSupportedVersion %}}>
 [`@docsy/theme`]: https://www.npmjs.com/package/@docsy/theme
+[agent-support-discovery]: /docs/content/agent-support/#discovery
+[agent-support-llms]: /docs/content/agent-support/#llms-txt
 [`sass-embedded`]: https://www.npmjs.com/package/sass-embedded
 [check]: /docs/update/#check
 [CL@0.17.0]: /project/about/changelog/#next

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -68,7 +68,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   unchanged too.
 - Optionally skim:
   - [Default script-dependency versions pinned](#script-dep-pins)
-  - [Agent directive in page HTML](#llms-directive)
+  - {{% _param NEW %}} Experimental
+    [agent directive in page HTML](#llms-directive)
   - [Other notable changes](#other-notable-changes), and
     [for maintainers](#for-maintainers)
 - {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.17.0](#upgrade)
@@ -252,7 +253,7 @@ rendering no longer changes when an upstream major ships.
 Sites that enable [`llms.txt`][agent-support-llms] now also point AI agents to
 it from their page HTML: a new theme partial, called from the theme's `baseof`
 templates, opens each page body with a hidden agent-facing directive. For what
-the directive carries and how it is hidden, see
+the directive carries and how agents find it, see
 [Discovery][agent-support-discovery]. This feature is [experimental][], part of
 the agent-support arc tracked in [#2614][].
 
@@ -260,8 +261,8 @@ Sites that don't enable `llms.txt` are unaffected: the partial emits nothing.
 
 ### Actions {#llms-directive-actions}
 
-**Applies if** your site enables `llms.txt` **and** overrides any of the theme's
-`baseof` templates (print variants included).
+{{% _param NEW %}} **Applies if** your site enables `llms.txt` **and** overrides
+any of the theme's `baseof` templates ([print][print-docs] variants included).
 
 - Call the new partial (it expects the page context) from each overridden
   template, as the first element of `<body>`:
@@ -388,8 +389,8 @@ About this release:
 - Git history since [0.16.0][compare-0.16.0]
 
 <!-- prettier-ignore-start -->
-[#2691]: https://github.com/google/docsy/issues/2691
 [#2614]: https://github.com/google/docsy/issues/2614
+[#2691]: https://github.com/google/docsy/issues/2691
 [0.16.0]: https://github.com/google/docsy/releases/v0.16.0
 [0.17.0]: https://github.com/google/docsy/releases/v0.17.0
 [0.18.0 milestone]: https://github.com/google/docsy/milestone/27
@@ -417,6 +418,7 @@ About this release:
 [Netlify]: /docs/deployment/netlify/
 [official support policy]: /project/about/changelog/#official-support
 [order of steps]: /docs/update/#update-order
+[print-docs]: /docs/content/print/
 [overrides]: /docs/update/#update-overrides
 [Project style files]: /docs/content/lookandfeel/#project-style-files
 [semantic classes]: /docs/content/lookandfeel/#semantic-classes

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -260,8 +260,8 @@ Sites that don't enable `llms.txt` are unaffected: the partial emits nothing.
 
 ### Actions {#llms-directive-actions}
 
-**Applies if** your site enables `llms.txt` **and** overrides any of the
-theme's `baseof` templates (print variants included).
+**Applies if** your site enables `llms.txt` **and** overrides any of the theme's
+`baseof` templates (print variants included).
 
 - Call the new partial (it expects the page context) from each overridden
   template, as the first element of `<body>`:

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -51,7 +51,7 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   - [Theme-dependencies install command renamed](#install-command)
   - [Default script-dependency versions pinned](#script-dep-pins): Mermaid,
     KaTeX, markmap, and Redoc no longer resolve from the CDN's `latest`
-- **[Agent directive in page HTML](#llms-directive)**: pages of
+- **[Agent directive in page HTML](#llms-directive)** (experimental): pages of
   `llms.txt`-publishing sites point agents to the index
 - **[Other notable changes](#other-notable-changes)**, and
   [for maintainers](#for-maintainers): supply-chain hardening and npm trusted
@@ -249,22 +249,25 @@ rendering no longer changes when an upstream major ships.
 
 ## {{% _param NEW %}} Agent directive in page HTML {#llms-directive}
 
-For sites that publish [`llms.txt`][agent-support-llms], each page body now
-opens with a visually-hidden directive pointing AI agents to the language's
-`llms.txt` index and, when the page has one, its Markdown version. Agents
-reading the page HTML find the pointer near the top of the document, ahead of
-any navigation; the directive is hidden from visual and assistive presentation.
-This continues the agent-support arc tracked in [#2614][].
+Sites that publish [`llms.txt`][agent-support-llms] now also point AI agents to
+it from every page: a new theme partial, called from the theme's `baseof`
+templates, opens each page body with a hidden agent-facing directive. For what
+the directive carries and how it is hidden, see
+[Discovery][agent-support-discovery]. This feature is [experimental][], part of
+the agent-support arc tracked in [#2614][].
 
-The directive is emitted by a new theme partial called from the theme's `baseof`
-templates; see [Discovery][agent-support-discovery].
+Sites that don't publish `llms.txt` are unaffected: the partial emits nothing.
 
 ### Actions {#llms-directive-actions}
 
-**Applies if** your site overrides any of the theme's `baseof` templates.
+**Applies if** your site publishes `llms.txt` **and** overrides any of the
+theme's `baseof` templates (print variants included).
 
-- Call the new `llms-directive.html` partial from your overrides; see
-  [Discovery][agent-support-discovery].
+- Call the new partial from each override, as the first element of `<body>`:
+
+  ```go-html-template
+  {{ partial "llms-directive.html" . -}}
+  ```
 
 ## Other notable changes
 
@@ -318,8 +321,9 @@ section. {{< /comment >}}
   - **[Node][update-node]**: LTS 24 (unchanged)
   - **Dart Sass**: [new requirement](#dart-sass-actions)
 - Remember to [review your theme overrides][overrides]: this release reworks
-  theme files that sites commonly override, including `head-css.html` and
-  `breadcrumb.html`.
+  theme files that sites commonly override, including `head-css.html`,
+  `breadcrumb.html`, and the `baseof` templates (see the
+  [agent directive](#llms-directive-actions)).
 
 [^vers-note]:
     Matches `docsy.dev`'s tested Hugo pin and the theme's declared minimum Hugo
@@ -347,9 +351,9 @@ In addition to the [generic site checks][check], for this release:
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).
 - [ ] Mermaid diagrams render at the [pinned version](#script-dep-pins).
-- [ ] If your site publishes `llms.txt`, view-source on a page shows the
-      [agent directive](#llms-directive) near the top of the body -- especially
-      if you override `baseof` templates.
+- [ ] If your site publishes `llms.txt`, view-source on any page shows the
+      [agent directive](#llms-directive) (`For AI agents:`) at the top of
+      `<body>` -- especially if you override `baseof` templates.
 
 </section>
 
@@ -401,6 +405,7 @@ About this release:
 [Dart Sass]: https://sass-lang.com/dart-sass/
 [dart-sass-2413]: https://github.com/sass/dart-sass/pull/2413
 [deployment docs]: /docs/deployment/
+[experimental]: /project/about/changelog/#experimental
 [footer copyright docs]: /docs/content/lookandfeel/#footer-copyright
 [gh-pages-deploy]: /docs/deployment/github-pages/
 [Install Dart Sass]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass

--- a/docsy.dev/content/en/docs/content/navigation.md
+++ b/docsy.dev/content/en/docs/content/navigation.md
@@ -303,7 +303,7 @@ To hide a page or section from the left navigation menu, set `toc_hide: true` in
 the front matter.
 
 To hide a page from the section summary on a [docs section landing
-page]({{< ref "adding-content#docs-section-landing-pages" >}}), set
+page](/docs/content/adding-content/#docs-section-landing-pages), set
 `hide_summary: true` in the front matter. If you want to hide a page from both
 the TOC menu and the section summary list, you need to set both `toc_hide` and
 `hide_summary` to `true` in the front matter.

--- a/docsy.dev/content/en/docs/content/navigation.md
+++ b/docsy.dev/content/en/docs/content/navigation.md
@@ -303,7 +303,7 @@ To hide a page or section from the left navigation menu, set `toc_hide: true` in
 the front matter.
 
 To hide a page from the section summary on a [docs section landing
-page]({{< ref "content#docs-section-landing-pages" >}}), set
+page]({{< ref "adding-content#docs-section-landing-pages" >}}), set
 `hide_summary: true` in the front matter. If you want to hide a page from both
 the TOC menu and the section summary list, you need to set both `toc_hide` and
 `hide_summary` to `true` in the front matter.

--- a/docsy.dev/content/en/docs/content/navigation.md
+++ b/docsy.dev/content/en/docs/content/navigation.md
@@ -302,11 +302,11 @@ description: >
 To hide a page or section from the left navigation menu, set `toc_hide: true` in
 the front matter.
 
-To hide a page from the section summary on a [docs section landing
-page](/docs/content/adding-content/#docs-section-landing-pages), set
-`hide_summary: true` in the front matter. If you want to hide a page from both
-the TOC menu and the section summary list, you need to set both `toc_hide` and
-`hide_summary` to `true` in the front matter.
+To hide a page from the section summary on a
+[docs section landing page](/docs/content/adding-content/#docs-section-landing-pages),
+set `hide_summary: true` in the front matter. If you want to hide a page from
+both the TOC menu and the section summary list, you need to set both `toc_hide`
+and `hide_summary` to `true` in the front matter.
 
 {{< tabpane text=true >}} {{< tab header="Front matter:" disabled=true />}}
 {{% tab header="toml" lang="toml" %}}

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -175,7 +175,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   [#2737][]).
 - **[Agent directive in page HTML][0.17.0-blog-llms-directive]**
   ([experimental](#experimental)): added a hidden agent-facing pointer to
-  `llms.txt` at the top of each page body of sites that publish the index
+  `llms.txt` at the top of each page body of sites that enable the index
   ([#2614][]).
 - Silenced Sass deprecation warnings in site builds, project style files
   included; see the [release report][0.17.0-blog-dart-sass] ([#2731][]).

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -173,9 +173,10 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   Mermaid, KaTeX, markmap-autoloader, and Redoc now load at pinned versions
   instead of resolving from the CDN's `latest` ([#2703][], [#2705][], [#2706][],
   [#2737][]).
-- **[Agent directive in page HTML][0.17.0-blog-llms-directive]**: pages of
-  `llms.txt`-publishing sites now open with a hidden pointer to the index; sites
-  overriding `baseof` templates call the new partial themselves ([#2614][]).
+- **[Agent directive in page HTML][0.17.0-blog-llms-directive]**
+  ([experimental](#experimental)): added a hidden agent-facing pointer to
+  `llms.txt` at the top of each page body of sites that publish the index
+  ([#2614][]).
 - Silenced Sass deprecation warnings in site builds, project style files
   included; see the [release report][0.17.0-blog-dart-sass] ([#2731][]).
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -173,6 +173,9 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   Mermaid, KaTeX, markmap-autoloader, and Redoc now load at pinned versions
   instead of resolving from the CDN's `latest` ([#2703][], [#2705][], [#2706][],
   [#2737][]).
+- **[Agent directive in page HTML][0.17.0-blog-llms-directive]**: pages of
+  `llms.txt`-publishing sites now open with a hidden pointer to the index; sites
+  overriding `baseof` templates call the new partial themselves ([#2614][]).
 - Silenced Sass deprecation warnings in site builds, project style files
   included; see the [release report][0.17.0-blog-dart-sass] ([#2731][]).
 
@@ -197,6 +200,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 
 <!-- prettier-ignore-start -->
 [#2047]: https://github.com/google/docsy/issues/2047
+[#2614]: https://github.com/google/docsy/issues/2614
 [#2700]: https://github.com/google/docsy/pull/2700
 [#2703]: https://github.com/google/docsy/issues/2703
 [#2705]: https://github.com/google/docsy/issues/2705
@@ -212,6 +216,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [0.17.0 release report]: /blog/2026/0.17.0/
 [0.17.0-blog-dart-sass]: /blog/2026/0.17.0/#dart-sass
 [0.17.0-blog-install]: /blog/2026/0.17.0/#install-command
+[0.17.0-blog-llms-directive]: /blog/2026/0.17.0/#llms-directive
 [0.17.0-blog-maintainers]: /blog/2026/0.17.0/#for-maintainers
 [0.17.0-blog-script-pins]: /blog/2026/0.17.0/#script-dep-pins
 [0.17.0]: https://github.com/google/docsy/releases/tag/v0.17.0


### PR DESCRIPTION
- Contributes to #2691
- **Agent llms.txt directive coverage** (#2741): adds the release-post section (with the baseof-override applies-if), Release-summary and skim-list entries, a sanity-check item, and the changelog line citing the #2614 arc; mechanics delegated to the agent-support docs' Discovery section.
- **Nav-anchor fix**: `navigation.md` referenced `#docs-section-landing-pages` on `content/`, where the anchor doesn't resolve; retargets the `ref` at `adding-content/`, the anchor's home.
- **Preview(s)**:
  - https://deploy-preview-2743--docsydocs.netlify.app/blog/2026/0.17.0/
  - https://deploy-preview-2743--docsydocs.netlify.app/project/about/changelog/
