### PR TITLE
Theme toggler: localize assistive text, fix stale aria-label

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -486,7 +486,9 @@ https://github.com/google/docsy/pull/2259,200,1782498225
 https://github.com/google/docsy/pull/2276,200,1782498225
 https://github.com/google/docsy/pull/2291,200,1782498242
 https://github.com/google/docsy/pull/2303,200,1782498224
+https://github.com/google/docsy/pull/2331,200,1788004055
 https://github.com/google/docsy/pull/2332,200,1787929767
+https://github.com/google/docsy/pull/2343,200,1788004055
 https://github.com/google/docsy/pull/2364,200,1782498224
 https://github.com/google/docsy/pull/2366,200,1782498224
 https://github.com/google/docsy/pull/2371,200,1782498225

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -353,6 +353,7 @@ https://github.com/google/docsy/issues/2705,200,1787588586
 https://github.com/google/docsy/issues/2706,200,1787588586
 https://github.com/google/docsy/issues/2732,200,1787323021
 https://github.com/google/docsy/issues/2737,200,1787613566
+https://github.com/google/docsy/issues/2753,200,1787999250
 https://github.com/google/docsy/issues/2756,200,1787934072
 https://github.com/google/docsy/issues/331,200,1782498237
 https://github.com/google/docsy/issues/349,200,1782498234

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -346,11 +346,12 @@ rendering no longer changes when an upstream major ships.
 
 The theme's [UI strings][i18n-bundles] got a translation-coverage pass:
 
-- **Mode menu**: the [light/dark mode menu][lightdark] labels and the menu
-  button's assistive text, previously English-only, join the theme's
-  translatable strings (the `ui_theme_*` keys) and ship translated in every
-  bundled locale. The button's accessible name now also tracks the selected
-  mode; it was stuck at its page-load value.
+- **Mode menu** (the [light/dark mode menu][lightdark]):
+  - Its labels and the toggle button's assistive text, previously English-only,
+    join the theme's translatable strings (the `ui_theme_*` keys) and ship
+    translated in every bundled locale.
+  - The button's accessible name now also tracks the selected mode; it was stuck
+    at its page-load value.
 - **Complete coverage**: each of the theme's 31 bundled locales now defines the
   theme's full translation-key set, so none of them falls back to English.
 - **Locale refreshes**: Turkish and Ukrainian translations updated and extended.

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -349,6 +349,9 @@ The theme's [UI strings][i18n-bundles] got a translation-coverage pass:
 - **Mode menu**: the [light/dark mode menu][lightdark] labels join the theme's
   translatable strings (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`) and
   ship translated in every bundled locale; they were previously English-only.
+  The menu button's assistive text follows (`ui_theme_toggle`), and its
+  accessible name now tracks the selected mode -- it was stuck at its page-load
+  value.
 - **Complete coverage**: each of the theme's 31 bundled locales now defines the
   theme's full translation-key set, so none of them falls back to English.
 - **Locale refreshes**: Turkish and Ukrainian translations updated and extended.

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -346,12 +346,11 @@ rendering no longer changes when an upstream major ships.
 
 The theme's [UI strings][i18n-bundles] got a translation-coverage pass:
 
-- **Mode menu**: the [light/dark mode menu][lightdark] labels join the theme's
-  translatable strings (`ui_theme_light`, `ui_theme_dark`, `ui_theme_auto`) and
-  ship translated in every bundled locale; they were previously English-only.
-  The menu button's assistive text follows (`ui_theme_toggle`), and its
-  accessible name now tracks the selected mode -- it was stuck at its page-load
-  value.
+- **Mode menu**: the [light/dark mode menu][lightdark] labels and the menu
+  button's assistive text, previously English-only, join the theme's
+  translatable strings (the `ui_theme_*` keys) and ship translated in every
+  bundled locale. The button's accessible name now also tracks the selected
+  mode; it was stuck at its page-load value.
 - **Complete coverage**: each of the theme's 31 bundled locales now defines the
   theme's full translation-key set, so none of them falls back to English.
 - **Locale refreshes**: Turkish and Ukrainian translations updated and extended.

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -183,7 +183,9 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   included; see the [release report][0.17.0-blog-dart-sass] ([#2731][]).
 - Made the light/dark mode menu labels translatable, filled in missing UI
   strings across locales, and updated the Turkish and Ukrainian locales
-  ([#1987][], [#2751][], [#2332][pr2332], [#2451][]).
+  ([#1987][], [#2751][], [#2332][pr2332], [#2451][]). Also localized the theme
+  toggler's assistive text, and fixed its label so that it reflects the selected
+  mode ([#2753][]).
 - Dropped broken `Dockerfile` and `docker-compose.yaml` files and retired Docker
   quickstart page ([#2748][]).
 
@@ -231,6 +233,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [#2747]: https://github.com/google/docsy/pull/2747
 [#2748]: https://github.com/google/docsy/pull/2748
 [#2751]: https://github.com/google/docsy/pull/2751
+[#2753]: https://github.com/google/docsy/issues/2753
 [0.17.0 release report]: /blog/2026/0.17.0/
 [0.17.0-blog-dart-sass]: /blog/2026/0.17.0/#dart-sass
 [0.17.0-blog-fontawesome]: /blog/2026/0.17.0/#fontawesome

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -184,7 +184,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 - Made the light/dark mode menu labels and assistive text translatable, fixed
   the toggle button's label to reflect the selected mode, filled in missing UI
   strings across locales, and updated the Turkish and Ukrainian locales
-  ([#1987][], [#2753][], [#2751][], [#2332][pr2332], [#2451][]).
+  ([#1987][], [#2753][], [#2751][], [#2332][], [#2451][]).
 - Dropped broken `Dockerfile` and `docker-compose.yaml` files and retired Docker
   quickstart page ([#2748][]).
 
@@ -213,7 +213,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 <!-- prettier-ignore-start -->
 [#2047]: https://github.com/google/docsy/issues/2047
 [#2314]: https://github.com/google/docsy/issues/2314
-[pr2332]: https://github.com/google/docsy/pull/2332
+[#2332]: https://github.com/google/docsy/pull/2332
 [#2451]: https://github.com/google/docsy/pull/2451
 [#1987]: https://github.com/google/docsy/issues/1987
 [#2614]: https://github.com/google/docsy/issues/2614
@@ -545,7 +545,7 @@ Patch release [0.14.1][]: fixed **ToC** sidebar width in xl viewports
 - **Improved accessibility**: [color contrast and
   typography][0.13.0-blog-accessibility] ([#2285][]).
 - **Dark mode** fixes and improvements:
-  - [Flash Of Unstyled Content][0.13.0-blog-fouc] (FOUC) ([#2332][]).
+  - [Flash Of Unstyled Content][0.13.0-blog-fouc] (FOUC) ([#2343][]).
   - Improved TOC entry color contrast in dark mode ([#2376][], [#2379][]).
 - **Mobile navbar**: added scroll indicators for overflow navigation
   ([#2406][]).
@@ -574,8 +574,8 @@ Patch release [0.14.1][]: fixed **ToC** sidebar width in xl viewports
 [#2285]: https://github.com/google/docsy/issues/2285
 [#2303]: https://github.com/google/docsy/pull/2303
 [#2313]: https://github.com/google/docsy/issues/2313
-[#2331]: https://github.com/google/docsy/issues/2331
-[#2332]: https://github.com/google/docsy/issues/2332
+[#2331]: https://github.com/google/docsy/pull/2331
+[#2343]: https://github.com/google/docsy/pull/2343
 [#2364]: https://github.com/google/docsy/pull/2364
 [#2366]: https://github.com/google/docsy/pull/2366
 [#2371]: https://github.com/google/docsy/pull/2371

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -181,11 +181,10 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   ([#2614][]).
 - Silenced Sass deprecation warnings in site builds, project style files
   included; see the [release report][0.17.0-blog-dart-sass] ([#2731][]).
-- Made the light/dark mode menu labels translatable, filled in missing UI
+- Made the light/dark mode menu labels and assistive text translatable, fixed
+  the toggle button's label to reflect the selected mode, filled in missing UI
   strings across locales, and updated the Turkish and Ukrainian locales
-  ([#1987][], [#2751][], [#2332][pr2332], [#2451][]). Also localized the theme
-  toggler's assistive text, and fixed its label so that it reflects the selected
-  mode ([#2753][]).
+  ([#1987][], [#2753][], [#2751][], [#2332][pr2332], [#2451][]).
 - Dropped broken `Dockerfile` and `docker-compose.yaml` files and retired Docker
   quickstart page ([#2748][]).
 

--- a/tests/fixture-site/theme-toggler.test.mjs
+++ b/tests/fixture-site/theme-toggler.test.mjs
@@ -46,8 +46,16 @@ for (const [page, toggleText, label] of cases) {
 
     const button = doc.querySelector('button#bd-theme');
     assert.ok(button, 'toggler button is present');
-    assert.equal(button.getAttribute('aria-label'), label, 'aria-label');
-    assert.equal(button.getAttribute('title'), label, 'title');
+    assert.equal(
+      button.getAttribute('aria-label'),
+      label,
+      'aria-label carries the localized toggle-plus-mode name',
+    );
+    assert.equal(
+      button.getAttribute('title'),
+      label,
+      'title carries the localized toggle-plus-mode name',
+    );
 
     // The sentinel span dark-mode.js derives label updates from.
     const sentinel = button.querySelector('span#bd-theme-text');
@@ -56,7 +64,11 @@ for (const [page, toggleText, label] of cases) {
       sentinel.classList.contains('visually-hidden'),
       'sentinel is visually hidden',
     );
-    assert.equal(sentinel.textContent.trim(), toggleText, 'sentinel text');
+    assert.equal(
+      sentinel.textContent.trim(),
+      toggleText,
+      'sentinel carries the localized toggle text',
+    );
   });
 }
 

--- a/tests/fixture-site/theme-toggler.test.mjs
+++ b/tests/fixture-site/theme-toggler.test.mjs
@@ -1,6 +1,6 @@
 // Regression coverage for #2753: the theme toggler's accessible name is
 // localized and carries the mode, and the visually hidden #bd-theme-text
-// sentinel that dark-mode.js keys on is present — without it the label
+// sentinel that dark-mode.js keys on is present: without it the label
 // silently never updates on scheme switch (the original bug).
 
 import { test } from 'node:test';

--- a/tests/fixture-site/theme-toggler.test.mjs
+++ b/tests/fixture-site/theme-toggler.test.mjs
@@ -1,0 +1,75 @@
+// Regression coverage for #2753: the theme toggler's accessible name is
+// localized and carries the mode, and the visually hidden #bd-theme-text
+// sentinel that dark-mode.js keys on is present — without it the label
+// silently never updates on scheme switch (the original bug).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+import { buildSite } from './lib/build-site.mjs';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+);
+
+const site = buildSite('theme-toggler', {
+  files: {
+    'content/_index.md': '---\ntitle: Home\n---\nHome body\n',
+    'content/_index.fr.md': '---\ntitle: Accueil\n---\nAccueil\n',
+  },
+  extraConfig: `defaultContentLanguage: en
+languages:
+  en:
+    weight: 1
+  fr:
+    weight: 2
+params:
+  ui:
+    showLightDarkModeMenu: true
+`,
+});
+
+// Full label per locale: "TOGGLE (AUTO)", from the locale's i18n values.
+const cases = [
+  ['index.html', 'Toggle theme', 'Toggle theme (Auto)'],
+  ['fr/index.html', 'Changer de thème', 'Changer de thème (Automatique)'],
+];
+
+for (const [page, toggleText, label] of cases) {
+  test(`toggler accessible name is localized on ${page}`, () => {
+    assert.equal(site.status, 0, `fixture build succeeds:\n${site.stderr}`);
+    const doc = new JSDOM(site.publicFile(page)).window.document;
+
+    const button = doc.querySelector('button#bd-theme');
+    assert.ok(button, 'toggler button is present');
+    assert.equal(button.getAttribute('aria-label'), label, 'aria-label');
+    assert.equal(button.getAttribute('title'), label, 'title');
+
+    // The sentinel span dark-mode.js derives label updates from.
+    const sentinel = button.querySelector('span#bd-theme-text');
+    assert.ok(sentinel, 'label-update sentinel span is present');
+    assert.ok(
+      sentinel.classList.contains('visually-hidden'),
+      'sentinel is visually hidden',
+    );
+    assert.equal(sentinel.textContent.trim(), toggleText, 'sentinel text');
+  });
+}
+
+test('every bundled locale defines ui_theme_toggle', () => {
+  const i18nDir = path.join(repoRoot, 'theme', 'i18n');
+  const locales = readdirSync(i18nDir).filter((f) => f.endsWith('.yaml'));
+  assert.ok(locales.length >= 31, 'locale catalog is present');
+  for (const f of locales) {
+    const content = readFileSync(path.join(i18nDir, f), 'utf8');
+    assert.match(
+      content,
+      /^ui_theme_toggle: \S/m,
+      `${f} defines ui_theme_toggle`,
+    );
+  }
+});

--- a/theme/assets/js/dark-mode.js
+++ b/theme/assets/js/dark-mode.js
@@ -59,6 +59,7 @@
     if (themeSwitcherText) {
       const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.textContent.trim()})`
       themeSwitcher.setAttribute('aria-label', themeSwitcherLabel)
+      themeSwitcher.setAttribute('title', themeSwitcherLabel)
     }
 
     if (focus) {

--- a/theme/assets/js/dark-mode.js
+++ b/theme/assets/js/dark-mode.js
@@ -57,7 +57,7 @@
     btnToActive.setAttribute('aria-pressed', 'true')
     activeThemeIcon.setAttribute('href', svgOfActiveBtn)
     if (themeSwitcherText) {
-      const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.dataset.bsThemeValue})`
+      const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.textContent.trim()})`
       themeSwitcher.setAttribute('aria-label', themeSwitcherLabel)
     }
 

--- a/theme/i18n/ar.yaml
+++ b/theme/i18n/ar.yaml
@@ -13,6 +13,7 @@ ui_search: اِبْحث فِي هذَا اَلموْقِع
 ui_theme_light: فاتح
 ui_theme_dark: داكن
 ui_theme_auto: تلقائي
+ui_theme_toggle: تبديل السمة
 
 # Used in sentences such as "Posted in News"
 ui_in: فِي

--- a/theme/i18n/az.yaml
+++ b/theme/i18n/az.yaml
@@ -13,6 +13,7 @@ ui_search: Bu saytda axtarın...
 ui_theme_light: Açıq
 ui_theme_dark: Tünd
 ui_theme_auto: Avtomatik
+ui_theme_toggle: Temanı dəyiş
 
 # Used in sentences such as "Posted in News"
 ui_in: daxilində

--- a/theme/i18n/bg.yaml
+++ b/theme/i18n/bg.yaml
@@ -13,6 +13,7 @@ ui_search: Търси в тази страница…
 ui_theme_light: Светла
 ui_theme_dark: Тъмна
 ui_theme_auto: Автоматична
+ui_theme_toggle: Превключване на темата
 
 # Used in sentences such as "Posted in News"
 ui_in: в

--- a/theme/i18n/bn.yaml
+++ b/theme/i18n/bn.yaml
@@ -13,6 +13,7 @@ ui_search: এই সাইটে খোঁজ করুন…
 ui_theme_light: হালকা
 ui_theme_dark: গাঢ়
 ui_theme_auto: স্বয়ংক্রিয়
+ui_theme_toggle: থিম পরিবর্তন করুন
 
 # "পোস্ট করা নিউজ" এর মতো বাক্যে ব্যবহৃত
 ui_in: মধ্যে

--- a/theme/i18n/de.yaml
+++ b/theme/i18n/de.yaml
@@ -13,7 +13,7 @@ ui_search: Diese Seite durchsuchen…
 ui_theme_light: Hell
 ui_theme_dark: Dunkel
 ui_theme_auto: Automatisch
-ui_theme_toggle: Design umschalten
+ui_theme_toggle: Darstellung umschalten
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/de.yaml
+++ b/theme/i18n/de.yaml
@@ -13,6 +13,7 @@ ui_search: Diese Seite durchsuchen…
 ui_theme_light: Hell
 ui_theme_dark: Dunkel
 ui_theme_auto: Automatisch
+ui_theme_toggle: Design umschalten
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/en.yaml
+++ b/theme/i18n/en.yaml
@@ -13,6 +13,7 @@ ui_search: Search this site…
 ui_theme_light: Light
 ui_theme_dark: Dark
 ui_theme_auto: Auto
+ui_theme_toggle: Toggle theme
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/es.yaml
+++ b/theme/i18n/es.yaml
@@ -13,6 +13,7 @@ ui_search: Buscar
 ui_theme_light: Claro
 ui_theme_dark: Oscuro
 ui_theme_auto: Automático
+ui_theme_toggle: Cambiar tema
 
 # Used in sentences such as "Posted in News"
 ui_in: en

--- a/theme/i18n/et.yaml
+++ b/theme/i18n/et.yaml
@@ -13,6 +13,7 @@ ui_search: Otsi lehelt…
 ui_theme_light: Hele
 ui_theme_dark: Tume
 ui_theme_auto: Automaatne
+ui_theme_toggle: Vaheta teemat
 
 # Used in sentences such as "Posted in News"
 # not perfect. In Estonian this idea is represented by a suffix, not a separate word.

--- a/theme/i18n/fa.yaml
+++ b/theme/i18n/fa.yaml
@@ -13,6 +13,7 @@ ui_search: در این سایت جستجو کنید...
 ui_theme_light: روشن
 ui_theme_dark: تاریک
 ui_theme_auto: خودکار
+ui_theme_toggle: تغییر پوسته
 
 # Used in sentences such as "Posted in News"
 ui_in: در

--- a/theme/i18n/fi.yaml
+++ b/theme/i18n/fi.yaml
@@ -13,6 +13,7 @@ ui_search: Hae sivustolta...
 ui_theme_light: Vaalea
 ui_theme_dark: Tumma
 ui_theme_auto: Automaattinen
+ui_theme_toggle: Vaihda teemaa
 
 # Used in sentences such as "Posted in News"
 # Not perfect: Finnish expresses this with a case suffix, not a separate word.

--- a/theme/i18n/fr.yaml
+++ b/theme/i18n/fr.yaml
@@ -13,6 +13,7 @@ ui_search: Rechercher
 ui_theme_light: Clair
 ui_theme_dark: Sombre
 ui_theme_auto: Automatique
+ui_theme_toggle: Changer de thème
 
 # Used in sentences such as "Posted in News"
 ui_in: dans

--- a/theme/i18n/he.yaml
+++ b/theme/i18n/he.yaml
@@ -13,6 +13,7 @@ ui_search: חיפוש באתר…
 ui_theme_light: בהיר
 ui_theme_dark: כהה
 ui_theme_auto: אוטומטי
+ui_theme_toggle: החלפת ערכת נושא
 
 # Used in sentences such as "Posted in News"
 ui_in: ב

--- a/theme/i18n/hi.yaml
+++ b/theme/i18n/hi.yaml
@@ -13,6 +13,7 @@ ui_search: इस साइट में खोजें…
 ui_theme_light: हल्का
 ui_theme_dark: गहरा
 ui_theme_auto: स्वचालित
+ui_theme_toggle: थीम बदलें
 
 # Used in sentences such as "Posted in News"
 ui_in: में

--- a/theme/i18n/hu.yaml
+++ b/theme/i18n/hu.yaml
@@ -13,6 +13,7 @@ ui_search: Keresés ezen az oldalon…
 ui_theme_light: Világos
 ui_theme_dark: Sötét
 ui_theme_auto: Automatikus
+ui_theme_toggle: Téma váltása
 
 # so I left it as is
 ui_in: in

--- a/theme/i18n/it.yaml
+++ b/theme/i18n/it.yaml
@@ -13,6 +13,7 @@ ui_search: Cerca nel sito…
 ui_theme_light: Chiaro
 ui_theme_dark: Scuro
 ui_theme_auto: Automatico
+ui_theme_toggle: Cambia tema
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/ja.yaml
+++ b/theme/i18n/ja.yaml
@@ -13,6 +13,7 @@ ui_search: サイトを検索...
 ui_theme_light: ライト
 ui_theme_dark: ダーク
 ui_theme_auto: 自動
+ui_theme_toggle: テーマを切り替える
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/ko.yaml
+++ b/theme/i18n/ko.yaml
@@ -13,6 +13,7 @@ ui_search: 사이트에서 검색…
 ui_theme_light: 라이트
 ui_theme_dark: 다크
 ui_theme_auto: 자동
+ui_theme_toggle: 테마 전환
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/nl.yaml
+++ b/theme/i18n/nl.yaml
@@ -13,6 +13,7 @@ ui_search: Doorzoek deze site
 ui_theme_light: Licht
 ui_theme_dark: Donker
 ui_theme_auto: Automatisch
+ui_theme_toggle: Thema wisselen
 
 # Used in sentences such as "Posted in News"
 ui_in: in

--- a/theme/i18n/no.yaml
+++ b/theme/i18n/no.yaml
@@ -13,6 +13,7 @@ ui_search: Søk på nettstedet…
 ui_theme_light: Lyst
 ui_theme_dark: Mørkt
 ui_theme_auto: Automatisk
+ui_theme_toggle: Bytt tema
 
 # Used in sentences such as "Posted in News"
 ui_in: i

--- a/theme/i18n/oc.yaml
+++ b/theme/i18n/oc.yaml
@@ -13,6 +13,7 @@ ui_search: Cercar dins lo site…
 ui_theme_light: Clar
 ui_theme_dark: Escur
 ui_theme_auto: Automatic
+ui_theme_toggle: Cambiar de tèma
 
 # Used in sentences such as "Posted in News"
 ui_in: Dins

--- a/theme/i18n/pl.yaml
+++ b/theme/i18n/pl.yaml
@@ -13,6 +13,7 @@ ui_search: Szukaj na stronie ...
 ui_theme_light: Jasny
 ui_theme_dark: Ciemny
 ui_theme_auto: Automatyczny
+ui_theme_toggle: Przełącz motyw
 
 # Used in sentences such as "Posted in News"
 ui_in: w

--- a/theme/i18n/pt-br.yaml
+++ b/theme/i18n/pt-br.yaml
@@ -13,6 +13,7 @@ ui_search: Buscar no site…
 ui_theme_light: Claro
 ui_theme_dark: Escuro
 ui_theme_auto: Automático
+ui_theme_toggle: Alternar tema
 
 # Used in sentences such as "Posted in News"
 ui_in: em

--- a/theme/i18n/ro.yaml
+++ b/theme/i18n/ro.yaml
@@ -13,6 +13,7 @@ ui_search: Caută pe acest site…
 ui_theme_light: Luminoasă
 ui_theme_dark: Întunecată
 ui_theme_auto: Automată
+ui_theme_toggle: Comută tema
 
 # Used in sentences such as "Posted in News"
 ui_in: în

--- a/theme/i18n/ru.yaml
+++ b/theme/i18n/ru.yaml
@@ -13,6 +13,7 @@ ui_search: Поиск по сайту…
 ui_theme_light: Светлая
 ui_theme_dark: Тёмная
 ui_theme_auto: Авто
+ui_theme_toggle: Переключить тему
 
 # Used in sentences such as "Posted in News"
 ui_in: в

--- a/theme/i18n/sr-cyrl.yaml
+++ b/theme/i18n/sr-cyrl.yaml
@@ -13,6 +13,7 @@ ui_search: Претражите сајт…
 ui_theme_light: Светла
 ui_theme_dark: Тамна
 ui_theme_auto: Аутоматска
+ui_theme_toggle: Промени тему
 
 # Used in sentences such as "Posted in News"
 ui_in: у

--- a/theme/i18n/sr-latn.yaml
+++ b/theme/i18n/sr-latn.yaml
@@ -13,6 +13,7 @@ ui_search: Pretražite sajt…
 ui_theme_light: Svetla
 ui_theme_dark: Tamna
 ui_theme_auto: Automatska
+ui_theme_toggle: Promeni temu
 
 # Used in sentences such as "Posted in News"
 ui_in: u

--- a/theme/i18n/sv.yaml
+++ b/theme/i18n/sv.yaml
@@ -13,6 +13,7 @@ ui_search: Sök denna sida…
 ui_theme_light: Ljust
 ui_theme_dark: Mörkt
 ui_theme_auto: Automatiskt
+ui_theme_toggle: Byt tema
 
 # Used in sentences such as "Posted in News"
 ui_in: i

--- a/theme/i18n/tr.yaml
+++ b/theme/i18n/tr.yaml
@@ -13,6 +13,7 @@ ui_search: Bu sitede arayın…
 ui_theme_light: Açık
 ui_theme_dark: Koyu
 ui_theme_auto: Otomatik
+ui_theme_toggle: Temayı değiştir
 
 # Used in sentences such as "Posted in News"
 ui_in: içinde

--- a/theme/i18n/uk.yaml
+++ b/theme/i18n/uk.yaml
@@ -13,6 +13,7 @@ ui_search: Пошук по сайту…
 ui_theme_light: Світла
 ui_theme_dark: Темна
 ui_theme_auto: Авто
+ui_theme_toggle: Перемкнути тему
 
 # Used in sentences such as "Posted in News"
 ui_in: у

--- a/theme/i18n/zh-cn.yaml
+++ b/theme/i18n/zh-cn.yaml
@@ -13,6 +13,7 @@ ui_search: 站内搜索……
 ui_theme_light: 浅色
 ui_theme_dark: 深色
 ui_theme_auto: 自动
+ui_theme_toggle: 切换主题
 
 # Used in sentences such as "Posted in News"
 ui_in: 在

--- a/theme/i18n/zh-tw.yaml
+++ b/theme/i18n/zh-tw.yaml
@@ -13,6 +13,7 @@ ui_search: 站內搜尋…
 ui_theme_light: 淺色
 ui_theme_dark: 深色
 ui_theme_auto: 自動
+ui_theme_toggle: 切換主題
 
 # Used in sentences such as "Posted in News"
 ui_in: 於

--- a/theme/layouts/_partials/theme-toggler.html
+++ b/theme/layouts/_partials/theme-toggler.html
@@ -21,17 +21,14 @@
 
 {{/* Adapted from: https://github.com/twbs/bootstrap/blob/main/site/layouts/partials/theme-toggler.html */ -}}
 
-{{ $isExamples := eq .Layout "examples" -}}
 <button class="btn btn-link nav-link dropdown-toggle d-flex align-items-center"
         id="bd-theme"
         type="button"
         aria-expanded="false"
         data-bs-toggle="dropdown"
-        aria-label="Toggle theme (auto)">
+        aria-label="{{ T "ui_theme_toggle" }} ({{ T "ui_theme_auto" }})">
   <svg class="bi my-1 theme-icon-active"><use href="#circle-half"></use></svg>
-  {{- /* Disable menu name for Docsy:
-    <span class="{{ if $isExamples }}visually-hidden{{ else }}d-lg-none ms-2{{ end }}" id="bd-theme-text">Toggle theme</span>
-  */}}
+  <span class="visually-hidden" id="bd-theme-text">{{ T "ui_theme_toggle" }}</span>
 </button>
 <ul class="dropdown-menu" aria-labelledby="bd-theme">
   <li>

--- a/theme/layouts/_partials/theme-toggler.html
+++ b/theme/layouts/_partials/theme-toggler.html
@@ -21,12 +21,14 @@
 
 {{/* Adapted from: https://github.com/twbs/bootstrap/blob/main/site/layouts/partials/theme-toggler.html */ -}}
 
+{{ $toggleLabel := printf "%s (%s)" (T "ui_theme_toggle") (T "ui_theme_auto") -}}
 <button class="btn btn-link nav-link dropdown-toggle d-flex align-items-center"
         id="bd-theme"
         type="button"
         aria-expanded="false"
         data-bs-toggle="dropdown"
-        aria-label="{{ T "ui_theme_toggle" }} ({{ T "ui_theme_auto" }})">
+        title="{{ $toggleLabel }}"
+        aria-label="{{ $toggleLabel }}">
   <svg class="bi my-1 theme-icon-active"><use href="#circle-half"></use></svg>
   <span class="visually-hidden" id="bd-theme-text">{{ T "ui_theme_toggle" }}</span>
 </button>


### PR DESCRIPTION
- Fixes #2753
- **Localizes the assistive text**: adds an i18n key across all locales, following the #2482/#2751 pattern; the label is mirrored into `title`, giving the icon-only button a mouse-user affordance (Docusaurus prior art)
- **Fixes the stale `aria-label`**: restores the visually hidden span that `dark-mode.js` keys on (its absence is why the label never updated); the refreshed label reuses the menu items' localized text
- **Regression test**: fixture render (en+fr) of the accessible name and sentinel, plus locale key coverage
- **Changelog + release report**: folds the fix into the 0.17.0 i18n entries; also corrects a wrong FOUC ref in the changelog's 0.13.0 section that the entry's `pr2332` label was papering over
- **Preview(s)**:
  - https://deploy-preview-2758--docsydocs.netlify.app/project/about/changelog/#next
  - https://deploy-preview-2758--docsydocs.netlify.app/blog/2026/0.17.0/#internationalization
