### PR TITLE
Nav page: drop an orphan footnote reference

### DIFF
--- a/docsy.dev/content/en/docs/content/navigation.md
+++ b/docsy.dev/content/en/docs/content/navigation.md
@@ -75,7 +75,7 @@ section index or page with `weight: 30` would appear after the Documentation
 section in the menu, while one with `weight: 10` would appear before it.
 
 If you want to add a link to an external site to this menu, add it to your site
-configuration:[^add-external-link-via]
+configuration:
 
 {{< tabpane text=true persist=lang >}}
 {{< tab header="Configuration file:" disabled=true />}}


### PR DESCRIPTION
- Drops a footnote reference that has rendered as literal `[^add-external-link-via]` text on the [Navigation page](https://www.docsy.dev/docs/content/navigation/#adding-icons-to-the-navbar) since #2372, which added the reference without its definition; the sentence reads fine without it
- Site-wide scan: no other orphan footnote references (two other suspects are correctly rendered indented definitions)
- Not catchable by the current lint net: markdownlint's MD052 covers reference links/images only; footnote references are outside its rule vocabulary (verified by probe)

**Preview**: https://deploy-preview-2754--docsydocs.netlify.app/docs/content/navigation/
