### PR TITLE
AGENTS.md: set the release milestone on PRs landing in the upcoming release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,12 @@ notes), see the maintainer notes' [Content placement][] section.
 [Content placement]:
   docsy.dev/content/en/project/about/maintainer-notes.md#content-placement
 
+## Pull requests
+
+When creating a PR whose changes will land in the upcoming release, set the
+PR's milestone to that release (e.g. `0.17.0`); the open release milestones are
+listed at <https://github.com/google/docsy/milestones>.
+
 ## Monorepo layout
 
 The repo root orchestrates two npm workspaces:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,8 @@ notes), see the maintainer notes' [Content placement][] section.
 
 ## Pull requests
 
-When creating a PR whose changes will land in the upcoming release, set the
-PR's milestone to that release (e.g. `0.17.0`); the open release milestones are
+When creating a PR whose changes will land in the upcoming release, set the PR's
+milestone to that release (e.g. `0.17.0`); the open release milestones are
 listed at <https://github.com/google/docsy/milestones>.
 
 ## Monorepo layout


### PR DESCRIPTION
- Records the owner's PR-milestone rule (2026-08-26) where agent lanes onboard, so PRs created for the upcoming release get the milestone set without being told.
