### PR TITLE
i18n: fill missing keys across all locales

### DIFF
--- a/theme/i18n/ar.yaml
+++ b/theme/i18n/ar.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: تنبيه
+important: مهم
+note: ملاحظة
+tip: نصيحة
+warning: تحذير
+
 # UI strings. Buttons and similar.
 ui_pager_prev: السَّابق
 ui_pager_next: التَّالي
@@ -60,3 +67,7 @@ feedback_title: تَقيِيم الأدَاء
 feedback_question: هل كَانَت هَذِه الصَّفْحة مُفيدَة
 feedback_positive: نعم
 feedback_negative: لََا
+
+# Table of contents
+toc_on_this_page: في هذه الصفحة
+toc_top_of_page: أعلى الصفحة

--- a/theme/i18n/az.yaml
+++ b/theme/i18n/az.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: Diqqət
+important: Vacib
+note: Qeyd
+tip: Məsləhət
+warning: Xəbərdarlıq
+
 # UI strings. Buttons and similar.
 ui_pager_prev: Əvvəlki
 ui_pager_next: Növbəti
@@ -20,6 +27,7 @@ post_byline_by: tərəfindən
 post_created: Yaradıldı
 post_last_mod: Son redaktə
 post_edit_this: Bu səhifəni redaktə edin
+post_view_markdown: Markdown-ı görüntülə
 post_view_this: Səhifənin mənbəyini görüntülə
 post_create_child_page: Alt səhifə yaradın
 post_create_issue: Sənəd mövzusu yaradın
@@ -59,3 +67,7 @@ feedback_title: Rəy
 feedback_question: Bu səhifə sizin üçün faydalı oldu?
 feedback_positive: Bəli
 feedback_negative: Xeyr
+
+# Table of contents
+toc_on_this_page: Bu səhifədə
+toc_top_of_page: Səhifənin yuxarısı

--- a/theme/i18n/bg.yaml
+++ b/theme/i18n/bg.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: Внимание
+important: Важно
+note: Забележка
+tip: Съвет
+warning: Предупреждение
+
 # UI strings. Buttons and similar.
 ui_pager_prev: Предишен
 ui_pager_next: Следващ
@@ -6,6 +13,9 @@ ui_search: Търси в тази страница…
 
 # Used in sentences such as "Posted in News"
 ui_in: в
+
+# Used in sentences such as "All Tags"
+ui_all: всички
 
 # Footer text
 footer_all_rights_reserved: Всички права запазени!
@@ -19,6 +29,7 @@ post_last_mod: Последна промяна
 post_edit_this: Промени тази страница
 post_create_child_page: Създай дъщерна страница
 post_view_markdown: Преглед на Markdown
+post_view_this: Преглед на изходния код на страницата
 post_create_issue: Създаване на издаване на документ
 post_create_project_issue: Създаване на издаване на проект
 post_posts_in: Публикувано в
@@ -49,3 +60,13 @@ community_how_to: >-
   You can find out how to contribute to {{ .Site.Title }} in our
 community_guideline: >-
   Contribution Guidelines
+
+# Feedback
+feedback_title: Обратна връзка
+feedback_question: Беше ли полезна тази страница?
+feedback_positive: Да
+feedback_negative: Не
+
+# Table of contents
+toc_on_this_page: На тази страница
+toc_top_of_page: Към началото на страницата

--- a/theme/i18n/et.yaml
+++ b/theme/i18n/et.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: Ettevaatust
+important: Tähtis
+note: Märkus
+tip: Vihje
+warning: Hoiatus
+
 # UI strings. Buttons and similar.
 ui_pager_prev: Eelmine
 ui_pager_next: Järgmine
@@ -7,6 +14,9 @@ ui_search: Otsi lehelt…
 # Used in sentences such as "Posted in News"
 # not perfect. In Estonian this idea is represented by a suffix, not a separate word.
 ui_in: kohas
+
+# Used in sentences such as "All Tags"
+ui_all: kõik
 
 # Footer text
 footer_all_rights_reserved: Kõik õigused kaitstud
@@ -20,6 +30,7 @@ post_created: Loodud
 post_last_mod: Viimati muudetud
 post_edit_this: Täienda lehte
 post_view_markdown: Vaata Markdowni
+post_view_this: Vaata lehe lähtekoodi
 post_create_child_page: Loo alamleht
 # perhaps there is a better translation for "issue"...
 post_create_issue: Tõstata dokumentatsiooni kohta ülesanne
@@ -28,6 +39,13 @@ post_create_project_issue: Tõstata projekti kohta ülesanne
 post_posts_in: Postitused
 post_reading_time: minute read
 post_less_than_a_minute_read: less than a minute
+
+# Print support
+print_printable_section:
+  See on selle jaotise mitmeleheküljeline prinditav vaade.
+print_click_to_print: Printimiseks klõpsa siia
+print_show_regular: Tagasi selle lehe tavavaatesse
+print_entire_section: Prindi kogu jaotis
 
 # Community
 community_join: >-
@@ -47,3 +65,13 @@ community_how_to: >-
   You can find out how to contribute to {{ .Site.Title }} in our
 community_guideline: >-
   Contribution Guidelines
+
+# Feedback
+feedback_title: Tagasiside
+feedback_question: Kas sellest lehest oli abi?
+feedback_positive: Jah
+feedback_negative: Ei
+
+# Table of contents
+toc_on_this_page: Sellel lehel
+toc_top_of_page: Lehe algusesse

--- a/theme/i18n/fa.yaml
+++ b/theme/i18n/fa.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: احتیاط
+important: مهم
+note: یادداشت
+tip: نکته
+warning: هشدار
+
 # UI strings. Buttons and similar.
 ui_pager_prev: قبلی
 ui_pager_next: بعدی
@@ -6,6 +13,9 @@ ui_search: در این سایت جستجو کنید...
 
 # Used in sentences such as "Posted in News"
 ui_in: در
+
+# Used in sentences such as "All Tags"
+ui_all: همه
 
 # Footer text
 footer_all_rights_reserved: تمام حقوق محفوظ است.
@@ -56,3 +66,7 @@ feedback_title: بازخورد
 feedback_question: این صفحه به شما کمک کرد؟
 feedback_positive: آره
 feedback_negative: نه
+
+# Table of contents
+toc_on_this_page: در این صفحه
+toc_top_of_page: بالای صفحه

--- a/theme/i18n/fi.yaml
+++ b/theme/i18n/fi.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: Huomio
+important: Tärkeää
+note: Huomautus
+tip: Vinkki
+warning: Varoitus
+
 # UI strings. Buttons and similar.
 ui_pager_prev: Edellinen
 ui_pager_next: Seuraava
@@ -52,3 +59,13 @@ community_how_to: >-
   Voit oppia kehittämään {{ .Site.Title }}:a meidän
 community_guideline: >-
   osallistumisohjeissamme
+
+# Feedback
+feedback_title: Palaute
+feedback_question: Oliko tästä sivusta apua?
+feedback_positive: Kyllä
+feedback_negative: Ei
+
+# Table of contents
+toc_on_this_page: Tällä sivulla
+toc_top_of_page: Sivun alkuun

--- a/theme/i18n/fi.yaml
+++ b/theme/i18n/fi.yaml
@@ -12,7 +12,8 @@ ui_read_more: Lue lisää
 ui_search: Hae sivustolta...
 
 # Used in sentences such as "Posted in News"
-ui_in:
+# Not perfect: Finnish expresses this with a case suffix, not a separate word.
+ui_in: osiossa
 
 # Used in sentences such as "All Tags"
 ui_all: kaikki

--- a/theme/i18n/fr.yaml
+++ b/theme/i18n/fr.yaml
@@ -14,6 +14,9 @@ ui_search: Rechercher
 # Used in sentences such as "Posted in News"
 ui_in: dans
 
+# Used in sentences such as "All Tags"
+ui_all: tous
+
 # Footer text
 footer_all_rights_reserved: Tous droits réservés
 

--- a/theme/i18n/hi.yaml
+++ b/theme/i18n/hi.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: सावधानी
+important: महत्वपूर्ण
+note: नोट
+tip: सुझाव
+warning: चेतावनी
+
 # UI strings. Buttons and similar.
 ui_pager_prev: पिछला
 ui_pager_next: अगला
@@ -54,3 +61,13 @@ community_how_to: >-
   आप हमारे यहां {{ .Site.Title }} में योगदान करने का तरीका जान सकते हैं
 community_guideline: >-
   योगदान दिशानिर्देश
+
+# Feedback
+feedback_title: प्रतिक्रिया
+feedback_question: क्या यह पृष्ठ सहायक था?
+feedback_positive: हाँ
+feedback_negative: नहीं
+
+# Table of contents
+toc_on_this_page: इस पृष्ठ पर
+toc_top_of_page: पृष्ठ के शीर्ष पर

--- a/theme/i18n/hu.yaml
+++ b/theme/i18n/hu.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: Vigyázat
+important: Fontos
+note: Megjegyzés
+tip: Tipp
+warning: Figyelmeztetés
+
 # UI strings. Buttons and similar.
 ui_pager_prev: Előző
 ui_pager_next: Következő
@@ -6,6 +13,9 @@ ui_search: Keresés ezen az oldalon…
 
 # so I left it as is
 ui_in: in
+
+# Used in sentences such as "All Tags"
+ui_all: összes
 
 # Footer text
 footer_all_rights_reserved: Minden jog fenntartva
@@ -19,6 +29,7 @@ post_last_mod: Utolsó módosítás
 post_edit_this: Oldal szerkesztése
 post_create_child_page: Aloldal létrehozása
 post_view_markdown: Markdown megtekintése
+post_view_this: Az oldal forrásának megtekintése
 post_create_issue: Dokumentáció issue létrehozása
 post_create_project_issue: Projekt issue létrehozása
 # so I left it as is
@@ -50,3 +61,13 @@ community_how_to: >-
   You can find out how to contribute to {{ .Site.Title }} in our
 community_guideline: >-
   Contribution Guidelines
+
+# Feedback
+feedback_title: Visszajelzés
+feedback_question: Hasznos volt ez az oldal?
+feedback_positive: Igen
+feedback_negative: Nem
+
+# Table of contents
+toc_on_this_page: Ezen az oldalon
+toc_top_of_page: Az oldal tetejére

--- a/theme/i18n/it.yaml
+++ b/theme/i18n/it.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: Attenzione
+important: Importante
+note: Nota
+tip: Suggerimento
+warning: Avviso
+
 # UI strings. Buttons and similar.
 ui_pager_prev: Precedente
 ui_pager_next: Successivo
@@ -6,6 +13,9 @@ ui_search: Cerca nel sito…
 
 # Used in sentences such as "Posted in News"
 ui_in: in
+
+# Used in sentences such as "All Tags"
+ui_all: tutti
 
 # Footer text
 footer_all_rights_reserved: Tutti i diritti riservati
@@ -19,6 +29,7 @@ post_last_mod: Ultima modifica
 post_edit_this: Modifica
 post_create_child_page: Create child page
 post_view_markdown: Visualizza Markdown
+post_view_this: Visualizza il sorgente della pagina
 post_create_issue: Crea issue di documentazione
 post_create_project_issue: Crea issue di progetto
 post_posts_in: Post in
@@ -49,3 +60,13 @@ community_how_to: >-
   You can find out how to contribute to {{ .Site.Title }} in our
 community_guideline: >-
   Contribution Guidelines
+
+# Feedback
+feedback_title: Feedback
+feedback_question: Questa pagina è stata utile?
+feedback_positive: Sì
+feedback_negative: No
+
+# Table of contents
+toc_on_this_page: In questa pagina
+toc_top_of_page: Inizio pagina

--- a/theme/i18n/ja.yaml
+++ b/theme/i18n/ja.yaml
@@ -14,6 +14,9 @@ ui_search: サイトを検索...
 # Used in sentences such as "Posted in News"
 ui_in: in
 
+# Used in sentences such as "All Tags"
+ui_all: すべて
+
 # Footer text
 footer_all_rights_reserved: All Rights Reserved
 
@@ -62,3 +65,7 @@ feedback_title: フィードバック
 feedback_question: このページは役に立ちましたか?
 feedback_positive: 役に立った
 feedback_negative: 役に立たなかった
+
+# Table of contents
+toc_on_this_page: このページの内容
+toc_top_of_page: ページの先頭へ

--- a/theme/i18n/ko.yaml
+++ b/theme/i18n/ko.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: 주의
+important: 중요
+note: 참고
+tip: 팁
+warning: 경고
+
 # UI strings. Buttons and similar.
 ui_pager_prev: 이전
 ui_pager_next: 다음
@@ -6,6 +13,9 @@ ui_search: 사이트에서 검색…
 
 # Used in sentences such as "Posted in News"
 ui_in: in
+
+# Used in sentences such as "All Tags"
+ui_all: 모든
 
 # Footer text
 footer_all_rights_reserved: All Rights Reserved
@@ -19,6 +29,7 @@ post_last_mod: 최종 수정
 post_edit_this: 페이지 편집
 post_create_child_page: 하부 페이지 생성
 post_view_markdown: Markdown 보기
+post_view_this: 페이지 소스 보기
 post_create_issue: 문서에 이슈 생성
 post_create_project_issue: 프로젝트에 이슈 생성
 post_posts_in: Posts in
@@ -49,3 +60,13 @@ community_how_to: >-
   You can find out how to contribute to {{ .Site.Title }} in our
 community_guideline: >-
   Contribution Guidelines
+
+# Feedback
+feedback_title: 피드백
+feedback_question: 이 페이지가 도움이 되었나요?
+feedback_positive: 예
+feedback_negative: 아니요
+
+# Table of contents
+toc_on_this_page: 이 페이지에서
+toc_top_of_page: 페이지 상단으로

--- a/theme/i18n/nl.yaml
+++ b/theme/i18n/nl.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: Let op
+important: Belangrijk
+note: Opmerking
+tip: Tip
+warning: Waarschuwing
+
 # UI strings. Buttons and similar.
 ui_pager_prev: Vorige
 ui_pager_next: Volgende
@@ -54,3 +61,13 @@ community_how_to: >-
   onze
 community_guideline: >-
   Richtlijnen voor bijdrage
+
+# Feedback
+feedback_title: Feedback
+feedback_question: Was deze pagina nuttig?
+feedback_positive: Ja
+feedback_negative: Nee
+
+# Table of contents
+toc_on_this_page: Op deze pagina
+toc_top_of_page: Begin van de pagina

--- a/theme/i18n/oc.yaml
+++ b/theme/i18n/oc.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: Atencion
+important: Important
+note: Nòta
+tip: Conselh
+warning: Avertiment
+
 # UI strings. Buttons and similar.
 ui_pager_prev: Precedent
 ui_pager_next: Seguent
@@ -58,3 +65,7 @@ feedback_title: Feedback
 feedback_question: Èra utila aquesta pagina ?
 feedback_positive: Oc
 feedback_negative: Non
+
+# Table of contents
+toc_on_this_page: Sus aquesta pagina
+toc_top_of_page: Naut de la pagina

--- a/theme/i18n/pl.yaml
+++ b/theme/i18n/pl.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: Przestroga
+important: Ważne
+note: Uwaga
+tip: Porada
+warning: Ostrzeżenie
+
 # UI strings. Buttons and similar.
 ui_pager_prev: Wstecz
 ui_pager_next: Dalej
@@ -6,6 +13,9 @@ ui_search: Szukaj na stronie ...
 
 # Used in sentences such as "Posted in News"
 ui_in: w
+
+# Used in sentences such as "All Tags"
+ui_all: wszystkie
 
 # Footer text
 footer_all_rights_reserved: Wszelkie prawa zastrzeżone
@@ -19,6 +29,7 @@ post_last_mod: Ostatnia modyfikacja
 post_edit_this: Edytuj tę stronę
 post_create_child_page: Utwórz podstronę
 post_view_markdown: Wyświetl Markdown
+post_view_this: Zobacz źródło strony
 post_create_issue: Zgłoś błąd w dokumencie
 post_create_project_issue: Zgłoś błąd na stronie
 post_posts_in: Posty
@@ -49,3 +60,13 @@ community_how_to: >-
   You can find out how to contribute to {{ .Site.Title }} in our
 community_guideline: >-
   Contribution Guidelines
+
+# Feedback
+feedback_title: Opinia
+feedback_question: Czy ta strona była pomocna?
+feedback_positive: Tak
+feedback_negative: Nie
+
+# Table of contents
+toc_on_this_page: Na tej stronie
+toc_top_of_page: Początek strony

--- a/theme/i18n/sv.yaml
+++ b/theme/i18n/sv.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: Försiktighet
+important: Viktigt
+note: Anmärkning
+tip: Tips
+warning: Varning
+
 # UI strings. Buttons and similar.
 ui_pager_prev: Tidigare
 ui_pager_next: Nästa
@@ -54,3 +61,13 @@ community_how_to: >-
   Du kan ta reda på hur du medverkar till {{ .Site.Title }} i våra
 community_guideline: >-
   Riktlinjer för att Medverka
+
+# Feedback
+feedback_title: Feedback
+feedback_question: Var den här sidan till hjälp?
+feedback_positive: Ja
+feedback_negative: Nej
+
+# Table of contents
+toc_on_this_page: På den här sidan
+toc_top_of_page: Överst på sidan

--- a/theme/i18n/tr.yaml
+++ b/theme/i18n/tr.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: Dikkat
+important: Önemli
+note: Not
+tip: İpucu
+warning: Uyarı
+
 # UI strings. Buttons and similar.
 ui_pager_prev: Önceki
 ui_pager_next: Sonraki
@@ -61,3 +68,7 @@ feedback_title: Geribildirim
 feedback_question: Bu sayfa yararlı oldu mu?
 feedback_positive: Evet
 feedback_negative: Hayır
+
+# Table of contents
+toc_on_this_page: Bu sayfada
+toc_top_of_page: Sayfanın başı


### PR DESCRIPTION
- Contributes to #2390: resumes and completes the per-locale i18n backfill, which stalled mid-alphabet at 16/31 locales
- **Fills every missing key**, so that all 31 locales now carry the full `en.yaml` key set: alert labels (15 locales), `toc_*` (16), `feedback_*` (10), `ui_all` (9), `post_view_this` (6), az `post_view_markdown`, and the et print section
- **Fills `fi` `ui_in`** (empty value, which falls back to English in blog bylines); surfaced by post-submit review
- **Best-effort first cut**: values use OS/docs-canonical terms, kept consistent with each locale's existing style; native-speaker corrections welcome as follow-up PRs
