### PR TITLE
Add a Swagger UI test page with vendored petstore spec

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -416,6 +416,7 @@ https://github.com/google/docsy/issues/new?title=Search,200,1782498242
 https://github.com/google/docsy/issues/new?title=Semantic%20classes,200,1787146561
 https://github.com/google/docsy/issues/new?title=Serving%20your%20site%20locally,200,1782498244
 https://github.com/google/docsy/issues/new?title=Style%20guide,200,1782498547
+https://github.com/google/docsy/issues/new?title=Swagger%20UI,200,1787764312
 https://github.com/google/docsy/issues/new?title=Taxonomy%20Support,200,1782498243
 https://github.com/google/docsy/issues/new?title=Troubleshooting%20and%20known%20issues,200,1784211755
 https://github.com/google/docsy/issues/new?title=Update%20Docsy%20without%20Hugo%20Modules,200,1782498243
@@ -898,6 +899,7 @@ https://swagger.io/tools/swagger-ui/,200,1782498237
 https://tekton.dev/,200,1782498244
 https://themes.gohugo.io/,200,1782498226
 https://theupdateframework.io/,200,1782498230
+https://unpkg.com/swagger-ui-dist@5.32.14/swagger-ui.css,200,1787764312
 https://v0-6.kubeflow.org/docs/,200,1782498237
 https://web.archive.org/web/20251116052945/https://docs.fontawesome.com/v6/web/setup/upgrade/whats-changed,200,1782498226
 https://web.archive.org/web/20251117042118/https://docs.fontawesome.com/v6/web/setup/upgrade,200,1782498230

--- a/docsy.dev/content/en/docs/content/shortcodes/index.md
+++ b/docsy.dev/content/en/docs/content/shortcodes/index.md
@@ -442,8 +442,8 @@ description: Reference for the Pet Store API
 <!-- prettier-ignore-end -->
 <!-- markdownlint-restore -->
 
-For a live rendering of this example, see the [Swagger UI test
-page](/tests/layouts/swagger/).
+For a live rendering of this example, see the
+[Swagger UI test page](/tests/layouts/swagger/).
 
 > [!IMPORTANT]
 >

--- a/docsy.dev/content/en/docs/content/shortcodes/index.md
+++ b/docsy.dev/content/en/docs/content/shortcodes/index.md
@@ -442,6 +442,9 @@ description: Reference for the Pet Store API
 <!-- prettier-ignore-end -->
 <!-- markdownlint-restore -->
 
+For a live rendering of this example, see the [Swagger UI test
+page](/tests/layouts/swagger/).
+
 > [!IMPORTANT]
 >
 > This shortcode relies on JavaScript libraries hosted on unpkg. Make sure that

--- a/docsy.dev/content/en/tests/layouts/swagger.md
+++ b/docsy.dev/content/en/tests/layouts/swagger.md
@@ -5,7 +5,7 @@ type: swagger
 
 This page renders [`/openapi/petstore.yaml`](/openapi/petstore.yaml) using the
 `swagger` layout and `swaggerui` shortcode. It exercises the theme's pinned
-Swagger UI CDN assets: after a version or SRI-hash bump, an API reference
-below and a clean browser console (no `integrity` errors) confirm the pins.
+Swagger UI CDN assets: after a version or SRI-hash bump, an API reference below
+and a clean browser console (no `integrity` errors) confirm the pins.
 
 {{< swaggerui src="/openapi/petstore.yaml" >}}

--- a/docsy.dev/content/en/tests/layouts/swagger.md
+++ b/docsy.dev/content/en/tests/layouts/swagger.md
@@ -1,0 +1,11 @@
+---
+title: Swagger UI
+type: swagger
+---
+
+This page renders [`/openapi/petstore.yaml`](/openapi/petstore.yaml) using the
+`swagger` layout and `swaggerui` shortcode. It exercises the theme's pinned
+Swagger UI CDN assets: after a version or SRI-hash bump, an API reference
+below and a clean browser console (no `integrity` errors) confirm the pins.
+
+{{< swaggerui src="/openapi/petstore.yaml" >}}

--- a/docsy.dev/lychee.toml
+++ b/docsy.dev/lychee.toml
@@ -40,4 +40,6 @@ exclude = [
   '^https://github\.com/google/docsy/releases/(tag/)?v0\.17\.0$',
   '^https://www\.docsy\.dev/blog/2026/0\.17\.0/$',
   '^https://main--docsydocs\.netlify\.app/blog/2026/0\.17\.0/$',
+  '^https://www\.docsy\.dev/tests/layouts/swagger/$',
+  '^https://main--docsydocs\.netlify\.app/tests/layouts/swagger/$',
 ]

--- a/docsy.dev/static/openapi/petstore.yaml
+++ b/docsy.dev/static/openapi/petstore.yaml
@@ -1,0 +1,120 @@
+# Source: https://github.com/OAI/learn.openapis.org/blob/main/examples/v3.0/petstore.yaml
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pets'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+        required: true
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      maxItems: 100
+      items:
+        $ref: '#/components/schemas/Pet'
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
- **Permanent rendered check for the theme's Swagger UI CDN pins** (follow-up to #2744): a `/tests/layouts/swagger/` page exercising the `swagger` layout + `swaggerui` shortcode, so every future version/SRI bump has a stable URL for the browser check -- and its deploy preview shows reviewers the pins working.
- **Vendors the minimal petstore spec** (OAI `learn.openapis.org` example, source noted in-file) at `/openapi/petstore.yaml`: self-contained, no live petstore dependency, and the page doubles as a live rendering of the shortcode docs' exact example -- now linked from that docs section.
- **Preview(s)**:
  - https://deploy-preview-2745--docsydocs.netlify.app/tests/layouts/swagger/
