### PR TITLE
Blog+CL 0.17.0: cover Font Awesome 7, the i18n wave, and the Docker drop

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -77,6 +77,7 @@
     "vsoch",
     "warnf",
     "warnidf",
+    "webfonts",
     "worktree",
     "wrapup"
   ]

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -307,6 +307,7 @@ https://github.com/google/docsy/issues/1841,200,1782498235
 https://github.com/google/docsy/issues/1845,200,1782498239
 https://github.com/google/docsy/issues/1852,200,1782498238
 https://github.com/google/docsy/issues/1944,200,1782498238
+https://github.com/google/docsy/issues/1987,200,1787961973
 https://github.com/google/docsy/issues/2,200,1782498235
 https://github.com/google/docsy/issues/2001,200,1782498235
 https://github.com/google/docsy/issues/2035,200,1782498234

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -56,6 +56,7 @@ https://docs.docker.com/compose/install/,200,1782563368
 https://docs.docker.com/engine/install/,200,1782563368
 https://docs.docker.com/engine/reference/builder/,200,1782563368
 https://docs.docker.com/get-docker/,200,1782498226
+https://docs.fontawesome.com/web/setup/upgrade/whats-changed,200,1787929766
 https://docs.github.com/en/actions,200,1782563369
 https://docs.github.com/en/actions/deployment/about-deployments/about-continuous-deployment,200,1782563367
 https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository,200,1782563368
@@ -94,6 +95,7 @@ https://favicon.io/,200,1782498227
 https://fission.io/,200,1782498244
 https://flaviocopes.com/npm-packages-local-global/,200,1782563368
 https://fluxcd.io/,200,1782498244
+https://fontawesome.com/,200,1787929766
 https://fontawesome.com/icons/,200,1782498227
 https://fontawesome.com/icons?d=gallery&m=free,200,1782498237
 https://fontawesome.com/icons?d=gallery&p=2,200,1782498235
@@ -316,6 +318,7 @@ https://github.com/google/docsy/issues/2266,200,1782498235
 https://github.com/google/docsy/issues/2285,200,1782498225
 https://github.com/google/docsy/issues/2289,200,1782498234
 https://github.com/google/docsy/issues/2313,200,1782498225
+https://github.com/google/docsy/issues/2314,200,1787929767
 https://github.com/google/docsy/issues/2328,200,1782498234
 https://github.com/google/docsy/issues/2329,200,1782563367
 https://github.com/google/docsy/issues/2331,200,1782498225
@@ -476,6 +479,7 @@ https://github.com/google/docsy/pull/2259,200,1782498225
 https://github.com/google/docsy/pull/2276,200,1782498225
 https://github.com/google/docsy/pull/2291,200,1782498242
 https://github.com/google/docsy/pull/2303,200,1782498224
+https://github.com/google/docsy/pull/2332,200,1787929767
 https://github.com/google/docsy/pull/2364,200,1782498224
 https://github.com/google/docsy/pull/2366,200,1782498224
 https://github.com/google/docsy/pull/2371,200,1782498225
@@ -492,9 +496,11 @@ https://github.com/google/docsy/pull/2406,200,1782498224
 https://github.com/google/docsy/pull/2443,200,1782498223
 https://github.com/google/docsy/pull/2444,200,1782498223
 https://github.com/google/docsy/pull/2447,200,1782498232
+https://github.com/google/docsy/pull/2451,200,1787929768
 https://github.com/google/docsy/pull/2470,200,1782498223
 https://github.com/google/docsy/pull/2477,200,1782563372
 https://github.com/google/docsy/pull/2480,200,1782498223
+https://github.com/google/docsy/pull/2482,200,1787929767
 https://github.com/google/docsy/pull/2505/changes,200,1782498233
 https://github.com/google/docsy/pull/2524,200,1782498223
 https://github.com/google/docsy/pull/2533,200,1782498223
@@ -543,7 +549,9 @@ https://github.com/google/docsy/pull/2722,200,1787153684
 https://github.com/google/docsy/pull/2724,200,1787076569
 https://github.com/google/docsy/pull/2726,200,1787137876
 https://github.com/google/docsy/pull/2731,200,1787331617
+https://github.com/google/docsy/pull/2747,200,1787929767
 https://github.com/google/docsy/pull/2748,200,1787848215
+https://github.com/google/docsy/pull/2751,200,1787929767
 https://github.com/google/docsy/pull/941,200,1782498225
 https://github.com/google/docsy/pulls,200,1782563369
 https://github.com/google/docsy/releases,200,1782563368

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -56,6 +56,8 @@ https://docs.docker.com/compose/install/,200,1782563368
 https://docs.docker.com/engine/install/,200,1782563368
 https://docs.docker.com/engine/reference/builder/,200,1782563368
 https://docs.docker.com/get-docker/,200,1782498226
+https://docs.fontawesome.com/upgrade/scss,200,1787947232
+https://docs.fontawesome.com/web/dig-deeper/accessibility,200,1787947232
 https://docs.fontawesome.com/web/setup/upgrade/whats-changed,200,1787929766
 https://docs.github.com/en/actions,200,1782563369
 https://docs.github.com/en/actions/deployment/about-deployments/about-continuous-deployment,200,1782563367

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -131,6 +131,7 @@ https://getbootstrap.com/docs/5.3/customize/color/,200,1782498237
 https://getbootstrap.com/docs/5.3/customize/sass/#maps-and-loops,200,1782498237
 https://getbootstrap.com/docs/5.3/customize/sass/#variable-defaults,200,1782498237
 https://getbootstrap.com/docs/5.3/getting-started/rtl/,200,1782563368
+https://getbootstrap.com/docs/5.3/helpers/visually-hidden/,200,1787941870
 https://git-scm.com/,200,1782563368
 https://git-scm.com/book/en/v2/Git-Tools-Submodules,200,1782563368
 https://git-scm.com/downloads,200,1787863994

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -348,6 +348,7 @@ https://github.com/google/docsy/issues/2705,200,1787588586
 https://github.com/google/docsy/issues/2706,200,1787588586
 https://github.com/google/docsy/issues/2732,200,1787323021
 https://github.com/google/docsy/issues/2737,200,1787613566
+https://github.com/google/docsy/issues/2756,200,1787934072
 https://github.com/google/docsy/issues/331,200,1782498237
 https://github.com/google/docsy/issues/349,200,1782498234
 https://github.com/google/docsy/issues/375,200,1782498235

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -318,6 +318,7 @@ https://github.com/google/docsy/issues/2133,200,1782563371
 https://github.com/google/docsy/issues/2173,200,1782498225
 https://github.com/google/docsy/issues/2243,200,1782498234
 https://github.com/google/docsy/issues/2266,200,1782498235
+https://github.com/google/docsy/issues/2279,200,1787948759
 https://github.com/google/docsy/issues/2285,200,1782498225
 https://github.com/google/docsy/issues/2289,200,1782498234
 https://github.com/google/docsy/issues/2313,200,1782498225

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -55,13 +55,15 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
     `install:theme-deps`, retiring npm install hooks
 - **[Semantic classes](#semantic-classes)**: breadcrumb markup moves from
   Bootstrap to `td-` classes
-- **[Agent directive in page HTML](#llms-directive)** (experimental):
-  `llms.txt`-enabled sites point agents to the index
 - **[Internationalization](#internationalization)**: theme-UI strings fully
   translatable, with gaps filled across all locales
-- **[Other notable changes](#other-notable-changes)**: footer-copyright fix and
-  the Docker-quickstart retirement; and [for maintainers](#for-maintainers):
-  supply-chain hardening and npm trusted publishing
+- **[Agent directive in page HTML](#llms-directive)** (experimental):
+  `llms.txt`-enabled sites point agents to the index
+- **[Other notable changes](#other-notable-changes)**:
+  - Footer-copyright rendering fix
+  - Docker-quickstart retirement
+  - [For maintainers](#for-maintainers): supply-chain hardening and npm trusted
+    publishing
 
 ## Ready to upgrade? <a id="breaking-changes"></a>
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -4,9 +4,9 @@ linkTitle: Release 0.17.0
 date: 2026-08-19
 draft: true
 description: >-
-  Docsy modernizes its foundations: builds move to Dart Sass (the sass CLI joins
-  your build), icons to Font Awesome 7, and script defaults to pinned versions;
-  breadcrumbs begin the move to semantic classes.
+  Docsy modernizes and strengthens its foundations: builds move to Dart Sass
+  (the sass CLI joins your build), icons to Font Awesome 7, and script defaults
+  to pinned versions; breadcrumbs begin the move to semantic classes.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
@@ -28,10 +28,10 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
 
 {{% card header="Highlights" %}}
 
-- {{% _param FAS_LG rocket primary %}} <span>**Modernized foundations**:
-  [Dart Sass](#dart-sass), [Font Awesome 7](#fontawesome), and
-  [pinned script versions](#script-dep-pins) bring Docsy's build up to
-  date</span>
+- {{% _param FAS_LG rocket primary %}} <span>**Modernized and strengthened
+  foundations**: [Dart Sass](#dart-sass), [Font Awesome 7](#fontawesome), and
+  [pinned script versions](#script-dep-pins) make Docsy's build current and its
+  rendering predictable</span>
 - {{% _param FAS_LG tags info %}}
   <span>**[Semantic classes](#semantic-classes)**: Docsy chrome markup starts
   moving from Bootstrap to Docsy's own `td-` classes, beginning with
@@ -44,8 +44,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
 
 ## Release summary
 
-- **Modernized foundations**: current, actively maintained dependencies with
-  deterministic defaults
+- **Modernized and strengthened foundations**: current, actively maintained
+  dependencies with deterministic defaults
   - [Dart Sass replaces LibSass](#dart-sass): the `sass` CLI becomes a build
     prerequisite
   - [Font Awesome 7](#fontawesome): icons render at a uniform width by default

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -165,7 +165,7 @@ release: breadcrumbs.
 | `nav.td-breadcrumbs__single` | `nav.td-breadcrumbs--single`                   |
 
 Unchanged: the `td-breadcrumbs` class on the `<nav>` element. The markup no
-longer carries an `active` class: state styling keys on the ARIA-mandated
+longer carries an `active` class: state styling keys on the standard
 `aria-current="page"` attribute, so visual state and accessibility state can't
 drift apart.
 
@@ -206,9 +206,10 @@ breadcrumb class names.
 ## {{% _param BREAKING %}} Font Awesome 7 {#fontawesome}
 
 Docsy's icon library is upgraded from [Font Awesome][] 6.7.2 to 7.3.1. Icon
-markup and the `icon:` config values keep rendering unchanged: the
-`fa-solid`/`fa-brands` classes and their `fas`/`fab` shorthands still ship, and
-no icon used by the theme was renamed.
+markup and the `icon:` config values keep rendering unchanged, with one
+Free-icon exception noted in the Actions: the `fa-solid`/`fa-brands` classes and
+their `fas`/`fab` shorthands still ship, and every icon the theme uses remains
+in the Free bundle.
 
 What you will see: **icons now render at a uniform width by default**. Font
 Awesome 7 draws every icon on a fixed-width canvas with the glyph centered,
@@ -266,8 +267,9 @@ that nearby text doesn't repeat.
   - For a semantic inline icon, add `aria-label` and `role="img"` to the icon
     itself.
 
-{{% _param BREAKING %}} **Applies if** you hotlink theme webfonts or use Font
-Awesome's screen-reader utility classes.
+{{% _param BREAKING %}} **Applies if** you hotlink theme webfonts, or use Font
+Awesome's screen-reader utility classes, layout helpers, or the `vector-square`
+icon.
 
 - Webfonts are woff2-only in v7: the `.ttf` files that v6 also shipped are gone.
   Replace any non-woff2 hotlink under `/webfonts/`.
@@ -275,6 +277,12 @@ Awesome's screen-reader utility classes.
   `.fa-sr-only-focusable` utility classes are gone from the theme's compiled
   CSS: use Bootstrap's [`.visually-hidden` and
   `.visually-hidden-focusable`][visually-hidden] instead.
+- Layout helpers (`fa-pull-*`, `fa-ul`/`fa-li`, borders) now position via CSS
+  logical properties, following text direction: recheck right-to-left pages and
+  remove any RTL compensation CSS that now double-corrects.
+- Font Awesome 7 Free drops the `vector-square` icon (its v7 successor,
+  `draw-square`, is Pro-only): a custom `icon:` value or content icon naming it
+  now renders blank. Pick a different Free icon.
 
 ## {{% _param BREAKING %}} Install command renamed {#install-command}
 
@@ -386,9 +394,10 @@ sites.
 0.17.0 hardens the project's supply-chain posture: npm lockfiles are committed
 with lock-exact, script-free installs; a committed supply-chain audit, a
 script-runner lint, and an `npm audit` gate guard the dependency and workflow
-surface; and npm install hooks and implicit `pre`/`post` run-hooks are gone
-(inlined into their parent scripts), with the full test suite renamed to
-`test:full`. The changelog's [For-maintainers list][CL@0.17.0] itemizes these.
+surface; and npm install hooks and the run scripts' implicit `pre`/`post` hooks
+are gone (inlined into their parent scripts; the pack-time lifecycle hooks
+remain), with the full test suite renamed to `test:full`. The changelog's
+[For-maintainers list][CL@0.17.0] itemizes these.
 
 ### npm trusted publishing {#trusted-publishing}
 
@@ -442,8 +451,10 @@ verification steps, and sanity checks.
 
 In addition to the [generic site checks][check], for this release:
 
-- [ ] Every environment that builds your site provides the `sass` CLI
-      (`sass --version`); see [Dart Sass actions](#dart-sass-actions).
+- [ ] Every environment that builds your site provides the `sass` CLI: for
+      npm-based sites run `npm exec --no -- sass --version` (the CLI is on
+      `PATH` inside npm scripts, not in your shell); for other installs,
+      `sass --version`. See [Dart Sass actions](#dart-sass-actions).
 - [ ] If you diff built CSS, expect the changes this post describes --
       [Dart Sass serialization](#dart-sass-recheck),
       [Font Awesome 7](#fontawesome), and

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -36,9 +36,9 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   <span>**[Semantic classes](#semantic-classes)**: Docsy chrome markup starts
   moving from Bootstrap to Docsy's own `td-` classes, beginning with
   breadcrumbs</span>
-- {{% _param FAS_LG robot warning %}}
-  <span>**[Agent directive in page HTML](#llms-directive)** (experimental):
-  every page now points AI agents to your `llms.txt` index</span>
+- {{% _param FAS_LG globe warning %}}
+  <span>**[Internationalization](#internationalization)**: the theme UI is now
+  fully translatable in every bundled locale</span>
 
 {{% /card %}}
 
@@ -57,10 +57,11 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   Bootstrap to `td-` classes
 - **[Agent directive in page HTML](#llms-directive)** (experimental):
   `llms.txt`-enabled sites point agents to the index
-- **[Other notable changes](#other-notable-changes)**: translatable theme-menu
-  labels, locale updates, Docker-quickstart retirement; and
-  [for maintainers](#for-maintainers): supply-chain hardening and npm trusted
-  publishing
+- **[Internationalization](#internationalization)**: theme-UI strings fully
+  translatable, with gaps filled across all locales
+- **[Other notable changes](#other-notable-changes)**: footer-copyright fix and
+  the Docker-quickstart retirement; and [for maintainers](#for-maintainers):
+  supply-chain hardening and npm trusted publishing
 
 ## Ready to upgrade? <a id="breaking-changes"></a>
 
@@ -74,6 +75,7 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   - [Default script-dependency versions pinned](#script-dep-pins)
   - {{% _param NEW %}} Experimental
     [agent directive in page HTML](#llms-directive)
+  - [Internationalization](#internationalization)
   - [Other notable changes](#other-notable-changes), and
     [for maintainers](#for-maintainers)
 - {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.17.0](#upgrade)
@@ -330,12 +332,15 @@ any of the theme's `baseof` templates ([print][print-docs] variants included).
 
 - **Footer copyright**: a same-year range now renders as the single year
   (`© 2026` instead of `© 2026–2026`). See the [footer copyright docs][].
-- **i18n**: the theme's light/dark mode menu labels are now translatable
-  (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`, provided for all bundled
-  locales), missing UI strings were filled in across locales, and the Turkish
-  and Ukrainian locales received updates.
 - **Docker support dropped**: the repo's broken Docker configuration files are
   removed and the Docker quickstart page is retired.
+
+### {{% _param FAS globe "" %}} Internationalization
+
+The theme UI is now fully translatable: the light/dark mode menu labels join the
+theme's i18n bundle (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`),
+provided for all bundled locales. Missing UI strings have been filled in across
+locales, and the Turkish and Ukrainian locales received updates.
 
 For this and all other changes, see the [0.17.0][] release page.
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -223,11 +223,14 @@ details, see [What's changed in v7][].
 ### Actions {#fontawesome-actions}
 
 {{% _param BREAKING %}} **Applies if** you override the
-`$td-font-awesome-font-name` theme variable with a Font Awesome family name.
+`$td-font-awesome-font-name` theme variable with a Font Awesome family name, or
+your project's CSS or Sass hardcodes one.
 
-- Update the family name for v7, for example `'Font Awesome 7 Free'` (the new
-  default). An override naming a custom, non-Font-Awesome font needs no change.
-  The variable feeds only Docsy's icon pseudo-elements, as before.
+- Update the family name for v7: `'Font Awesome 7 Free'` (the new theme default)
+  or `'Font Awesome 7 Brands'` -- v7 registers no v6-named `@font-face`, so a
+  hardcoded v6 family silently falls through to another font. An override naming
+  a custom, non-Font-Awesome font needs no change. The theme variable feeds only
+  Docsy's icon pseudo-elements, as before.
 
 {{% _param BREAKING %}} **Applies if** your project's Sass reaches into Font
 Awesome's Sass surface -- variables such as `$fa-var-*` or functions like
@@ -277,9 +280,9 @@ icon.
   `.fa-sr-only-focusable` utility classes are gone from the theme's compiled
   CSS: use Bootstrap's [`.visually-hidden` and
   `.visually-hidden-focusable`][visually-hidden] instead.
-- Layout helpers (`fa-pull-*`, `fa-ul`/`fa-li`, borders) now position via CSS
-  logical properties, following text direction: recheck right-to-left pages and
-  remove any RTL compensation CSS that now double-corrects.
+- Layout helpers `fa-pull-*` and `fa-ul`/`fa-li` now position via CSS logical
+  properties, following text direction: recheck right-to-left pages and remove
+  any RTL compensation CSS that now double-corrects.
 - Font Awesome 7 Free drops the `vector-square` icon (its v7 successor,
   `draw-square`, is Pro-only): a custom `icon:` value or content icon naming it
   now renders blank. Pick a different Free icon.
@@ -303,13 +306,19 @@ code).
   npm run install:theme-deps
   ```
 
+- Update every automation that invokes the old command -- package scripts (such
+  as the [setup guide's][other-options] `_prepare:docsy` example), CI workflows,
+  deployment commands: `npm run postinstall` now fails with npm's "Missing
+  script" error.
+
 {{% _param BREAKING %}} **Applies if** your site installs Docsy from GitHub with
 npm (development and testing only).
 
 - The theme's dependencies are no longer installed as a side effect of
-  `npm install`. Run the install command yourself, from `node_modules/docsy/`,
-  or switch to the [`@docsy/theme`][] registry package, which needs no install
-  step.
+  `npm install`. Run the install command from `node_modules/docsy/` after every
+  clean install or update -- wire it into your setup steps, since a fresh
+  `npm ci` discards the result -- or switch to the [`@docsy/theme`][] registry
+  package, which needs no install step.
 
 Hugo-module and `@docsy/theme` registry installs are unaffected.
 
@@ -451,9 +460,10 @@ verification steps, and sanity checks.
 
 In addition to the [generic site checks][check], for this release:
 
-- [ ] Every environment that builds your site provides the `sass` CLI: for
-      npm-based sites run `npm exec --no -- sass --version` (the CLI is on
-      `PATH` inside npm scripts, not in your shell); for other installs,
+- [ ] Every environment that builds your site provides Dart Sass
+      {{% param dartSassMinVersion %}} or later: npm-based sites, run
+      `node_modules/.bin/sass --version` from your project root (the CLI is on
+      `PATH` inside npm scripts, not in your shell); other installs,
       `sass --version`. See [Dart Sass actions](#dart-sass-actions).
 - [ ] If you diff built CSS, expect the changes this post describes --
       [Dart Sass serialization](#dart-sass-recheck),
@@ -540,6 +550,7 @@ About this release:
 [Netlify]: /docs/deployment/netlify/
 [official support policy]: /project/about/changelog/#official-support
 [order of steps]: /docs/update/#update-order
+[other-options]: /docs/get-started/other-options/
 [print-docs]: /docs/content/print/
 [overrides]: /docs/update/#update-overrides
 [Project style files]: /docs/content/lookandfeel/#project-style-files

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -55,8 +55,10 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
     `install:theme-deps`, retiring npm install hooks
 - **[Semantic classes](#semantic-classes)**: breadcrumb markup moves from
   Bootstrap to `td-` classes
-- **[Internationalization](#internationalization)**: complete UI-string
-  translations across all bundled locales
+- **[Internationalization](#internationalization)**:
+  - Mode-menu labels (light/dark/auto) translatable and translated
+  - Complete UI-string translations across all bundled locales
+  - Turkish and Ukrainian locale refreshes
 - **[Agent directive in page HTML](#llms-directive)** (experimental):
   `llms.txt`-enabled sites point agents to the index
 - **[Other notable changes](#other-notable-changes)**:

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -97,6 +97,34 @@ dependencies, which as a side effect covers your own [project style files][] too
 quiet build log is therefore not evidence that your own Sass is
 deprecation-free.
 
+### Expected CSS changes {#dart-sass-recheck}
+
+Dart Sass serializes some Sass-computed colors differently than LibSass did. For
+example:
+
+```diff
+- --bs-primary-bg-subtle: #cfe2ff;
++ --bs-primary-bg-subtle: rgb(81.0196078431%, 88.6274509804%, 99.8431372549%);
+```
+
+Both forms specify the same color, up to a rounding difference of at most one
+step in a single color channel. If you diff built CSS, expect this serialization
+churn throughout, alongside [Font Awesome 7](#fontawesome)'s stylesheet changes:
+it is normal, not drift. Comparison tooling -- bit-exact visual tests, snapshots
+of built CSS -- needs its expectations re-captured.
+
+### No LibSass fallback {#libsass-escape-hatch}
+
+**Applies if** your build platform has no Dart Sass distribution (for example,
+the BSDs).
+
+There is no way to keep building this release with Hugo's embedded LibSass: the
+theme's stylesheets now use `sass:` modules and Sass's new `if()` conditional
+syntax (`if(condition: value; else: value)`), which LibSass does not implement.
+In particular, overriding `head-css.html` to restore a LibSass `toCSS` call
+builds green but ships an unstyled site. For binary-less platforms, the durable
+path is Dart Sass's planned [pure-JS embedded mode][dart-sass-2413].
+
 ### Actions {#dart-sass-actions}
 
 {{% _param BREAKING %}} **Applies to all sites**: every install mode uses the
@@ -117,41 +145,12 @@ update in the [order of steps][]:
   new `if()` conditional syntax, which older releases can't parse. Only the
   Docsy-tested version is [officially supported][official support policy].
 
-### Expected CSS changes {#dart-sass-recheck}
-
-Dart Sass serializes some Sass-computed colors differently than LibSass did. For
-example:
-
-```diff
-- --bs-primary-bg-subtle: #cfe2ff;
-+ --bs-primary-bg-subtle: rgb(81.0196078431%, 88.6274509804%, 99.8431372549%);
-```
-
-Both forms specify the same color, up to a rounding difference of at most one
-step in a single color channel. If you diff built CSS, expect this serialization
-churn throughout, alongside [Font Awesome 7](#fontawesome)'s stylesheet changes:
-it is normal, not drift. Comparison tooling -- bit-exact visual tests, snapshots
-of built CSS -- needs its expectations re-captured; otherwise, the only action
-is:
-
-**Applies if** your [custom Chroma style sheets][chroma-docs]
-(`assets/scss/td/chroma/_light.scss` and `_dark.scss`) reference theme or
-Bootstrap variables such as `$primary`.
+{{% _param BREAKING %}} **Applies if** your [custom Chroma style
+sheets][chroma-docs] (`assets/scss/td/chroma/_light.scss` and `_dark.scss`)
+reference theme or Bootstrap variables such as `$primary`.
 
 - Inline those color values: custom Chroma files now load as isolated Sass
   modules, so such references fail with "Undefined variable".
-
-### No LibSass fallback {#libsass-escape-hatch}
-
-**Applies if** your build platform has no Dart Sass distribution (for example,
-the BSDs).
-
-There is no way to keep building this release with Hugo's embedded LibSass: the
-theme's stylesheets now use `sass:` modules and Sass's new `if()` conditional
-syntax (`if(condition: value; else: value)`), which LibSass does not implement.
-In particular, overriding `head-css.html` to restore a LibSass `toCSS` call
-builds green but ships an unstyled site. For binary-less platforms, the durable
-path is Dart Sass's planned [pure-JS embedded mode][dart-sass-2413].
 
 ## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -50,8 +50,10 @@ cSpell:ignore: chromastyles libsass
   - [Default script-dependency versions pinned](#script-dep-pins)
   - [Install command renamed](#install-command)
 - **[Semantic classes](#semantic-classes)**: starting with breadcrumbs
-- **[Internationalization](#internationalization)**: full translation-key
-  coverage across all bundled locales
+- **[Internationalization](#internationalization)**:
+  - Mode-menu labels localized
+  - Full translation-key coverage
+  - Turkish and Ukrainian locale refreshes
 - **[Agent directive in page HTML](#llms-directive)** (experimental)
 - **[Other notable changes](#other-notable-changes)**: footer-copyright fix,
   Docker-quickstart retirement

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -308,8 +308,7 @@ code).
 
 - Update every automation that invokes the old command: package scripts (such as
   the [setup guide's][other-options] `_prepare:docsy` example), CI workflows,
-  and deployment commands. `npm run postinstall` now fails with npm's "Missing
-  script" error.
+  and deployment commands.
 
 {{% _param BREAKING %}} **Applies if** your site installs Docsy from GitHub with
 npm (development and testing only).

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -37,8 +37,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   moving from Bootstrap to Docsy's own `td-` classes, beginning with
   breadcrumbs</span>
 - {{% _param FAS_LG globe warning %}}
-  <span>**[Internationalization](#internationalization)**: complete i18n
-  coverage in every bundled locale, and more</span>
+  <span>**[Internationalization](#internationalization)**: complete
+  translation-key coverage in every bundled locale, and more</span>
 
 {{% /card %}}
 
@@ -55,8 +55,10 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
     `install:theme-deps`, retiring npm install hooks
 - **[Semantic classes](#semantic-classes)**: breadcrumb markup moves from
   Bootstrap to `td-` classes
-- **[Internationalization](#internationalization)**: mode-menu labels localized,
-  full key-set coverage, and locale refreshes
+- **[Internationalization](#internationalization)**:
+  - Mode-menu labels localized
+  - Full translation-key coverage across bundled locales
+  - Turkish and Ukrainian locale refreshes
 - **[Agent directive in page HTML](#llms-directive)** (experimental):
   `llms.txt`-enabled sites point agents to the index
 - **[Other notable changes](#other-notable-changes)**:
@@ -324,8 +326,7 @@ The theme's UI strings are now translated across the board:
   strings (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`) and ship
   translated in every bundled locale; they were previously English-only.
 - **Complete coverage**: each of the theme's 31 bundled locales now defines the
-  theme's full set of translatable UI strings, so none of them falls back to
-  English.
+  theme's full translation-key set, so none of them falls back to English.
 - **Locale refreshes**: Turkish and Ukrainian translations updated and extended.
 
 If your project's i18n files supply any of these strings, you can now drop the

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -105,11 +105,11 @@ example:
 + --bs-primary-bg-subtle: rgb(81.0196078431%, 88.6274509804%, 99.8431372549%);
 ```
 
-Both forms specify the same color, up to a rounding difference of at most one
-step in a single color channel. If you diff built CSS, expect this serialization
-churn throughout, alongside [Font Awesome 7](#fontawesome)'s stylesheet changes:
-it is normal, not drift. Comparison tooling (bit-exact visual tests, snapshots
-of built CSS) needs its expectations re-captured, and code that string-matches
+Both forms specify the same color, up to a rounding difference of less than one
+8-bit step per channel. If you diff built CSS, expect this serialization churn
+throughout, alongside [Font Awesome 7](#fontawesome)'s stylesheet changes: it is
+normal, not drift. Comparison tooling (bit-exact visual tests, snapshots of
+built CSS) needs its expectations re-captured, and code that string-matches
 these serialized values needs the same update.
 
 ### Actions {#dart-sass-actions}
@@ -202,11 +202,11 @@ breadcrumb class names.
 
 ## {{% _param BREAKING %}} Font Awesome 7 {#fontawesome}
 
-Docsy's icon library is upgraded from [Font Awesome][] 6.7.2 to 7.3.1. Icon
-markup and the `icon:` config values keep rendering unchanged, with one
-Free-icon exception noted in the Actions: the `fa-solid`/`fa-brands` classes and
-their `fas`/`fab` shorthands still ship, and every icon the theme uses remains
-in the Free bundle.
+Docsy's icon library is upgraded from [Font Awesome][] 6.7.2 to 7.3.1. Existing
+icon markup and `icon:` config values continue to resolve, with one Free-icon
+exception noted in the Actions: the `fa-solid`/`fa-brands` classes and their
+`fas`/`fab` shorthands still ship, and every icon the theme uses remains in the
+Free bundle.
 
 What you will see: **icons now render at a uniform width by default**. Font
 Awesome 7 draws every icon on a fixed-width canvas with the glyph centered,
@@ -356,8 +356,9 @@ The theme's [UI strings][i18n-bundles] got a translation-coverage pass:
 {{% _param CLEANUP %}} **Applies if** your project's i18n files [override theme
 UI strings][custom-ui-strings].
 
-- Optionally, drop the entries that the theme now covers: your values override
-  the theme's, so stale copies silently pin yesterday's wording.
+- Optionally, drop redundant copies of theme strings, keeping intentional
+  project-specific wording: your values override the theme's, so stale copies
+  silently pin yesterday's wording.
 
 ## {{% _param NEW %}} Agent directive in page HTML {#llms-directive}
 
@@ -475,6 +476,9 @@ In addition to the [generic site checks][check], for this release:
       looks right in your navbar and footer; see [Font Awesome 7](#fontawesome).
 - [ ] If your site uses Mermaid, diagrams render at the
       [pinned version](#script-dep-pins).
+- [ ] If your site is multilingual and enables the light/dark mode menu, its
+      labels render in each locale's language; see
+      [Internationalization](#internationalization).
 - [ ] If your site enables `llms.txt`, view-source shows the
       [agent directive](#llms-directive) (`For AI agents:`) at the top of
       `<body>`; check one page per overridden `baseof` template.

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -128,17 +128,13 @@ example:
 ```
 
 Both forms specify the same color, up to a rounding difference of at most one
-step in a single color channel: imperceptible to the eye, though bit-exact
-visual tests can flag it. If you diff built CSS, expect this serialization churn
-throughout, alongside [Font Awesome 7](#fontawesome)'s stylesheet changes.
+step in a single color channel. If you diff built CSS, expect this serialization
+churn throughout, alongside [Font Awesome 7](#fontawesome)'s stylesheet changes:
+it is normal, not drift. Comparison tooling -- bit-exact visual tests, snapshots
+of built CSS -- needs its expectations re-captured; otherwise, the only action
+is:
 
-**Applies if** your tests or JavaScript string-match built-CSS values: CSS
-snapshots or golden files, or reads of Sass-computed custom properties such as
-`--bs-*-bg-subtle` and `--bs-table-*` through `getPropertyValue()`.
-
-- Re-capture the expected strings from an upgraded build.
-
-**Applies if** your custom Chroma style sheets
+**Applies if** your [custom Chroma style sheets][chroma-docs]
 (`assets/scss/td/chroma/_light.scss` and `_dark.scss`) reference theme or
 Bootstrap variables such as `$primary`.
 
@@ -510,6 +506,7 @@ About this release:
 [agent-support-llms]: /docs/content/agent-support/#llms-txt
 [`sass-embedded`]: https://www.npmjs.com/package/sass-embedded
 [check]: /docs/update/#check
+[chroma-docs]: /docs/content/lookandfeel/#lightdark-code-styles
 [custom-ui-strings]: /docs/language/#create-custom-ui-strings
 [i18n-bundles]: /docs/language/#internationalization-bundles
 [lightdark]: /docs/content/lookandfeel/#lightdark-mode-menu

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -5,8 +5,8 @@ date: 2026-08-19
 draft: true
 description: >-
   Docsy now builds with Dart Sass, so the sass CLI joins your build. This
-  release also moves breadcrumbs to semantic classes, pins default script
-  versions, and renames the theme-dependencies install command.
+  release also upgrades to Font Awesome 7, moves breadcrumbs to semantic
+  classes, and pins default script versions.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
@@ -35,6 +35,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   <span>**[Semantic classes](#semantic-classes)**: Docsy chrome markup starts
   moving from Bootstrap to Docsy's own `td-` classes, beginning with
   breadcrumbs</span>
+- {{% _param FAS_LG icons danger %}} <span>**[Font Awesome 7](#fontawesome)**:
+  icons get uniform widths by default; glyphs are redrawn</span>
 - {{% _param FAS_LG thumbtack warning %}}
   <span>**[Pinned script versions](#script-dep-pins)**: Mermaid, KaTeX, markmap,
   and Redoc no longer resolve from the CDN's `latest`</span>
@@ -47,13 +49,15 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   prerequisite
 - **[Semantic classes](#semantic-classes)**: breadcrumb markup moves from
   Bootstrap to `td-` classes
+- **[Font Awesome 7](#fontawesome)**: icons render at a uniform width by default
 - **Install and defaults**:
   - [Theme-dependencies install command renamed](#install-command)
   - [Default script-dependency versions pinned](#script-dep-pins): Mermaid,
     KaTeX, markmap, and Redoc no longer resolve from the CDN's `latest`
 - **[Agent directive in page HTML](#llms-directive)** (experimental):
   `llms.txt`-enabled sites point agents to the index
-- **[Other notable changes](#other-notable-changes)**, and
+- **[Other notable changes](#other-notable-changes)**: translatable theme-menu
+  labels, locale updates, Docker-quickstart retirement; and
   [for maintainers](#for-maintainers): supply-chain hardening and npm trusted
   publishing
 
@@ -63,6 +67,7 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
 - Review {{% _param BADGE BREAKING warning %}} changes:
   - {{% _param BREAKING %}} [Dart Sass replaces LibSass](#dart-sass)
   - {{% _param BREAKING %}} [Breadcrumb semantic classes](#semantic-classes)
+  - {{% _param BREAKING %}} [Font Awesome 7](#fontawesome)
   - {{% _param BREAKING %}} [Install command renamed](#install-command)
 - No Hugo change this release: the [version list](#upgrade) is otherwise
   unchanged too.
@@ -199,6 +204,55 @@ breadcrumb class names.
   keep-alive at all: the documented [single-breadcrumb display
   override][single-override] stops matching until renamed.
 
+## {{% _param BREAKING %}} Font Awesome 7 {#fontawesome}
+
+Docsy's icon library is upgraded from [Font Awesome][] 6.7.2 to 7.3.1. Icon
+markup and the `icon:` config values keep working unchanged: the
+`fa-solid`/`fa-brands` classes and their `fas`/`fab` shorthands still ship, and
+no icon used by the theme was renamed.
+
+What you will see: **icons now render at a uniform width by default**. Font
+Awesome 7 draws every icon on a fixed-width canvas with the glyph centered,
+where v6 hugged each glyph's natural width -- the design that Docsy already
+opted into where alignment mattered. Icons in navbars, footers, and icon+label
+lists gain a little horizontal whitespace, and glyphs are redrawn. To restore
+natural width on a given icon, add `fa-width-auto`; the old `fa-fw` class is
+deprecated (it aliases `fa-width-fixed`, now the default). For the rationale and
+details, see [What's changed in v7][].
+
+### Actions {#fontawesome-actions}
+
+{{% _param BREAKING %}} **Applies if** you override the
+`$td-font-awesome-font-name` theme variable.
+
+- Update the family name for v7, for example `'Font Awesome 7 Free'` (the new
+  default). The variable feeds only Docsy's icon pseudo-elements, as before.
+
+{{% _param BREAKING %}} **Applies if** your project's Sass reaches into Font
+Awesome's Sass surface -- variables such as `$fa-var-*` or functions like
+`fa-content()`. This surface was never part of Docsy's documented [customization
+API][project style files], but until now it was reachable through leaked
+imports, in two modes:
+
+- **Loud**: `$fa-var-*` and `fa-content()` references now fail to compile, since
+  Font Awesome 7's Sass is module-based. If you accept the same no-stability
+  caveat as for [internal styles][resetting-internal], the namespaced form
+  works: `@use 'td/support/fa';` then `fa.fa-content(fa.$var-NAME)`. Never
+  `@use … as *`: Font Awesome's unprefixed variables collide with Bootstrap's.
+- **Silent**: Font Awesome configuration globals set in your project Sass --
+  `$fa-font-path`, `$fa-font-display`, and similar -- compile but **no longer
+  have any effect**: the module loads with its defaults. If you relied on one
+  (for example, self-hosted webfonts via `$fa-font-path`), verify your icons
+  still render and load; there is no override hook in this release.
+
+{{% _param BREAKING %}} **Applies if** you hotlink theme webfonts or use
+undocumented name-only icon values.
+
+- Webfonts are woff2-only in v7: requests for `.ttf`/`.woff` files under
+  `/webfonts/` now 404.
+- Name-only `icon:` values (`icon: fa-book`) render nothing instead of a
+  fallback glyph: add a style prefix (`icon: fa-solid fa-book`).
+
 ## {{% _param BREAKING %}} Install command renamed {#install-command}
 
 The command that installs the theme's npm dependencies is renamed:
@@ -275,6 +329,12 @@ any of the theme's `baseof` templates ([print][print-docs] variants included).
 
 - **Footer copyright**: a same-year range now renders as the single year
   (`© 2026` instead of `© 2026–2026`). See the [footer copyright docs][].
+- **i18n**: the theme's light/dark mode menu labels are now translatable
+  (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`, provided for all bundled
+  locales), missing UI strings were filled in across locales, and the Turkish
+  and Ukrainian locales received updates.
+- **Docker support dropped**: the repo's broken Docker configuration files are
+  removed and the Docker quickstart page is retired.
 
 For this and all other changes, see the [0.17.0][] release page.
 
@@ -352,6 +412,8 @@ In addition to the [generic site checks][check], for this release:
 - [ ] Breadcrumbs render styled, especially if you had custom breadcrumb CSS,
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).
+- [ ] Icons render (no missing glyphs), and icon spacing looks right in your
+      navbar and footer; see [Font Awesome 7](#fontawesome).
 - [ ] Mermaid diagrams render at the [pinned version](#script-dep-pins).
 - [ ] If your site enables `llms.txt`, view-source shows the
       [agent directive](#llms-directive) (`For AI agents:`) at the top of
@@ -408,6 +470,7 @@ About this release:
 [dart-sass-2413]: https://github.com/sass/dart-sass/pull/2413
 [deployment docs]: /docs/deployment/
 [experimental]: /project/about/changelog/#experimental
+[Font Awesome]: https://fontawesome.com/
 [footer copyright docs]: /docs/content/lookandfeel/#footer-copyright
 [gh-pages-deploy]: /docs/deployment/github-pages/
 [Install Dart Sass]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass
@@ -428,4 +491,6 @@ About this release:
 [update-hugo]: /docs/update/#update-hugo
 [update-node]: /docs/update/#update-node
 [update-theme]: /docs/update/#update-theme
+[resetting-internal]: /docs/content/lookandfeel/#resetting-internal-styles
+[What's changed in v7]: https://docs.fontawesome.com/web/setup/upgrade/whats-changed
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -119,7 +119,8 @@ Both forms specify the same color, up to a rounding difference of at most one
 step in a single color channel. If you diff built CSS, expect this serialization
 churn throughout, alongside [Font Awesome 7](#fontawesome)'s stylesheet changes:
 it is normal, not drift. Comparison tooling -- bit-exact visual tests, snapshots
-of built CSS -- needs its expectations re-captured.
+of built CSS -- and any tests or code that string-match these serialized values
+need their expectations re-captured.
 
 ### Actions {#dart-sass-actions}
 
@@ -258,15 +259,18 @@ their own: icon-only links or buttons, or inline icons conveying information
 that nearby text doesn't repeat.
 
 - Font Awesome 7 hides webfont icons from assistive technology by default (the
-  glyph now ships with empty CSS alternative text). Label the surrounding
-  element (for example, with `aria-label`), per [Font Awesome's accessibility
-  guidance][fa-a11y]. Decorative icons need nothing.
+  glyph now ships with empty CSS alternative text), per [Font Awesome's
+  accessibility guidance][fa-a11y]. Decorative icons need nothing.
+  - For an icon-only link or button, put the label on the interactive element
+    (for example, with `aria-label`), not on the icon.
+  - For a semantic inline icon, add `aria-label` and `role="img"` to the icon
+    itself.
 
 {{% _param BREAKING %}} **Applies if** you hotlink theme webfonts or use Font
 Awesome's screen-reader utility classes.
 
-- Webfonts are woff2-only in v7: requests for `.ttf`/`.woff` files under
-  `/webfonts/` now 404.
+- Webfonts are woff2-only in v7: the `.ttf` files that v6 also shipped are gone.
+  Replace any non-woff2 hotlink under `/webfonts/`.
 - The `.sr-only`, `.sr-only-focusable`, `.fa-sr-only`, and
   `.fa-sr-only-focusable` utility classes are gone from the theme's compiled
   CSS: use Bootstrap's [`.visually-hidden` and
@@ -440,10 +444,11 @@ In addition to the [generic site checks][check], for this release:
 
 - [ ] Every environment that builds your site provides the `sass` CLI
       (`sass --version`); see [Dart Sass actions](#dart-sass-actions).
-- [ ] If you diff built CSS, expect the
-      [Dart Sass serialization changes](#dart-sass-recheck) and the
-      [Font Awesome 7](#fontawesome) stylesheet and webfont changes; investigate
-      anything else.
+- [ ] If you diff built CSS, expect the changes this post describes --
+      [Dart Sass serialization](#dart-sass-recheck),
+      [Font Awesome 7](#fontawesome), and
+      [breadcrumb classes](#semantic-classes) -- and investigate only
+      unexplained differences.
 - [ ] Breadcrumbs render styled, especially if you had custom breadcrumb CSS,
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -323,8 +323,12 @@ The theme's [UI strings][i18n-bundles] are now translated across the board:
   theme's full translation-key set, so none of them falls back to English.
 - **Locale refreshes**: Turkish and Ukrainian translations updated and extended.
 
-If your project's i18n files [supply any of these strings][custom-ui-strings],
-you can now drop the entries the theme covers.
+{{% _param CLEANUP %}} **Action** (optional): applies if your project's i18n
+files [override theme UI strings][custom-ui-strings].
+
+- Drop the entries that the theme now covers, keeping only your genuine
+  customizations: your values override the theme's, so stale copies silently pin
+  yesterday's wording.
 
 ## {{% _param NEW %}} Agent directive in page HTML {#llms-directive}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -344,8 +344,7 @@ rendering no longer changes when an upstream major ships.
 
 ## {{% _param FAS globe "" %}} Internationalization
 
-The theme's [UI strings][i18n-bundles] now have full translation-key coverage in
-every bundled locale, and newly cover the light/dark mode menu labels:
+The theme's [UI strings][i18n-bundles] got a translation-coverage pass:
 
 - **Mode menu**: the [light/dark mode menu][lightdark] labels join the theme's
   translatable strings (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`) and
@@ -357,9 +356,8 @@ every bundled locale, and newly cover the light/dark mode menu labels:
 {{% _param CLEANUP %}} **Applies if** your project's i18n files [override theme
 UI strings][custom-ui-strings].
 
-- Optionally, drop the entries that the theme now covers, keeping only your
-  genuine customizations: your values override the theme's, so stale copies
-  silently pin yesterday's wording.
+- Optionally, drop the entries that the theme now covers: your values override
+  the theme's, so stale copies silently pin yesterday's wording.
 
 ## {{% _param NEW %}} Agent directive in page HTML {#llms-directive}
 
@@ -461,9 +459,9 @@ verification steps, and sanity checks.
 In addition to the [generic site checks][check], for this release:
 
 - [ ] Every environment that builds your site provides Dart Sass
-      {{% param dartSassMinVersion %}} or later: npm-based sites, run
+      {{% param dartSassMinVersion %}} or later: for npm-based sites, run
       `node_modules/.bin/sass --version` from your project root (the CLI is on
-      `PATH` inside npm scripts, not in your shell); other installs,
+      `PATH` inside npm scripts, not in your shell); for other installs,
       `sass --version`. See [Dart Sass actions](#dart-sass-actions).
 - [ ] If you diff built CSS, expect the changes this post describes
       ([Dart Sass serialization](#dart-sass-recheck),

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -50,16 +50,13 @@ cSpell:ignore: chromastyles libsass
   - [Default script-dependency versions pinned](#script-dep-pins)
   - [Install command renamed](#install-command)
 - **[Semantic classes](#semantic-classes)**: starting with breadcrumbs
-- **[Internationalization](#internationalization)**:
-  - Mode-menu labels localized
-  - Full translation-key coverage
-  - Turkish and Ukrainian locale refreshes
+- **[Internationalization](#internationalization)**: full translation-key
+  coverage across all bundled locales
 - **[Agent directive in page HTML](#llms-directive)** (experimental)
-- **[Other notable changes](#other-notable-changes)**:
-  - Footer-copyright rendering fix
-  - Docker-quickstart retirement
-  - [For maintainers](#for-maintainers): supply-chain hardening, npm trusted
-    publishing
+- **[Other notable changes](#other-notable-changes)**: footer-copyright fix,
+  Docker-quickstart retirement
+- **[For maintainers](#for-maintainers)**: supply-chain hardening, npm trusted
+  publishing
 
 ## Ready to upgrade? <a id="breaking-changes"></a>
 
@@ -71,10 +68,10 @@ cSpell:ignore: chromastyles libsass
   - {{% _param BREAKING %}} [Install command renamed](#install-command)
 - Optionally skim:
   - [Default script-dependency versions pinned](#script-dep-pins)
-  - {{% _param NEW %}} Experimental
-    [agent directive in page HTML](#llms-directive)
   - {{% _param NEW %}} / {{% _param CLEANUP %}}
     [Internationalization](#internationalization)
+  - {{% _param NEW %}} Experimental
+    [agent directive in page HTML](#llms-directive)
   - [Other notable changes](#other-notable-changes), and
     [for maintainers](#for-maintainers)
 - {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.17.0](#upgrade)
@@ -207,7 +204,7 @@ breadcrumb class names.
 ## {{% _param BREAKING %}} Font Awesome 7 {#fontawesome}
 
 Docsy's icon library is upgraded from [Font Awesome][] 6.7.2 to 7.3.1. Icon
-markup and the `icon:` config values keep working unchanged: the
+markup and the `icon:` config values keep rendering unchanged: the
 `fa-solid`/`fa-brands` classes and their `fas`/`fab` shorthands still ship, and
 no icon used by the theme was renamed.
 
@@ -236,11 +233,14 @@ API][project style files], but until now it was reachable through leaked
 imports, in two modes:
 
 - **Loud**: `$fa-var-*` references -- alone or inside `fa-content()` calls --
-  now fail to compile, since Font Awesome 7's Sass is module-based. If you
-  accept the same no-stability caveat as for [internal
-  styles][resetting-internal], the namespaced form works:
-  `@use 'td/support/fa';` then `fa.fa-content(fa.$var-NAME)`. Never
-  `@use … as *`: Font Awesome's unprefixed variables collide with Bootstrap's.
+  now fail to compile, since Font Awesome 7's Sass is module-based; so do
+  `@include`s of removed v6 mixins such as `fa-icon-solid` and
+  `fa-family-classic` (see [Font Awesome's Sass upgrade
+  notes][fa-sass-upgrade]). If you accept the same no-stability caveat as for
+  [internal styles][resetting-internal], the namespaced form works for variables
+  and functions: `@use 'td/support/fa';` then `fa.fa-content(fa.$var-NAME)`.
+  Never `@use … as *`: Font Awesome's unprefixed variables collide with
+  Bootstrap's.
 - **Silent**: two cases compile green but stop doing what they used to:
   - Font Awesome configuration globals set in your project Sass --
     `$fa-font-path`, `$fa-font-display`, and similar -- **no longer have any
@@ -252,17 +252,24 @@ imports, in two modes:
   - Bare `fa-content()` calls with a literal argument (no `$fa-var-*`) pass
     through as literal CSS: the `content` value ships as text, not a glyph.
 
-{{% _param BREAKING %}} **Applies if** you hotlink theme webfonts, use
-undocumented name-only icon values, or use Font Awesome's screen-reader utility
-classes.
+{{% _param BREAKING %}} **Applies if** any of your site's icons carry meaning on
+their own: icon-only links or buttons, or inline icons conveying information
+that nearby text doesn't repeat.
+
+- Font Awesome 7 hides webfont icons from assistive technology by default (the
+  glyph now ships with empty CSS alternative text). Label the surrounding
+  element (for example, with `aria-label`), per [Font Awesome's accessibility
+  guidance][fa-a11y]. Decorative icons need nothing.
+
+{{% _param BREAKING %}} **Applies if** you hotlink theme webfonts or use Font
+Awesome's screen-reader utility classes.
 
 - Webfonts are woff2-only in v7: requests for `.ttf`/`.woff` files under
   `/webfonts/` now 404.
-- Name-only `icon:` values (`icon: fa-book`) render nothing instead of a
-  fallback glyph: add a style prefix (`icon: fa-solid fa-book`).
 - The `.sr-only`, `.sr-only-focusable`, `.fa-sr-only`, and
   `.fa-sr-only-focusable` utility classes are gone from the theme's compiled
-  CSS: use Bootstrap's [`.visually-hidden`][visually-hidden] classes instead.
+  CSS: use Bootstrap's [`.visually-hidden` and
+  `.visually-hidden-focusable`][visually-hidden] instead.
 
 ## {{% _param BREAKING %}} Install command renamed {#install-command}
 
@@ -315,8 +322,8 @@ rendering no longer changes when an upstream major ships.
 
 ## {{% _param FAS globe "" %}} Internationalization
 
-The theme's [UI strings][i18n-bundles] are now translated across the board, and
-cover the light/dark mode menu labels:
+The theme's [UI strings][i18n-bundles] now have full translation-key coverage in
+every bundled locale, and newly cover the light/dark mode menu labels:
 
 - **Mode menu**: the [light/dark mode menu][lightdark] labels join the theme's
   translatable strings (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`) and
@@ -325,12 +332,12 @@ cover the light/dark mode menu labels:
   theme's full translation-key set, so none of them falls back to English.
 - **Locale refreshes**: Turkish and Ukrainian translations updated and extended.
 
-{{% _param CLEANUP %}} **Action** (optional): applies if your project's i18n
-files [override theme UI strings][custom-ui-strings].
+{{% _param CLEANUP %}} **Applies if** your project's i18n files [override theme
+UI strings][custom-ui-strings].
 
-- Drop the entries that the theme now covers, keeping only your genuine
-  customizations: your values override the theme's, so stale copies silently pin
-  yesterday's wording.
+- Optionally, drop the entries that the theme now covers, keeping only your
+  genuine customizations: your values override the theme's, so stale copies
+  silently pin yesterday's wording.
 
 ## {{% _param NEW %}} Agent directive in page HTML {#llms-directive}
 
@@ -493,7 +500,9 @@ About this release:
 [check]: /docs/update/#check
 [custom-ui-strings]: /docs/language/#create-custom-ui-strings
 [i18n-bundles]: /docs/language/#internationalization-bundles
-[lightdark]: /docs/content/lookandfeel/#lightdark-color-feature
+[lightdark]: /docs/content/lookandfeel/#lightdark-mode-menu
+[fa-a11y]: https://docs.fontawesome.com/web/dig-deeper/accessibility
+[fa-sass-upgrade]: https://docs.fontawesome.com/upgrade/scss
 [CL@0.17.0]: /project/about/changelog/#next
 [compare-0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main
 [Dart Sass]: https://sass-lang.com/dart-sass/

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -51,10 +51,10 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   - [Font Awesome 7](#fontawesome): icons render at a uniform width by default
   - [Default script-dependency versions pinned](#script-dep-pins): Mermaid,
     KaTeX, markmap, and Redoc no longer resolve from the CDN's `latest`
+  - [Install command renamed](#install-command): `postinstall` →
+    `install:theme-deps`, retiring npm install hooks
 - **[Semantic classes](#semantic-classes)**: breadcrumb markup moves from
   Bootstrap to `td-` classes
-- **[Install command renamed](#install-command)**: `postinstall` →
-  `install:theme-deps`
 - **[Agent directive in page HTML](#llms-directive)** (experimental):
   `llms.txt`-enabled sites point agents to the index
 - **[Other notable changes](#other-notable-changes)**: translatable theme-menu
@@ -70,8 +70,6 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   - {{% _param BREAKING %}} [Breadcrumb semantic classes](#semantic-classes)
   - {{% _param BREAKING %}} [Font Awesome 7](#fontawesome)
   - {{% _param BREAKING %}} [Install command renamed](#install-command)
-- No Hugo change this release: the [version list](#upgrade) is otherwise
-  unchanged too.
 - Optionally skim:
   - [Default script-dependency versions pinned](#script-dep-pins)
   - {{% _param NEW %}} Experimental

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -44,27 +44,21 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
 
 ## Release summary
 
-- **Modernized and strengthened foundations**: current, actively maintained
-  dependencies with deterministic defaults
-  - [Dart Sass replaces LibSass](#dart-sass): the `sass` CLI becomes a build
-    prerequisite
-  - [Font Awesome 7](#fontawesome): icons render at a uniform width by default
-  - [Default script-dependency versions pinned](#script-dep-pins): Mermaid,
-    KaTeX, markmap, and Redoc no longer resolve from the CDN's `latest`
-  - [Install command renamed](#install-command): `postinstall` →
-    `install:theme-deps`, retiring npm install hooks
-- **[Semantic classes](#semantic-classes)**: breadcrumb markup moves from
-  Bootstrap to `td-` classes
+- **Modernized and strengthened foundations**:
+  - [Dart Sass replaces LibSass](#dart-sass)
+  - [Font Awesome 7](#fontawesome)
+  - [Default script-dependency versions pinned](#script-dep-pins)
+  - [Install command renamed](#install-command)
+- **[Semantic classes](#semantic-classes)**: starting with breadcrumbs
 - **[Internationalization](#internationalization)**:
   - Mode-menu labels localized
-  - Full translation-key coverage across bundled locales
+  - Full translation-key coverage
   - Turkish and Ukrainian locale refreshes
-- **[Agent directive in page HTML](#llms-directive)** (experimental):
-  `llms.txt`-enabled sites point agents to the index
+- **[Agent directive in page HTML](#llms-directive)** (experimental)
 - **[Other notable changes](#other-notable-changes)**:
   - Footer-copyright rendering fix
   - Docker-quickstart retirement
-  - [For maintainers](#for-maintainers): supply-chain hardening and npm trusted
+  - [For maintainers](#for-maintainers): supply-chain hardening, npm trusted
     publishing
 
 ## Ready to upgrade? <a id="breaking-changes"></a>

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -4,9 +4,9 @@ linkTitle: Release 0.17.0
 date: 2026-08-19
 draft: true
 description: >-
-  Docsy now builds with Dart Sass, so the sass CLI joins your build. This
-  release also upgrades to Font Awesome 7, moves breadcrumbs to semantic
-  classes, and pins default script versions.
+  Docsy modernizes its foundations: builds move to Dart Sass (the sass CLI joins
+  your build), icons to Font Awesome 7, and script defaults to pinned versions;
+  breadcrumbs begin the move to semantic classes.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
@@ -45,15 +45,17 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
 
 ## Release summary
 
-- **[Dart Sass replaces LibSass](#dart-sass)**: the `sass` CLI becomes a build
-  prerequisite
-- **[Semantic classes](#semantic-classes)**: breadcrumb markup moves from
-  Bootstrap to `td-` classes
-- **[Font Awesome 7](#fontawesome)**: icons render at a uniform width by default
-- **Install and defaults**:
-  - [Theme-dependencies install command renamed](#install-command)
+- **Modernized foundations**: current, actively maintained dependencies with
+  deterministic defaults
+  - [Dart Sass replaces LibSass](#dart-sass): the `sass` CLI becomes a build
+    prerequisite
+  - [Font Awesome 7](#fontawesome): icons render at a uniform width by default
   - [Default script-dependency versions pinned](#script-dep-pins): Mermaid,
     KaTeX, markmap, and Redoc no longer resolve from the CDN's `latest`
+- **[Semantic classes](#semantic-classes)**: breadcrumb markup moves from
+  Bootstrap to `td-` classes
+- **[Install command renamed](#install-command)**: `postinstall` →
+  `install:theme-deps`
 - **[Agent directive in page HTML](#llms-directive)** (experimental):
   `llms.txt`-enabled sites point agents to the index
 - **[Other notable changes](#other-notable-changes)**: translatable theme-menu

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -126,8 +126,10 @@ Bootstrap-computed custom properties such as `--bs-*-bg-subtle` and
 regression suite found at most single-channel rounding differences on a few
 dozen pixels per page.
 
-- If you diff built CSS across the upgrade, expect thousands of changed lines:
-  that is the serialization change, not drift.
+- If you diff built CSS across the upgrade, expect thousands of changed lines
+  from the serialization change alone: that is not drift. (The
+  [Font Awesome 7](#fontawesome) upgrade rewrites its own stylesheet portions
+  too.)
 - Recheck anything that string-matches `--bs-*` values in CSS, JavaScript, or
   tests, and update the expected strings.
 - Custom Chroma style sheets (`assets/scss/td/chroma/_light.scss` and
@@ -441,15 +443,17 @@ In addition to the [generic site checks][check], for this release:
 
 - [ ] Every environment that builds your site provides the `sass` CLI
       (`sass --version`); see [Dart Sass actions](#dart-sass-actions).
-- [ ] If you diff built CSS, the changes are
-      [serialization-only](#dart-sass-recheck); spot-check for visible color
-      drift (single-channel rounding differences are expected).
+- [ ] If you diff built CSS, expect the
+      [Dart Sass serialization changes](#dart-sass-recheck) and the
+      [Font Awesome 7](#fontawesome) stylesheet and webfont changes; investigate
+      anything else.
 - [ ] Breadcrumbs render styled, especially if you had custom breadcrumb CSS,
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).
 - [ ] Icons render, their webfont requests load (no 404s), and icon spacing
       looks right in your navbar and footer; see [Font Awesome 7](#fontawesome).
-- [ ] Mermaid diagrams render at the [pinned version](#script-dep-pins).
+- [ ] If your site uses Mermaid, diagrams render at the
+      [pinned version](#script-dep-pins).
 - [ ] If your site enables `llms.txt`, view-source shows the
       [agent directive](#llms-directive) (`For AI agents:`) at the top of
       `<body>`; check one page per overridden `baseof` template.

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -243,9 +243,11 @@ imports, in two modes:
   `@use … as *`: Font Awesome's unprefixed variables collide with Bootstrap's.
 - **Silent**: Font Awesome configuration globals set in your project Sass --
   `$fa-font-path`, `$fa-font-display`, and similar -- compile but **no longer
-  have any effect**: the module loads with its defaults. If you relied on one
-  (for example, self-hosted webfonts via `$fa-font-path`), verify your icons
-  still render and load; there is no override hook in this release.
+  have any effect**: the module loads with its defaults, so a green build is no
+  evidence these settings still work. If you set one (for example, self-hosted
+  webfonts via `$fa-font-path`), check your rendered site: icons must render and
+  their font requests must load. There is no override hook in this release;
+  restoring one is tracked in [#2756][].
 
 {{% _param BREAKING %}} **Applies if** you hotlink theme webfonts or use
 undocumented name-only icon values.
@@ -414,8 +416,8 @@ In addition to the [generic site checks][check], for this release:
 - [ ] Breadcrumbs render styled, especially if you had custom breadcrumb CSS,
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).
-- [ ] Icons render (no missing glyphs), and icon spacing looks right in your
-      navbar and footer; see [Font Awesome 7](#fontawesome).
+- [ ] Icons render, their webfont requests load (no 404s), and icon spacing
+      looks right in your navbar and footer; see [Font Awesome 7](#fontawesome).
 - [ ] Mermaid diagrams render at the [pinned version](#script-dep-pins).
 - [ ] If your site enables `llms.txt`, view-source shows the
       [agent directive](#llms-directive) (`For AI agents:`) at the top of
@@ -455,6 +457,7 @@ About this release:
 <!-- prettier-ignore-start -->
 [#2614]: https://github.com/google/docsy/issues/2614
 [#2691]: https://github.com/google/docsy/issues/2691
+[#2756]: https://github.com/google/docsy/issues/2756
 [0.16.0]: https://github.com/google/docsy/releases/v0.16.0
 [0.17.0]: https://github.com/google/docsy/releases/v0.17.0
 [0.18.0 milestone]: https://github.com/google/docsy/milestone/27

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -47,8 +47,8 @@ cSpell:ignore: chromastyles libsass
 - **Modernized and strengthened foundations**:
   - [Dart Sass replaces LibSass](#dart-sass)
   - [Font Awesome 7](#fontawesome)
-  - [Default script-dependency versions pinned](#script-dep-pins)
   - [Install command renamed](#install-command)
+  - [Default script-dependency versions pinned](#script-dep-pins)
 - **[Semantic classes](#semantic-classes)**: starting with breadcrumbs
 - **[Internationalization](#internationalization)**:
   - Mode-menu labels localized
@@ -86,24 +86,14 @@ developed Sass implementation, instead of Hugo's embedded LibSass. This adds one
 build prerequisite: the `sass` CLI must be available on your build's `PATH`.
 
 Why now? Hugo deprecated its embedded LibSass in 0.153.0, with removal to
-follow, and Hugo will never bundle Dart Sass: the planned [pure-JS embedded
-mode][dart-sass-2413] targets platforms without prebuilt binaries, not an
-in-binary compiler. Every further LibSass-built release would grow the set of
-sites on a dying pipeline.
+follow, and has no plans to bundle Dart Sass; migrating now spares your site a
+forced move later.
 
 Build logs stay quiet: the theme silences Sass deprecation warnings from
 dependencies, which as a side effect covers your own [project style files][] too
 (though not a custom `main.scss` entry point, whose warnings stay visible). A
 quiet build log is therefore not evidence that your own Sass is
 deprecation-free.
-
-> [!WARNING] No LibSass fallback
->
-> There is no way to build this release with Hugo's embedded LibSass: the
-> theme's stylesheets now use `sass:` modules and Sass's new `if()` syntax,
-> which LibSass doesn't implement. If your build platform has no Dart Sass
-> distribution (for example, the BSDs), stay on 0.16 until Dart Sass's planned
-> [pure-JS embedded mode][dart-sass-2413] ships.
 
 ### Expected CSS changes {#dart-sass-recheck}
 
@@ -119,10 +109,18 @@ Both forms specify the same color, up to a rounding difference of at most one
 step in a single color channel. If you diff built CSS, expect this serialization
 churn throughout, alongside [Font Awesome 7](#fontawesome)'s stylesheet changes:
 it is normal, not drift. Comparison tooling (bit-exact visual tests, snapshots
-of built CSS) and any tests or code that string-match these serialized values
-need their expectations re-captured.
+of built CSS) needs its expectations re-captured, and code that string-matches
+these serialized values needs the same update.
 
 ### Actions {#dart-sass-actions}
+
+> [!WARNING] No LibSass fallback
+>
+> There is no way to build this release with Hugo's embedded LibSass: the
+> theme's stylesheets now use `sass:` modules and Sass's new `if()` syntax,
+> which LibSass doesn't implement. If your build platform has no Dart Sass
+> distribution (for example, the BSDs), stay on 0.16 until Dart Sass's planned
+> [pure-JS embedded mode][dart-sass-2413] ships.
 
 {{% _param BREAKING %}} **Applies to all sites**: every install mode uses the
 theme's default Sass pipeline.
@@ -152,8 +150,7 @@ reference theme or Bootstrap variables such as `$primary`.
 ## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
 
 Docsy's chrome markup is moving from Bootstrap utility and component classes to
-Docsy-owned `td-` [semantic classes][] over the coming releases. In this
-release: breadcrumbs.
+Docsy-owned `td-` [semantic classes][] over the coming releases.
 
 ### Selector migration table
 
@@ -212,25 +209,29 @@ their `fas`/`fab` shorthands still ship, and every icon the theme uses remains
 in the Free bundle.
 
 What you will see: **icons now render at a uniform width by default**. Font
-Awesome 7 draws every icon on a fixed-width canvas with the glyph centered (a
-design Docsy already opted into where alignment mattered), where v6 hugged each
-glyph's natural width. Icons in navbars, footers, and icon+label lists gain a
-little horizontal whitespace, and glyphs are redrawn. To restore natural width
-on a given icon, add `fa-width-auto`; the old `fa-fw` class is deprecated (it
-aliases `fa-width-fixed`, now the default). For the rationale and details, see
-[What's changed in v7][].
+Awesome 7 draws every icon on a fixed-width canvas with the glyph centered,
+where v6 hugged each glyph's natural width. Icons in navbars, footers, and
+icon+label lists gain a little horizontal whitespace, and glyphs are redrawn. To
+restore natural width on a given icon, add `fa-width-auto`; the old `fa-fw`
+class is deprecated (it aliases `fa-width-fixed`, now the default). For the
+rationale and details, see [What's changed in v7][].
 
 ### Actions {#fontawesome-actions}
 
 {{% _param BREAKING %}} **Applies if** you override the
-`$td-font-awesome-font-name` theme variable with a Font Awesome family name, or
-set `font-family` for Font Awesome in your project's CSS or Sass.
+`$td-font-awesome-font-name` theme variable with a Font Awesome family name.
 
-- Update the family name for v7: `'Font Awesome 7 Free'` (the new theme default)
-  or `'Font Awesome 7 Brands'`. Font Awesome 7 registers no v6-named
-  `@font-face`, so a hardcoded v6 family silently falls through to another font.
-  An override naming a custom, non-Font-Awesome font needs no change. The theme
-  variable feeds only Docsy's icon pseudo-elements, as before.
+- Update it to the v7 form of your family, for example `'Font Awesome 7 Free'`
+  (the new theme default). An override naming a custom, non-Font-Awesome font
+  needs no change. The variable feeds only Docsy's icon pseudo-elements, as
+  before.
+
+{{% _param BREAKING %}} **Applies if** you set `font-family` for Font Awesome in
+your project's CSS or Sass.
+
+- Change it to the matching v7 family, `'Font Awesome 7 Free'` or
+  `'Font Awesome 7 Brands'`: v7 registers no v6-named `@font-face`, so a
+  hardcoded v6 family silently falls through to another font.
 
 {{% _param BREAKING %}} **Applies if** your project's Sass reaches into Font
 Awesome's Sass surface: variables such as `$fa-var-*` or functions like
@@ -547,7 +548,7 @@ About this release:
 [Netlify]: /docs/deployment/netlify/
 [official support policy]: /project/about/changelog/#official-support
 [order of steps]: /docs/update/#update-order
-[other-options]: /docs/get-started/other-options/
+[other-options]: /docs/get-started/other-options/#for-an-existing-site
 [print-docs]: /docs/content/print/
 [overrides]: /docs/update/#update-overrides
 [Project style files]: /docs/content/lookandfeel/#project-style-files

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -119,17 +119,25 @@ update in the [order of steps][]:
 
 ### Expected CSS changes {#dart-sass-recheck}
 
-Dart Sass serializes some Sass-computed colors differently than LibSass did (for
-example, `rgb(81.02%, 88.63%, 99.84%)` where LibSass emitted `#cfe2ff`).
-Rendered colors are visually unchanged: bit-exact comparison shows at most
-single-channel rounding differences. If you diff built CSS, expect thousands of
-changed lines of this serialization churn, alongside
-[Font Awesome 7](#fontawesome)'s stylesheet changes.
+Dart Sass serializes some Sass-computed colors differently than LibSass did. For
+example:
 
-**Applies if** your CSS, JavaScript, or tests string-match values of
-Sass-computed custom properties such as `--bs-*-bg-subtle` or `--bs-table-*`.
+```diff
+- --bs-primary-bg-subtle: #cfe2ff;
++ --bs-primary-bg-subtle: rgb(81.0196078431%, 88.6274509804%, 99.8431372549%);
+```
 
-- Update the expected strings.
+Both forms specify the same color, up to a rounding difference of at most one
+step in a single color channel: imperceptible to the eye, though bit-exact
+visual tests can flag it. If you diff built CSS, expect thousands of changed
+lines of this serialization churn, alongside [Font Awesome 7](#fontawesome)'s
+stylesheet changes.
+
+**Applies if** your tests or JavaScript string-match built-CSS values: CSS
+snapshots or golden files, or reads of Sass-computed custom properties such as
+`--bs-*-bg-subtle` and `--bs-table-*` through `getPropertyValue()`.
+
+- Re-capture the expected strings from an upgraded build.
 
 **Applies if** your custom Chroma style sheets
 (`assets/scss/td/chroma/_light.scss` and `_dark.scss`) reference theme or

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -38,7 +38,7 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   breadcrumbs</span>
 - {{% _param FAS_LG globe warning %}}
   <span>**[Internationalization](#internationalization)**: complete translations
-  in every bundled locale</span>
+  in every bundled locale, and more</span>
 
 {{% /card %}}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -224,7 +224,7 @@ aliases `fa-width-fixed`, now the default). For the rationale and details, see
 
 {{% _param BREAKING %}} **Applies if** you override the
 `$td-font-awesome-font-name` theme variable with a Font Awesome family name, or
-your project's CSS or Sass hardcodes one.
+set `font-family` for Font Awesome in your project's CSS or Sass.
 
 - Update the family name for v7: `'Font Awesome 7 Free'` (the new theme default)
   or `'Font Awesome 7 Brands'`. Font Awesome 7 registers no v6-named

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -21,7 +21,7 @@ params:
   katexVersion: 0.18.4
   markmapVersion: 0.18.12
   redocVersion: 2.5.3
-cSpell:ignore: autoloader markmap linux chromastyles libsass katex
+cSpell:ignore: chromastyles libsass
 ---
 
 <!-- markdownlint-disable descriptive-link-text no-space-in-emphasis -->
@@ -73,7 +73,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   - [Default script-dependency versions pinned](#script-dep-pins)
   - {{% _param NEW %}} Experimental
     [agent directive in page HTML](#llms-directive)
-  - [Internationalization](#internationalization)
+  - {{% _param NEW %}} / {{% _param CLEANUP %}}
+    [Internationalization](#internationalization)
   - [Other notable changes](#other-notable-changes), and
     [for maintainers](#for-maintainers)
 - {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.17.0](#upgrade)
@@ -314,7 +315,8 @@ rendering no longer changes when an upstream major ships.
 
 ## {{% _param FAS globe "" %}} Internationalization
 
-The theme's [UI strings][i18n-bundles] are now translated across the board:
+The theme's [UI strings][i18n-bundles] are now translated across the board, and
+cover the light/dark mode menu labels:
 
 - **Mode menu**: the [light/dark mode menu][lightdark] labels join the theme's
   translatable strings (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`) and

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -37,8 +37,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   moving from Bootstrap to Docsy's own `td-` classes, beginning with
   breadcrumbs</span>
 - {{% _param FAS_LG globe warning %}}
-  <span>**[Internationalization](#internationalization)**: complete translations
-  in every bundled locale, and more</span>
+  <span>**[Internationalization](#internationalization)**: complete i18n
+  coverage in every bundled locale, and more</span>
 
 {{% /card %}}
 
@@ -55,10 +55,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
     `install:theme-deps`, retiring npm install hooks
 - **[Semantic classes](#semantic-classes)**: breadcrumb markup moves from
   Bootstrap to `td-` classes
-- **[Internationalization](#internationalization)**:
-  - Mode-menu labels (light/dark/auto) translatable and translated
-  - Complete UI-string translations across all bundled locales
-  - Turkish and Ukrainian locale refreshes
+- **[Internationalization](#internationalization)**: mode-menu labels localized,
+  full key-set coverage, and locale refreshes
 - **[Agent directive in page HTML](#llms-directive)** (experimental):
   `llms.txt`-enabled sites point agents to the index
 - **[Other notable changes](#other-notable-changes)**:
@@ -228,10 +226,11 @@ details, see [What's changed in v7][].
 ### Actions {#fontawesome-actions}
 
 {{% _param BREAKING %}} **Applies if** you override the
-`$td-font-awesome-font-name` theme variable.
+`$td-font-awesome-font-name` theme variable with a Font Awesome family name.
 
 - Update the family name for v7, for example `'Font Awesome 7 Free'` (the new
-  default). The variable feeds only Docsy's icon pseudo-elements, as before.
+  default). An override naming a custom, non-Font-Awesome font needs no change.
+  The variable feeds only Docsy's icon pseudo-elements, as before.
 
 {{% _param BREAKING %}} **Applies if** your project's Sass reaches into Font
 Awesome's Sass surface -- variables such as `$fa-var-*` or functions like
@@ -239,26 +238,34 @@ Awesome's Sass surface -- variables such as `$fa-var-*` or functions like
 API][project style files], but until now it was reachable through leaked
 imports, in two modes:
 
-- **Loud**: `$fa-var-*` and `fa-content()` references now fail to compile, since
-  Font Awesome 7's Sass is module-based. If you accept the same no-stability
-  caveat as for [internal styles][resetting-internal], the namespaced form
-  works: `@use 'td/support/fa';` then `fa.fa-content(fa.$var-NAME)`. Never
+- **Loud**: `$fa-var-*` references -- alone or inside `fa-content()` calls --
+  now fail to compile, since Font Awesome 7's Sass is module-based. If you
+  accept the same no-stability caveat as for [internal
+  styles][resetting-internal], the namespaced form works:
+  `@use 'td/support/fa';` then `fa.fa-content(fa.$var-NAME)`. Never
   `@use … as *`: Font Awesome's unprefixed variables collide with Bootstrap's.
-- **Silent**: Font Awesome configuration globals set in your project Sass --
-  `$fa-font-path`, `$fa-font-display`, and similar -- compile but **no longer
-  have any effect**: the module loads with its defaults, so a green build is no
-  evidence these settings still work. If you set one (for example, self-hosted
-  webfonts via `$fa-font-path`), check your rendered site: icons must render and
-  their font requests must load. There is no override hook in this release;
-  restoring one is tracked in [#2756][].
+- **Silent**: two cases compile green but stop doing what they used to:
+  - Font Awesome configuration globals set in your project Sass --
+    `$fa-font-path`, `$fa-font-display`, and similar -- **no longer have any
+    effect**: the module loads with its defaults, so a green build is no
+    evidence these settings still work. If you set one (for example, self-hosted
+    webfonts via `$fa-font-path`), check your rendered site: icons must render
+    and their font requests must load. There is no override hook in this
+    release; restoring one is tracked in [#2756][].
+  - Bare `fa-content()` calls with a literal argument (no `$fa-var-*`) pass
+    through as literal CSS: the `content` value ships as text, not a glyph.
 
-{{% _param BREAKING %}} **Applies if** you hotlink theme webfonts or use
-undocumented name-only icon values.
+{{% _param BREAKING %}} **Applies if** you hotlink theme webfonts, use
+undocumented name-only icon values, or use Font Awesome's screen-reader utility
+classes.
 
 - Webfonts are woff2-only in v7: requests for `.ttf`/`.woff` files under
   `/webfonts/` now 404.
 - Name-only `icon:` values (`icon: fa-book`) render nothing instead of a
   fallback glyph: add a style prefix (`icon: fa-solid fa-book`).
+- The `.sr-only`, `.sr-only-focusable`, `.fa-sr-only`, and
+  `.fa-sr-only-focusable` utility classes are gone from the theme's compiled
+  CSS: use Bootstrap's [`.visually-hidden`][visually-hidden] classes instead.
 
 ## {{% _param BREAKING %}} Install command renamed {#install-command}
 
@@ -309,6 +316,21 @@ rendering no longer changes when an upstream major ships.
 - Set the dependency's version param (last column above) in your site config;
   for details, see the dependency's Docsy docs (first column).
 
+## {{% _param FAS globe "" %}} Internationalization
+
+The theme's UI strings are now translated across the board:
+
+- **Mode menu**: the light/dark/auto menu labels join the theme's translatable
+  strings (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`) and ship
+  translated in every bundled locale; they were previously English-only.
+- **Complete coverage**: each of the theme's 31 bundled locales now defines the
+  theme's full set of translatable UI strings, so none of them falls back to
+  English.
+- **Locale refreshes**: Turkish and Ukrainian translations updated and extended.
+
+If your project's i18n files supply any of these strings, you can now drop the
+entries the theme covers.
+
 ## {{% _param NEW %}} Agent directive in page HTML {#llms-directive}
 
 Sites that enable [`llms.txt`][agent-support-llms] now also point AI agents to
@@ -336,23 +358,8 @@ any of the theme's `baseof` templates ([print][print-docs] variants included).
 
 - **Footer copyright**: a same-year range now renders as the single year
   (`© 2026` instead of `© 2026–2026`). See the [footer copyright docs][].
-- **Docker support dropped**: the repo's broken Docker configuration files are
-  removed and the Docker quickstart page is retired.
-
-### {{% _param FAS globe "" %}} Internationalization
-
-The theme's UI strings are now translated across the board:
-
-- **Mode menu**: the light/dark/auto menu labels join the theme's translatable
-  strings (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`) and ship
-  translated in every bundled locale; they were previously English-only.
-- **Complete coverage**: each of the theme's 31 bundled locales now defines the
-  full UI-string set, so the theme's UI renders in your site's language end to
-  end.
-- **Locale refreshes**: Turkish and Ukrainian translations updated and extended.
-
-If your project's i18n files supply any of these strings, you can now drop the
-entries the theme covers.
+- **Outdated Docker setup retired**: the repo's broken Docker configuration
+  files are removed and the Docker quickstart page is retired.
 
 For this and all other changes, see the [0.17.0][] release page.
 
@@ -507,6 +514,7 @@ About this release:
 [single-override]: /docs/content/navigation/#breadcrumb-navigation
 [trusted publishing]: https://docs.npmjs.com/trusted-publishers
 [Update Docsy]: /docs/update/
+[visually-hidden]: https://getbootstrap.com/docs/5.3/helpers/visually-hidden/
 [update-hugo]: /docs/update/#update-hugo
 [update-node]: /docs/update/#update-node
 [update-theme]: /docs/update/#update-theme

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -28,18 +28,17 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
 
 {{% card header="Highlights" %}}
 
-- {{% _param FAS_LG palette primary %}} <span>**[Dart Sass](#dart-sass)**: Docsy
-  moves off Hugo's deprecated embedded LibSass (one new build
-  prerequisite)</span>
+- {{% _param FAS_LG rocket primary %}} <span>**Modernized foundations**:
+  [Dart Sass](#dart-sass), [Font Awesome 7](#fontawesome), and
+  [pinned script versions](#script-dep-pins) bring Docsy's build up to
+  date</span>
 - {{% _param FAS_LG tags info %}}
   <span>**[Semantic classes](#semantic-classes)**: Docsy chrome markup starts
   moving from Bootstrap to Docsy's own `td-` classes, beginning with
   breadcrumbs</span>
-- {{% _param FAS_LG icons danger %}} <span>**[Font Awesome 7](#fontawesome)**:
-  icons get uniform widths by default; glyphs are redrawn</span>
-- {{% _param FAS_LG thumbtack warning %}}
-  <span>**[Pinned script versions](#script-dep-pins)**: Mermaid, KaTeX, markmap,
-  and Redoc no longer resolve from the CDN's `latest`</span>
+- {{% _param FAS_LG robot warning %}}
+  <span>**[Agent directive in page HTML](#llms-directive)** (experimental):
+  every page now points AI agents to your `llms.txt` index</span>
 
 {{% /card %}}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -28,8 +28,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
 
 {{% card header="Highlights" %}}
 
-- {{% _param FAS_LG rocket primary %}} <span>**Modernized and strengthened
-  foundations**: [Dart Sass](#dart-sass), [Font Awesome 7](#fontawesome), and
+- {{% _param FAS_LG rocket primary %}} <span>**Foundations**:
+  [Dart Sass](#dart-sass), [Font Awesome 7](#fontawesome), and
   [pinned script versions](#script-dep-pins) make Docsy's build current and its
   rendering predictable</span>
 - {{% _param FAS_LG tags info %}}

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -117,27 +117,23 @@ update in the [order of steps][]:
   new `if()` conditional syntax, which older releases can't parse. Only the
   Docsy-tested version is [officially supported][official support policy].
 
-### What to recheck after upgrading {#dart-sass-recheck}
+### Expected CSS changes {#dart-sass-recheck}
 
-Dart Sass serializes some Sass-computed colors differently than LibSass did (for
-example, `rgb(81.02%, 88.63%, 99.84%)` where LibSass emitted `#cfe2ff`), across
-Bootstrap-computed custom properties such as `--bs-*-bg-subtle` and
-`--bs-table-*`. **Rendered colors are visually unchanged**: a bit-exact visual
-regression suite found at most single-channel rounding differences on a few
-dozen pixels per page.
+Dart Sass serializes some Sass-computed colors differently than LibSass,
+although their rendered colors are unchanged. If you diff built CSS, expect
+this serialization churn alongside [Font Awesome 7](#fontawesome)'s stylesheet
+changes.
 
-- If you diff built CSS across the upgrade, expect thousands of changed lines
-  from the serialization change alone: that is not drift. (The
-  [Font Awesome 7](#fontawesome) upgrade rewrites its own stylesheet portions
-  too.)
-- Recheck anything that string-matches `--bs-*` values in CSS, JavaScript, or
-  tests, and update the expected strings.
-- Custom Chroma style sheets (`assets/scss/td/chroma/_light.scss` and
-  `_dark.scss`) are now loaded as isolated Sass modules. Raw
-  `hugo gen chromastyles` dumps (the documented form) are unaffected, but a
-  hand-tuned dump that references theme or Bootstrap variables such as
-  `$primary` now fails with "Undefined variable": inline the color values
-  instead.
+**Applies if** your CSS, JavaScript, or tests string-match values of
+Sass-computed custom properties such as `--bs-*-bg-subtle` or `--bs-table-*`.
+
+- Update the expected strings.
+
+**Applies if** your custom Chroma style sheets reference theme or Bootstrap
+variables.
+
+- Inline those color values: custom Chroma files now load as isolated Sass
+  modules.
 
 ### No LibSass fallback {#libsass-escape-hatch}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -37,8 +37,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   moving from Bootstrap to Docsy's own `td-` classes, beginning with
   breadcrumbs</span>
 - {{% _param FAS_LG globe warning %}}
-  <span>**[Internationalization](#internationalization)**: complete UI-string
-  translations in all 31 bundled locales</span>
+  <span>**[Internationalization](#internationalization)**: complete translations
+  in every bundled locale</span>
 
 {{% /card %}}
 
@@ -344,8 +344,9 @@ The theme's UI strings are now translated across the board:
 - **Mode menu**: the light/dark/auto menu labels join the theme's translatable
   strings (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`) and ship
   translated in every bundled locale; they were previously English-only.
-- **Complete coverage**: every bundled locale now defines the theme's full
-  UI-string set, so the theme's UI renders in your site's language end to end.
+- **Complete coverage**: each of the theme's 31 bundled locales now defines the
+  full UI-string set, so the theme's UI renders in your site's language end to
+  end.
 - **Locale refreshes**: Turkish and Ukrainian translations updated and extended.
 
 If your project's i18n files supply any of these strings, you can now drop the

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -97,6 +97,14 @@ dependencies, which as a side effect covers your own [project style files][] too
 quiet build log is therefore not evidence that your own Sass is
 deprecation-free.
 
+> [!WARNING] No LibSass fallback
+>
+> There is no way to build this release with Hugo's embedded LibSass: the
+> theme's stylesheets now use `sass:` modules and Sass's new `if()` syntax,
+> which LibSass doesn't implement. If your build platform has no Dart Sass
+> distribution (for example, the BSDs), stay on 0.16 until Dart Sass's planned
+> [pure-JS embedded mode][dart-sass-2413] ships.
+
 ### Expected CSS changes {#dart-sass-recheck}
 
 Dart Sass serializes some Sass-computed colors differently than LibSass did. For
@@ -112,18 +120,6 @@ step in a single color channel. If you diff built CSS, expect this serialization
 churn throughout, alongside [Font Awesome 7](#fontawesome)'s stylesheet changes:
 it is normal, not drift. Comparison tooling -- bit-exact visual tests, snapshots
 of built CSS -- needs its expectations re-captured.
-
-### No LibSass fallback {#libsass-escape-hatch}
-
-**Applies if** your build platform has no Dart Sass distribution (for example,
-the BSDs).
-
-There is no way to keep building this release with Hugo's embedded LibSass: the
-theme's stylesheets now use `sass:` modules and Sass's new `if()` conditional
-syntax (`if(condition: value; else: value)`), which LibSass does not implement.
-In particular, overriding `head-css.html` to restore a LibSass `toCSS` call
-builds green but ships an unstyled site. For binary-less platforms, the durable
-path is Dart Sass's planned [pure-JS embedded mode][dart-sass-2413].
 
 ### Actions {#dart-sass-actions}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -37,8 +37,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
   moving from Bootstrap to Docsy's own `td-` classes, beginning with
   breadcrumbs</span>
 - {{% _param FAS_LG globe warning %}}
-  <span>**[Internationalization](#internationalization)**: the theme UI is now
-  fully translatable in every bundled locale</span>
+  <span>**[Internationalization](#internationalization)**: complete UI-string
+  translations in all 31 bundled locales</span>
 
 {{% /card %}}
 
@@ -55,8 +55,8 @@ cSpell:ignore: autoloader markmap linux chromastyles libsass katex
     `install:theme-deps`, retiring npm install hooks
 - **[Semantic classes](#semantic-classes)**: breadcrumb markup moves from
   Bootstrap to `td-` classes
-- **[Internationalization](#internationalization)**: theme-UI strings fully
-  translatable, with gaps filled across all locales
+- **[Internationalization](#internationalization)**: complete UI-string
+  translations across all bundled locales
 - **[Agent directive in page HTML](#llms-directive)** (experimental):
   `llms.txt`-enabled sites point agents to the index
 - **[Other notable changes](#other-notable-changes)**:
@@ -339,10 +339,17 @@ any of the theme's `baseof` templates ([print][print-docs] variants included).
 
 ### {{% _param FAS globe "" %}} Internationalization
 
-The theme UI is now fully translatable: the light/dark mode menu labels join the
-theme's i18n bundle (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`),
-provided for all bundled locales. Missing UI strings have been filled in across
-locales, and the Turkish and Ukrainian locales received updates.
+The theme's UI strings are now translated across the board:
+
+- **Mode menu**: the light/dark/auto menu labels join the theme's translatable
+  strings (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`) and ship
+  translated in every bundled locale; they were previously English-only.
+- **Complete coverage**: every bundled locale now defines the theme's full
+  UI-string set, so the theme's UI renders in your site's language end to end.
+- **Locale refreshes**: Turkish and Ukrainian translations updated and extended.
+
+If your project's i18n files supply any of these strings, you can now drop the
+entries the theme covers.
 
 For this and all other changes, see the [0.17.0][] release page.
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -129,9 +129,8 @@ example:
 
 Both forms specify the same color, up to a rounding difference of at most one
 step in a single color channel: imperceptible to the eye, though bit-exact
-visual tests can flag it. If you diff built CSS, expect thousands of changed
-lines of this serialization churn, alongside [Font Awesome 7](#fontawesome)'s
-stylesheet changes.
+visual tests can flag it. If you diff built CSS, expect this serialization churn
+throughout, alongside [Font Awesome 7](#fontawesome)'s stylesheet changes.
 
 **Applies if** your tests or JavaScript string-match built-CSS values: CSS
 snapshots or golden files, or reads of Sass-computed custom properties such as

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -119,21 +119,24 @@ update in the [order of steps][]:
 
 ### Expected CSS changes {#dart-sass-recheck}
 
-Dart Sass serializes some Sass-computed colors differently than LibSass,
-although their rendered colors are unchanged. If you diff built CSS, expect
-this serialization churn alongside [Font Awesome 7](#fontawesome)'s stylesheet
-changes.
+Dart Sass serializes some Sass-computed colors differently than LibSass did (for
+example, `rgb(81.02%, 88.63%, 99.84%)` where LibSass emitted `#cfe2ff`).
+Rendered colors are visually unchanged: bit-exact comparison shows at most
+single-channel rounding differences. If you diff built CSS, expect thousands of
+changed lines of this serialization churn, alongside
+[Font Awesome 7](#fontawesome)'s stylesheet changes.
 
 **Applies if** your CSS, JavaScript, or tests string-match values of
 Sass-computed custom properties such as `--bs-*-bg-subtle` or `--bs-table-*`.
 
 - Update the expected strings.
 
-**Applies if** your custom Chroma style sheets reference theme or Bootstrap
-variables.
+**Applies if** your custom Chroma style sheets
+(`assets/scss/td/chroma/_light.scss` and `_dark.scss`) reference theme or
+Bootstrap variables such as `$primary`.
 
 - Inline those color values: custom Chroma files now load as isolated Sass
-  modules.
+  modules, so such references fail with "Undefined variable".
 
 ### No LibSass fallback {#libsass-escape-hatch}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -314,17 +314,17 @@ rendering no longer changes when an upstream major ships.
 
 ## {{% _param FAS globe "" %}} Internationalization
 
-The theme's UI strings are now translated across the board:
+The theme's [UI strings][i18n-bundles] are now translated across the board:
 
-- **Mode menu**: the light/dark/auto menu labels join the theme's translatable
-  strings (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`) and ship
-  translated in every bundled locale; they were previously English-only.
+- **Mode menu**: the [light/dark mode menu][lightdark] labels join the theme's
+  translatable strings (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`) and
+  ship translated in every bundled locale; they were previously English-only.
 - **Complete coverage**: each of the theme's 31 bundled locales now defines the
   theme's full translation-key set, so none of them falls back to English.
 - **Locale refreshes**: Turkish and Ukrainian translations updated and extended.
 
-If your project's i18n files supply any of these strings, you can now drop the
-entries the theme covers.
+If your project's i18n files [supply any of these strings][custom-ui-strings],
+you can now drop the entries the theme covers.
 
 ## {{% _param NEW %}} Agent directive in page HTML {#llms-directive}
 
@@ -485,6 +485,9 @@ About this release:
 [agent-support-llms]: /docs/content/agent-support/#llms-txt
 [`sass-embedded`]: https://www.npmjs.com/package/sass-embedded
 [check]: /docs/update/#check
+[custom-ui-strings]: /docs/language/#create-custom-ui-strings
+[i18n-bundles]: /docs/language/#internationalization-bundles
+[lightdark]: /docs/content/lookandfeel/#lightdark-color-feature
 [CL@0.17.0]: /project/about/changelog/#next
 [compare-0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main
 [Dart Sass]: https://sass-lang.com/dart-sass/

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -118,8 +118,8 @@ example:
 Both forms specify the same color, up to a rounding difference of at most one
 step in a single color channel. If you diff built CSS, expect this serialization
 churn throughout, alongside [Font Awesome 7](#fontawesome)'s stylesheet changes:
-it is normal, not drift. Comparison tooling -- bit-exact visual tests, snapshots
-of built CSS -- and any tests or code that string-match these serialized values
+it is normal, not drift. Comparison tooling (bit-exact visual tests, snapshots
+of built CSS) and any tests or code that string-match these serialized values
 need their expectations re-captured.
 
 ### Actions {#dart-sass-actions}
@@ -212,13 +212,13 @@ their `fas`/`fab` shorthands still ship, and every icon the theme uses remains
 in the Free bundle.
 
 What you will see: **icons now render at a uniform width by default**. Font
-Awesome 7 draws every icon on a fixed-width canvas with the glyph centered,
-where v6 hugged each glyph's natural width -- the design that Docsy already
-opted into where alignment mattered. Icons in navbars, footers, and icon+label
-lists gain a little horizontal whitespace, and glyphs are redrawn. To restore
-natural width on a given icon, add `fa-width-auto`; the old `fa-fw` class is
-deprecated (it aliases `fa-width-fixed`, now the default). For the rationale and
-details, see [What's changed in v7][].
+Awesome 7 draws every icon on a fixed-width canvas with the glyph centered (a
+design Docsy already opted into where alignment mattered), where v6 hugged each
+glyph's natural width. Icons in navbars, footers, and icon+label lists gain a
+little horizontal whitespace, and glyphs are redrawn. To restore natural width
+on a given icon, add `fa-width-auto`; the old `fa-fw` class is deprecated (it
+aliases `fa-width-fixed`, now the default). For the rationale and details, see
+[What's changed in v7][].
 
 ### Actions {#fontawesome-actions}
 
@@ -227,19 +227,19 @@ details, see [What's changed in v7][].
 your project's CSS or Sass hardcodes one.
 
 - Update the family name for v7: `'Font Awesome 7 Free'` (the new theme default)
-  or `'Font Awesome 7 Brands'` -- v7 registers no v6-named `@font-face`, so a
-  hardcoded v6 family silently falls through to another font. An override naming
-  a custom, non-Font-Awesome font needs no change. The theme variable feeds only
-  Docsy's icon pseudo-elements, as before.
+  or `'Font Awesome 7 Brands'`. Font Awesome 7 registers no v6-named
+  `@font-face`, so a hardcoded v6 family silently falls through to another font.
+  An override naming a custom, non-Font-Awesome font needs no change. The theme
+  variable feeds only Docsy's icon pseudo-elements, as before.
 
 {{% _param BREAKING %}} **Applies if** your project's Sass reaches into Font
-Awesome's Sass surface -- variables such as `$fa-var-*` or functions like
+Awesome's Sass surface: variables such as `$fa-var-*` or functions like
 `fa-content()`. This surface was never part of Docsy's documented [customization
 API][project style files], but until now it was reachable through leaked
 imports, in two modes:
 
-- **Loud**: `$fa-var-*` references -- alone or inside `fa-content()` calls --
-  now fail to compile, since Font Awesome 7's Sass is module-based; so do
+- **Loud**: `$fa-var-*` references (alone or inside `fa-content()` calls) now
+  fail to compile, since Font Awesome 7's Sass is module-based; so do
   `@include`s of removed v6 mixins such as `fa-icon-solid` and
   `fa-family-classic` (see [Font Awesome's Sass upgrade
   notes][fa-sass-upgrade]). If you accept the same no-stability caveat as for
@@ -248,13 +248,13 @@ imports, in two modes:
   Never `@use … as *`: Font Awesome's unprefixed variables collide with
   Bootstrap's.
 - **Silent**: two cases compile green but stop doing what they used to:
-  - Font Awesome configuration globals set in your project Sass --
-    `$fa-font-path`, `$fa-font-display`, and similar -- **no longer have any
+  - Font Awesome configuration globals set in your project Sass
+    (`$fa-font-path`, `$fa-font-display`, and similar) **no longer have any
     effect**: the module loads with its defaults, so a green build is no
-    evidence these settings still work. If you set one (for example, self-hosted
-    webfonts via `$fa-font-path`), check your rendered site: icons must render
-    and their font requests must load. There is no override hook in this
-    release; restoring one is tracked in [#2756][].
+    evidence these settings still work. Check your rendered site, especially if
+    you self-host webfonts via `$fa-font-path`: icons must render and their font
+    requests must load. There is no override hook in this release; restoring one
+    is tracked in [#2756][].
   - Bare `fa-content()` calls with a literal argument (no `$fa-var-*`) pass
     through as literal CSS: the `content` value ships as text, not a glyph.
 
@@ -306,9 +306,9 @@ code).
   npm run install:theme-deps
   ```
 
-- Update every automation that invokes the old command -- package scripts (such
-  as the [setup guide's][other-options] `_prepare:docsy` example), CI workflows,
-  deployment commands: `npm run postinstall` now fails with npm's "Missing
+- Update every automation that invokes the old command: package scripts (such as
+  the [setup guide's][other-options] `_prepare:docsy` example), CI workflows,
+  and deployment commands. `npm run postinstall` now fails with npm's "Missing
   script" error.
 
 {{% _param BREAKING %}} **Applies if** your site installs Docsy from GitHub with
@@ -316,9 +316,9 @@ npm (development and testing only).
 
 - The theme's dependencies are no longer installed as a side effect of
   `npm install`. Run the install command from `node_modules/docsy/` after every
-  clean install or update -- wire it into your setup steps, since a fresh
-  `npm ci` discards the result -- or switch to the [`@docsy/theme`][] registry
-  package, which needs no install step.
+  clean install or update (wire it into your setup steps, since a fresh `npm ci`
+  discards the result), or switch to the [`@docsy/theme`][] registry package,
+  which needs no install step.
 
 Hugo-module and `@docsy/theme` registry installs are unaffected.
 
@@ -465,11 +465,11 @@ In addition to the [generic site checks][check], for this release:
       `node_modules/.bin/sass --version` from your project root (the CLI is on
       `PATH` inside npm scripts, not in your shell); other installs,
       `sass --version`. See [Dart Sass actions](#dart-sass-actions).
-- [ ] If you diff built CSS, expect the changes this post describes --
-      [Dart Sass serialization](#dart-sass-recheck),
+- [ ] If you diff built CSS, expect the changes this post describes
+      ([Dart Sass serialization](#dart-sass-recheck),
       [Font Awesome 7](#fontawesome), and
-      [breadcrumb classes](#semantic-classes) -- and investigate only
-      unexplained differences.
+      [breadcrumb classes](#semantic-classes)), and investigate only unexplained
+      differences.
 - [ ] Breadcrumbs render styled, especially if you had custom breadcrumb CSS,
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -369,7 +369,7 @@ For this and all other changes, see the [0.17.0][] release page.
 Changes in this section affect Docsy maintainers and contributors, not consuming
 sites.
 
-### {{% _param CLEANUP %}} Supply-chain hardening {#supply-chain}
+### Supply-chain hardening {#supply-chain}
 
 0.17.0 hardens the project's supply-chain posture: npm lockfiles are committed
 with lock-exact, script-free installs; a committed supply-chain audit, a
@@ -378,13 +378,13 @@ surface; and npm install hooks and implicit `pre`/`post` run-hooks are gone
 (inlined into their parent scripts), with the full test suite renamed to
 `test:full`. The changelog's [For-maintainers list][CL@0.17.0] itemizes these.
 
-### {{% _param CLEANUP %}} npm trusted publishing {#trusted-publishing}
+### npm trusted publishing {#trusted-publishing}
 
 Stable [`@docsy/theme`][] releases are now published from CI via npm [trusted
 publishing][] (OIDC): no long-lived registry tokens. This completes the
 npm-registry arc announced with 0.16.0.
 
-### {{% _param NEW %}} Chrome test baselines {#chrome-baselines}
+### Chrome test baselines {#chrome-baselines}
 
 Markup goldens, a framework-class output check, and a visual regression suite
 now guard the theme's chrome partials. These baselines gate the semantic-class

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -206,8 +206,8 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   the home. All are guarded by the repo test suite (`test:repo`). See [Default
   script-dependency versions][script-versions-notes].
 - Moved the `hugo-extended` pin to the root `package.json` and adopted a
-  two-step dependency-update flow (`npm run update:hugo`), opening more Renovate
-  managers ([#2747][]).
+  two-step update flow; see [Officially supported Hugo
+  version][hugo-version-notes] ([#2747][]).
 
 <!-- prettier-ignore-start -->
 [#2047]: https://github.com/google/docsy/issues/2047
@@ -241,6 +241,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [0.17.0]: https://github.com/google/docsy/releases/tag/v0.17.0
 [footer copyright docs]: /docs/content/lookandfeel/#footer-copyright
 [git history since 0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main
+[hugo-version-notes]: /project/about/maintainer-notes/#official-hugo-version
 [Install Dart Sass]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass
 [script-versions-notes]: /project/about/maintainer-notes/#script-versions
 [selector migration table]: /blog/2026/0.17.0/#selector-migration-table

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -159,6 +159,9 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 - Changed breadcrumb markup to carry Docsy [semantic classes][] with state keyed
   on `aria-current="page"` instead of an `active` class. If you customized
   breadcrumbs, see the [selector migration table][] ([#2722][]).
+- **[Font Awesome 7][0.17.0-blog-fontawesome]**: upgraded from 6.7.2 to 7.3.1;
+  icons render at a uniform width by default, and project Sass reaching into
+  Font Awesome's Sass surface needs migrating ([#2314][]).
 - Renamed the theme-dependencies install command that clone, submodule, and
   GitHub-npm installs run: `npm run postinstall` → `npm run install:theme-deps`;
   Docsy's packages no longer declare npm install hooks. For per-mode actions,
@@ -178,6 +181,9 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   ([#2614][]).
 - Silenced Sass deprecation warnings in site builds, project style files
   included; see the [release report][0.17.0-blog-dart-sass] ([#2731][]).
+- Made the light/dark mode menu labels translatable, filled in missing UI
+  strings across locales, and updated the Turkish and Ukrainian locales
+  ([#2482][], [#2751][], [#2332][pr2332], [#2451][]).
 - Dropped broken `Dockerfile` and `docker-compose.yaml` files and retired Docker
   quickstart page ([#2748][]).
 
@@ -199,9 +205,16 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   `params.mermaid.version`; the KaTeX, markmap-autoloader, and Redoc pins share
   the home. All are guarded by the repo test suite (`test:repo`). See [Default
   script-dependency versions][script-versions-notes].
+- Moved the `hugo-extended` pin to the root `package.json` and adopted a
+  two-step dependency-update flow (`npm run update:hugo`), opening more Renovate
+  managers ([#2747][]).
 
 <!-- prettier-ignore-start -->
 [#2047]: https://github.com/google/docsy/issues/2047
+[#2314]: https://github.com/google/docsy/issues/2314
+[pr2332]: https://github.com/google/docsy/pull/2332
+[#2451]: https://github.com/google/docsy/pull/2451
+[#2482]: https://github.com/google/docsy/pull/2482
 [#2614]: https://github.com/google/docsy/issues/2614
 [#2700]: https://github.com/google/docsy/pull/2700
 [#2703]: https://github.com/google/docsy/issues/2703
@@ -215,9 +228,12 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [#2724]: https://github.com/google/docsy/pull/2724
 [#2726]: https://github.com/google/docsy/pull/2726
 [#2731]: https://github.com/google/docsy/pull/2731
+[#2747]: https://github.com/google/docsy/pull/2747
 [#2748]: https://github.com/google/docsy/pull/2748
+[#2751]: https://github.com/google/docsy/pull/2751
 [0.17.0 release report]: /blog/2026/0.17.0/
 [0.17.0-blog-dart-sass]: /blog/2026/0.17.0/#dart-sass
+[0.17.0-blog-fontawesome]: /blog/2026/0.17.0/#fontawesome
 [0.17.0-blog-install]: /blog/2026/0.17.0/#install-command
 [0.17.0-blog-llms-directive]: /blog/2026/0.17.0/#llms-directive
 [0.17.0-blog-maintainers]: /blog/2026/0.17.0/#for-maintainers

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -154,7 +154,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 - **[Dart Sass][0.17.0-blog-dart-sass]**: switched the theme's default Sass
   transpiler from Hugo's embedded LibSass (deprecated) to Dart Sass; see
   [Install Dart Sass][]. Some Sass-computed colors in the built CSS change
-  serialization form, with no visible rendering change ([#2724][]).
+  serialization form, with no visible rendering change ([#2279][]).
 
 - Changed breadcrumb markup to carry Docsy [semantic classes][] with state keyed
   on `aria-current="page"` instead of an `active` class. If you customized
@@ -225,7 +225,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [#2712]: https://github.com/google/docsy/pull/2712
 [#2722]: https://github.com/google/docsy/pull/2722
 [#2714]: https://github.com/google/docsy/pull/2714
-[#2724]: https://github.com/google/docsy/pull/2724
+[#2279]: https://github.com/google/docsy/issues/2279
 [#2726]: https://github.com/google/docsy/pull/2726
 [#2731]: https://github.com/google/docsy/pull/2731
 [#2747]: https://github.com/google/docsy/pull/2747

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -183,7 +183,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   included; see the [release report][0.17.0-blog-dart-sass] ([#2731][]).
 - Made the light/dark mode menu labels translatable, filled in missing UI
   strings across locales, and updated the Turkish and Ukrainian locales
-  ([#2482][], [#2751][], [#2332][pr2332], [#2451][]).
+  ([#1987][], [#2751][], [#2332][pr2332], [#2451][]).
 - Dropped broken `Dockerfile` and `docker-compose.yaml` files and retired Docker
   quickstart page ([#2748][]).
 
@@ -214,7 +214,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [#2314]: https://github.com/google/docsy/issues/2314
 [pr2332]: https://github.com/google/docsy/pull/2332
 [#2451]: https://github.com/google/docsy/pull/2451
-[#2482]: https://github.com/google/docsy/pull/2482
+[#1987]: https://github.com/google/docsy/issues/1987
 [#2614]: https://github.com/google/docsy/issues/2614
 [#2700]: https://github.com/google/docsy/pull/2700
 [#2703]: https://github.com/google/docsy/issues/2703

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,7 +6,7 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
-- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy modernizes its foundations: builds move to Dart Sass (the sass CLI joins your build), icons to Font Awesome 7, and script defaults to pinned versions; breadcrumbs begin the move to semantic classes.
+- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy modernizes and strengthens its foundations: builds move to Dart Sass (the sass CLI joins your build), icons to Font Awesome 7, and script defaults to pinned versions; breadcrumbs begin the move to semantic classes.
 - [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Docsy is now on npm as @docsy/theme. This release also moves the theme into theme/, raises the Hugo minimum, and drops its default favicons in favor of discovery, each with upgrade actions.
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/): What changed in Hugo 0.158.0 through 0.164.x for Docsy sites: breaking changes, deprecations, security fixes, and known regressions, with per-version upgrade actions.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,7 +6,7 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
-- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy now builds with Dart Sass, so the sass CLI joins your build. This release also upgrades to Font Awesome 7, moves breadcrumbs to semantic classes, and pins default script versions.
+- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy modernizes its foundations: builds move to Dart Sass (the sass CLI joins your build), icons to Font Awesome 7, and script defaults to pinned versions; breadcrumbs begin the move to semantic classes.
 - [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Docsy is now on npm as @docsy/theme. This release also moves the theme into theme/, raises the Hugo minimum, and drops its default favicons in favor of discovery, each with upgrade actions.
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/): What changed in Hugo 0.158.0 through 0.164.x for Docsy sites: breaking changes, deprecations, security fixes, and known regressions, with per-version upgrade actions.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,7 +6,7 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
-- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy now builds with Dart Sass, so the sass CLI joins your build. This release also moves breadcrumbs to semantic classes, pins default script versions, and renames the theme-dependencies install command.
+- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy now builds with Dart Sass, so the sass CLI joins your build. This release also upgrades to Font Awesome 7, moves breadcrumbs to semantic classes, and pins default script versions.
 - [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Docsy is now on npm as @docsy/theme. This release also moves the theme into theme/, raises the Hugo minimum, and drops its default favicons in favor of discovery, each with upgrade actions.
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/): What changed in Hugo 0.158.0 through 0.164.x for Docsy sites: breaking changes, deprecations, security fixes, and known regressions, with per-version upgrade actions.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.


### PR DESCRIPTION
- Contributes to #2691
- **Font Awesome 7 section**: the width-default flip as the consumer story; Sass breakage framed as unsupported-usage, split loud (`$fa-var-*`, removed v6 mixins) / silent (config globals, bare literal `fa-content()` calls); AT-hidden-by-default a11y actions split per upstream (interactive vs semantic inline); removed sr-only utilities; follow-up tracker #2756 linked
- **Dart Sass section rework**: know-first/act-last order; no-LibSass-fallback callout with stay-on-0.16 advice; calibrated CSS-diff example (real full-precision serialization); Chroma gate moved into Actions
- **Internationalization**: own section, Highlights-card entry, and changelog line covering the four-PR wave (#2482, #2751, #2332, #2451); claims scoped to translation-key coverage
- **Smaller coverage**: outdated-Docker-setup bullet (#2748; its changelog entry rode the PR); hugo-extended root-homing changelog line linking the canonical two-step procedure (#2747); Dart Sass changelog entry now cites key issue #2279
- **Nav surfaces** conform to the release-post purpose model: Highlights card leads with foundations (3 entries), Release summary as a two-level map, triage imperative with post-ordered skim list
- **Preview(s)**:
  - https://deploy-preview-2755--docsydocs.netlify.app/blog/2026/0.17.0/
  - https://deploy-preview-2755--docsydocs.netlify.app/project/about/changelog/
