### PR TITLE
Bump swagger-ui-dist to 5.32.14 and DocSearch to 3.9.0, refresh SRI hashes

### DIFF
--- a/theme/layouts/_partials/head.html
+++ b/theme/layouts/_partials/head.html
@@ -89,8 +89,8 @@
 {{ define "algolia/head" -}}
 
 {{ if and .Site.Params.search (isset .Site.Params.search "algolia") -}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3.8.2"
-  integrity="sha512-l7pkV1dOURFyHCeH8I4fK9lCkQKuqhlsTCqRl3zktifDlB8oTUJ+mJPgYkK9kHpUut8j1iPquTv32t6hvTPv3g=="
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3.9.0/dist/style.css"
+  integrity="sha512-8uug7D8NgT+v/d07sokt/vr2noql7IVBehApnrNrbfIHT4OzJ/0r61YC7C3eHJhJdqATQOEnVMnp6Ik7njsy5w=="
   crossorigin="anonymous" />
 {{ end -}}
 

--- a/theme/layouts/_partials/scripts.html
+++ b/theme/layouts/_partials/scripts.html
@@ -66,8 +66,8 @@
 {{ partial "hooks/body-end.html" . -}}
 
 {{ define "algolia/scripts" -}}
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3.8.2"
-  integrity="sha512-lsD+XVzdBI6ZquXc8gqbw0/bgrfIsMJwY/8xvmvbN+U3gZSeG7BXQoCq4zv/yCmntR2GLHtgB+bD4ESPsKIbIA=="
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3.9.0/dist/umd/index.js"
+  integrity="sha512-88MvftlHa0v7odRECMfSOg2XjedcNcnF8jTzDgyrgzi5Qpf1Dq5vVxO49vlseushr7kVXCriGKNF4rJobckTpw=="
   crossorigin="anonymous" ></script>
 <script type="text/javascript">
 const containers = ['#docsearch-0', '#docsearch-1'];

--- a/theme/layouts/swagger/baseof.html
+++ b/theme/layouts/swagger/baseof.html
@@ -8,7 +8,7 @@
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
-    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.21.0/swagger-ui.css" integrity="sha384-WoOxtFhjrhn23jYeguEcSJkYdgSIer0UxZkoMKKEqROW+TDEmHEPwckfxWmZXSIw" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.32.14/swagger-ui.css" integrity="sha384-fgyWYkUAamzuI8mJFu/xpRP0JWCJRwkwUwsYDoOYVHUJ8NQE5cENn8ib3ppwFFSX" crossorigin="anonymous">
   </head>
   <body class="td-{{ .Kind }}">
     {{ partial "llms-directive.html" . -}}
@@ -30,8 +30,8 @@
             {{ if not (.Param "ui.breadcrumb_disable") -}}
               {{ partial "breadcrumb.html" . -}}
             {{ end -}}
-            <script src="https://unpkg.com/swagger-ui-dist@5.21.0/swagger-ui-bundle.js" integrity="sha384-sVLSl7HyCV1nd7RZmv/iLgSAiKQD9VfnzE0//SWrbZUtoVy2sPhQuAHF5hNCpDp7" crossorigin="anonymous"></script>
-            <script src="https://unpkg.com/swagger-ui-dist@5.21.0/swagger-ui-standalone-preset.js" integrity="sha384-Zc0myuwGRY+wF+Mppj70Hoq/w2OticNP92nkFTlghzBS/OxDNlYummEqqmcOCyAX" crossorigin="anonymous"></script>
+            <script src="https://unpkg.com/swagger-ui-dist@5.32.14/swagger-ui-bundle.js" integrity="sha384-Dt83RhU85ZmX7werw9uTFCzmauXUoSyx3pdzTQMABtsnFmooJy4Vz9/ACh7n5m1A" crossorigin="anonymous"></script>
+            <script src="https://unpkg.com/swagger-ui-dist@5.32.14/swagger-ui-standalone-preset.js" integrity="sha384-qHFJhTu2p93skX4AENE6nxauu1KhO4wMiEideQ4Lmr30H6EwV0WlLYcPXkyR1yvu" crossorigin="anonymous"></script>
             {{ block "main" . }}{{ end }}
           </main>
         </div>


### PR DESCRIPTION
- **swagger-ui-dist 5.21.0 → 5.32.14** (unpkg, `sha384`) and **DocSearch js/css 3.8.2 → 3.9.0** (jsDelivr, `sha512`): routine pin bumps of the hardcoded CDN loads; both versions past release cooldown, changelog scans clean for our classic-bundle and UMD usage.
- **SRI hashes regenerated from the npm tarballs** (not the CDN responses), then verified byte-identical against what each CDN serves.
- **DocSearch URLs now name the file path explicitly** (`/dist/umd/index.js`, `/dist/style.css`): jsDelivr's extensionless default entry is dynamically generated (it prepends a banner), so its bytes never match a tarball-derived SRI hash — jsDelivr itself warns against SRI on such URLs.
- Validated with `npm run test:repo` and a rendered check (swagger-layout page + DocSearch box, no console/SRI errors).
