### PR TITLE
0.17.0 artifacts: apply upgrade-run and review feedback

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -165,6 +165,7 @@ https://github.com/gchq/stroom-docs,200,1782498549
 https://github.com/geriom,200,1782498241
 https://github.com/git-guides/install-git,200,1782563369
 https://github.com/gohugoio/hugo/issues/14361,200,1782498234
+https://github.com/gohugoio/hugo/issues/8299,200,1788098403
 https://github.com/gohugoio/hugo/pull/14363,200,1782498234
 https://github.com/gohugoio/hugo/releases,200,1782563368
 https://github.com/gohugoio/hugo/releases/tag/v0.112.0,200,1782498238

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -561,6 +561,7 @@ https://github.com/google/docsy/pull/2731,200,1787331617
 https://github.com/google/docsy/pull/2747,200,1787929767
 https://github.com/google/docsy/pull/2748,200,1787848215
 https://github.com/google/docsy/pull/2751,200,1787929767
+https://github.com/google/docsy/pull/2757,200,1788005884
 https://github.com/google/docsy/pull/2760,200,1788020072
 https://github.com/google/docsy/pull/941,200,1782498225
 https://github.com/google/docsy/pulls,200,1782563369

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -86,18 +86,18 @@ cSpell:ignore: chromastyles libsass
 
 Docsy's stylesheets are now transpiled with [Dart Sass][], the actively
 developed Sass implementation, instead of Hugo's deprecated embedded LibSass.
-This adds one build prerequisite: the `sass` CLI must be available on your
-build's `PATH`.
+What this means for your site:
 
-Why now? Hugo [deprecated its embedded LibSass in 0.153.0][hugo-libsass-depr],
-with removal to follow, and has no plans to bundle Dart Sass; migrating now
-spares your site a forced move later.
-
-Build logs stay quiet: the theme silences Sass deprecation warnings from
-dependencies, which as a side effect covers your own [project style files][] too
-(though not a custom `main.scss` entry point, whose warnings stay visible). A
-quiet build log is therefore not evidence that your own Sass is
-deprecation-free.
+- **One new build prerequisite**: the `sass` CLI must be available on your
+  build's `PATH`.
+- **Why now?** The [LibSass deprecation landed in Hugo
+  0.153.0][hugo-libsass-depr], with removal to follow, and Hugo has no plans to
+  bundle Dart Sass; migrating now spares your site a forced move later.
+- **Quieter build logs**: Dart Sass is far chattier about deprecated Sass than
+  LibSass was, so the theme silences deprecation warnings from its dependencies,
+  your own [project style files][] included (only a custom `main.scss` entry
+  point keeps its warnings visible). A quiet log is therefore not evidence that
+  your own Sass is deprecation-free.
 
 ### Expected CSS changes {#dart-sass-recheck}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -86,13 +86,21 @@ cSpell:ignore: chromastyles libsass
 
 Docsy's stylesheets are now transpiled with [Dart Sass][], the actively
 developed Sass implementation, instead of Hugo's deprecated embedded LibSass.
-What this means for your site:
 
-- **One new build prerequisite**: the `sass` CLI must be available on your
-  build's `PATH`.
-- **Why now?** The [LibSass deprecation landed in Hugo
-  0.153.0][hugo-libsass-depr], with removal to follow, and Hugo has no plans to
-  bundle Dart Sass; migrating now spares your site a forced move later.
+The wins, for the theme and projects alike:
+
+- **Modern Sass**: Dart Sass tracks the evolving Sass language; LibSass stopped
+  moving years ago. The theme's stylesheets already use Sass modules and newer
+  syntax, and your own project Sass can follow at its own pace.
+- **No forced move later**: Hugo [deprecated its embedded LibSass in
+  0.153.0][hugo-libsass-depr], with removal to follow, and has no plans to
+  bundle Dart Sass. Migrating now, on Docsy's schedule, beats scrambling when
+  removal lands.
+
+What this means for your build:
+
+- **One new prerequisite**: the `sass` CLI must be available on your build's
+  `PATH`.
 - **Quieter build logs**: Dart Sass is far chattier about deprecated Sass than
   LibSass was, so the theme silences deprecation warnings from its dependencies,
   your own [project style files][] included (only a custom `main.scss` entry

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -48,7 +48,7 @@ cSpell:ignore: chromastyles libsass
 ## Release summary
 
 - **Modernized and strengthened foundations**:
-  - [Dart Sass replaces LibSass](#dart-sass)
+  - [Dart Sass replaces deprecated LibSass](#dart-sass)
   - [Font Awesome 7](#fontawesome)
   - [Install command renamed](#install-command)
   - [Default script-dependency versions pinned](#script-dep-pins)
@@ -67,7 +67,7 @@ cSpell:ignore: chromastyles libsass
 
 - :warning: Respect the [order of steps][] to avoid breaking your build.
 - Review {{% _param BADGE BREAKING warning %}} changes:
-  - {{% _param BREAKING %}} [Dart Sass replaces LibSass](#dart-sass)
+  - {{% _param BREAKING %}} [Dart Sass replaces deprecated LibSass](#dart-sass)
   - {{% _param BREAKING %}} [Breadcrumb semantic classes](#semantic-classes)
   - {{% _param BREAKING %}} [Font Awesome 7](#fontawesome)
   - {{% _param BREAKING %}} [Install command renamed](#install-command)
@@ -82,10 +82,10 @@ cSpell:ignore: chromastyles libsass
 - {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.17.0](#upgrade)
   yourself, or [ask an AI agent](#upgrading-with-ai).
 
-## {{% _param BREAKING %}} Dart Sass replaces LibSass {#dart-sass}
+## {{% _param BREAKING %}} Dart Sass replaces deprecated LibSass {#dart-sass}
 
 Docsy's stylesheets are now transpiled with [Dart Sass][], the actively
-developed Sass implementation, instead of Hugo's deprecated embedded LibSass.
+developed Sass implementation, instead of Hugo's embedded LibSass.
 
 The wins, for theme and project styles alike:
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -136,10 +136,10 @@ update in the [order of steps][]:
   - **npm-based sites**: install the Docsy-tested [`sass-embedded`][] package
     version, {{% param sassEmbeddedVersion %}}. CI builds that run through npm
     scripts need nothing more; GitHub Pages and Netlify setups are covered in
-    the [deployment docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]).
-    Note: `sass-embedded` also adds `@parcel/watcher` to your lockfile, an
-    install-script package from its pure-JS fallback; it never needs to run, so
-    projects that review or gate install scripts can deny it.
+    the [deployment docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]). the
+    [deployment docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]). For the
+    `@parcel/watcher` entry this adds to your lockfile, see the [install
+    note][Install Dart Sass].
   - **Other setups**: follow the guide's pointer to Hugo's Dart Sass
     installation instructions.
 - Where your platform dictates a Dart Sass version of its own, it must be at

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -39,6 +39,8 @@ cSpell:ignore: chromastyles libsass
 - {{% _param FAS_LG globe warning %}}
   <span>**[Internationalization](#internationalization)**: complete
   translation-key coverage in every bundled locale, and more</span>
+- {{% _param FAS_LG robot info %}} <span>**[Agent support](#llms-directive)**:
+  page HTML now points AI agents to your site's `llms.txt` index</span>
 
 {{% /card %}}
 
@@ -246,8 +248,9 @@ imports, in two modes:
   notes][fa-sass-upgrade]). If you accept the same no-stability caveat as for
   [internal styles][resetting-internal], the namespaced form works for variables
   and functions: `@use 'td/support/fa';` then `fa.fa-content(fa.$var-NAME)`.
-  Never `@use … as *`: Font Awesome's unprefixed variables collide with
-  Bootstrap's.
+  Alias variable names from v5/v6 (such as `$var-external-link-alt`) remain
+  defined in v7, so namespacing is usually the only change needed. Never
+  `@use … as *`: Font Awesome's unprefixed variables collide with Bootstrap's.
 - **Silent**: two cases compile green but stop doing what they used to:
   - Font Awesome configuration globals set in your project Sass
     (`$fa-font-path`, `$fa-font-display`, and similar) **no longer have any
@@ -467,8 +470,8 @@ In addition to the [generic site checks][check], for this release:
       `node_modules/.bin/sass --version` from your project root (the CLI is on
       `PATH` inside npm scripts, not in your shell); for other installs,
       `sass --version`. See [Dart Sass actions](#dart-sass-actions).
-- [ ] If you diff built CSS, expect the changes this post describes
-      ([Dart Sass serialization](#dart-sass-recheck),
+- [ ] If you diff built output (CSS and HTML), expect the changes this post
+      describes ([Dart Sass serialization](#dart-sass-recheck),
       [Font Awesome 7](#fontawesome), and
       [breadcrumb classes](#semantic-classes)), and investigate only unexplained
       differences.

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -18,6 +18,7 @@ params:
   hugoSupportedVersion: 0.164.0
   dartSassMinVersion: 1.95.0
   sassEmbeddedVersion: 1.102.0
+  fontAwesomeVersion: 7.3.1
   mermaidVersion: 11.17.0
   katexVersion: 0.18.4
   markmapVersion: 0.18.12
@@ -219,12 +220,13 @@ breadcrumb class names.
 
 ## {{% _param BREAKING %}} Font Awesome 7 {#fontawesome}
 
-Docsy's icon library is upgraded from [Font Awesome][] 6.7.2 to 7.3.1: the icon
-set is current again (v7's new icons included), and the theme inherits v7's
-modern accessibility defaults (see the Actions). Existing icon markup and
-`icon:` config values continue to resolve, with one Free-icon exception noted in
-the Actions: the `fa-solid`/`fa-brands` classes and their `fas`/`fab` shorthands
-still ship, and every icon the theme uses remains in the Free bundle.
+Docsy's icon library is upgraded from [Font Awesome][] v6 to v7
+({{% param fontAwesomeVersion %}}): the icon set is current again (v7's new
+icons included), and the theme inherits v7's modern accessibility defaults (see
+the Actions). Existing icon markup and `icon:` config values continue to
+resolve, with one Free-icon exception noted in the Actions: the
+`fa-solid`/`fa-brands` classes and their `fas`/`fab` shorthands still ship, and
+every icon the theme uses remains in the Free bundle.
 
 What you will see: **icons now render at a uniform width by default**. Font
 Awesome 7 draws every icon on a fixed-width canvas with the glyph centered,

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -5,8 +5,8 @@ date: 2026-08-19
 draft: true
 description: >-
   Docsy modernizes foundations: Dart Sass, Font Awesome 7, and pinned script
-  defaults. Breadcrumbs go semantic! Locales reach full translation coverage,
-  and pages can now link to llms.txt.
+  defaults. Breadcrumbs get semantic classes! Bundled locales reach full
+  UI-string coverage, and llms.txt sites gain agent discovery.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
@@ -94,9 +94,9 @@ The wins, for theme and project styles alike:
   moving years ago. The theme's stylesheets already use Sass modules and newer
   syntax, and your own project Sass can follow at its own pace.
 - **Ahead of Hugo's removal**: LibSass removal is coming to Hugo ([deprecated in
-  0.153.0][hugo-libsass-depr]), and Hugo has no plans to bundle Dart Sass.
-  Migrating with this release, guide in hand, beats a scramble when removal
-  lands.
+  0.153.0][hugo-libsass-depr]), and Hugo's standard binaries [won't bundle Dart
+  Sass][hugo-no-bundle]. Migrating with this release, guide in hand, beats a
+  scramble when removal lands.
 
 What this means for your build:
 
@@ -573,6 +573,7 @@ About this release:
 [compare-0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main
 [Dart Sass]: https://sass-lang.com/dart-sass/
 [hugo-libsass-depr]: https://github.com/gohugoio/hugo/releases/tag/v0.153.0
+[hugo-no-bundle]: https://github.com/gohugoio/hugo/issues/8299
 [dart-sass-2413]: https://github.com/sass/dart-sass/pull/2413
 [deployment docs]: /docs/deployment/
 [experimental]: /project/about/changelog/#experimental

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -95,8 +95,7 @@ The wins, for theme and project styles alike:
   syntax, and your own project Sass can follow at its own pace.
 - **Ahead of Hugo's removal**: LibSass removal is coming to Hugo ([deprecated in
   0.153.0][hugo-libsass-depr]), and Hugo's standard binaries [won't bundle Dart
-  Sass][hugo-no-bundle]. Migrating with this release, guide in hand, beats a
-  scramble when removal lands.
+  Sass][hugo-no-bundle].
 
 What this means for your build:
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -383,9 +383,10 @@ Sites that don't enable `llms.txt` are unaffected: the partial emits nothing.
 
 ### Actions {#llms-directive-actions}
 
-{{% _param BREAKING %}} **Applies if** your site enables `llms.txt` **and**
+{{% _param NEW %}} :warning: **Applies if** your site enables `llms.txt` **and**
 overrides any of the theme's `baseof` templates ([print][print-docs] variants
-included).
+included) — without the call below, the directive silently never renders on your
+pages.
 
 - Call the new partial from each overridden template, as the first element of
   `<body>`, passing it the page context:

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -51,8 +51,8 @@ cSpell:ignore: chromastyles libsass
 - **Modernized and strengthened foundations**:
   - [Dart Sass replaces deprecated LibSass](#dart-sass)
   - [Font Awesome 7](#fontawesome)
-  - [Install command renamed](#install-command)
   - [Default script-dependency versions pinned](#script-dep-pins)
+  - [Install command renamed](#install-command)
 - **[Semantic classes](#semantic-classes)**: starting with breadcrumbs
 - **[Internationalization](#internationalization)**:
   - Mode-menu labels localized
@@ -259,6 +259,26 @@ helpers or the `vector-square` icon.
   `draw-square`, is Pro-only): a custom `icon:` value or content icon naming it
   now renders blank. Pick a different Free icon.
 
+## Default script-dependency versions pinned {#script-dep-pins}
+
+Docsy now pins the default versions of its CDN-loaded script dependencies (see
+the table) instead of loading whatever `latest` resolves to on the CDN, so
+rendering no longer changes when an upstream major ships.
+
+| Dependency                         | Pinned version               | Loaded as                                     | Version param            |
+| ---------------------------------- | ---------------------------- | --------------------------------------------- | ------------------------ |
+| [KaTeX][katex-docs]                | {{% param katexVersion %}}   | Build-time stylesheet and fonts (self-hosted) | `params.katex.version`   |
+| [markmap-autoloader][markmap-docs] | {{% param markmapVersion %}} | Page-load script                              | `params.markmap.version` |
+| [Mermaid][mermaid-docs]            | {{% param mermaidVersion %}} | Page-load script                              | `params.mermaid.version` |
+| [Redoc][redoc-docs]                | {{% param redocVersion %}}   | Page-load script (`redoc` shortcode)          | `params.redoc.version`   |
+
+### Actions {#script-dep-pins-actions}
+
+**Applies if** you want a different version of one of these dependencies.
+
+- Set the dependency's version param (last column above) in your site config;
+  for details, see the dependency's Docsy docs (first column).
+
 ## {{% _param BREAKING %}} Install command renamed {#install-command}
 
 The command that installs the theme's npm dependencies is renamed:
@@ -292,26 +312,6 @@ npm (development and testing only).
   which needs no install step.
 
 Hugo-module and `@docsy/theme` registry installs are unaffected.
-
-## Default script-dependency versions pinned {#script-dep-pins}
-
-Docsy now pins the default versions of its CDN-loaded script dependencies (see
-the table) instead of loading whatever `latest` resolves to on the CDN, so
-rendering no longer changes when an upstream major ships.
-
-| Dependency                         | Pinned version               | Loaded as                                     | Version param            |
-| ---------------------------------- | ---------------------------- | --------------------------------------------- | ------------------------ |
-| [KaTeX][katex-docs]                | {{% param katexVersion %}}   | Build-time stylesheet and fonts (self-hosted) | `params.katex.version`   |
-| [markmap-autoloader][markmap-docs] | {{% param markmapVersion %}} | Page-load script                              | `params.markmap.version` |
-| [Mermaid][mermaid-docs]            | {{% param mermaidVersion %}} | Page-load script                              | `params.mermaid.version` |
-| [Redoc][redoc-docs]                | {{% param redocVersion %}}   | Page-load script (`redoc` shortcode)          | `params.redoc.version`   |
-
-### Actions {#script-dep-pins-actions}
-
-**Applies if** you want a different version of one of these dependencies.
-
-- Set the dependency's version param (last column above) in your site config;
-  for details, see the dependency's Docsy docs (first column).
 
 ## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -87,25 +87,26 @@ cSpell:ignore: chromastyles libsass
 Docsy's stylesheets are now transpiled with [Dart Sass][], the actively
 developed Sass implementation, instead of Hugo's deprecated embedded LibSass.
 
-The wins, for the theme and projects alike:
+The wins, for theme and project styles alike:
 
 - **Modern Sass**: Dart Sass tracks the evolving Sass language; LibSass stopped
   moving years ago. The theme's stylesheets already use Sass modules and newer
   syntax, and your own project Sass can follow at its own pace.
-- **No forced move later**: Hugo [deprecated its embedded LibSass in
-  0.153.0][hugo-libsass-depr], with removal to follow, and has no plans to
-  bundle Dart Sass. Migrating now, on Docsy's schedule, beats scrambling when
-  removal lands.
+- **Ahead of Hugo's removal**: LibSass removal is coming to Hugo ([deprecated in
+  0.153.0][hugo-libsass-depr]), and Hugo has no plans to bundle Dart Sass.
+  Migrating with this release, guide in hand, beats a scramble when removal
+  lands.
 
 What this means for your build:
 
 - **One new prerequisite**: the `sass` CLI must be available on your build's
   `PATH`.
-- **Quieter build logs**: Dart Sass is far chattier about deprecated Sass than
-  LibSass was, so the theme silences deprecation warnings from its dependencies,
-  your own [project style files][] included (only a custom `main.scss` entry
-  point keeps its warnings visible). A quiet log is therefore not evidence that
-  your own Sass is deprecation-free.
+- **Silenced deprecation warnings**: Dart Sass warns about deprecated Sass
+  constructs that the theme and its dependencies, vendored Bootstrap included,
+  haven't fully moved off yet, so the theme silences warnings from its
+  dependencies. The silencing also covers your own [project style files][]
+  (though not a custom `main.scss` entry point, whose warnings stay visible), so
+  a quiet log is not evidence that your own Sass is deprecation-free.
 
 ### Expected CSS changes {#dart-sass-recheck}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -241,16 +241,17 @@ Awesome's Sass surface: variables such as `$fa-var-*` or functions like
 API][project style files], but until now it was reachable through leaked
 imports, in two modes:
 
-- **Loud**: `$fa-var-*` references (alone or inside `fa-content()` calls) now
-  fail to compile, since Font Awesome 7's Sass is module-based; so do
-  `@include`s of removed v6 mixins such as `fa-icon-solid` and
-  `fa-family-classic` (see [Font Awesome's Sass upgrade
-  notes][fa-sass-upgrade]). If you accept the same no-stability caveat as for
-  [internal styles][resetting-internal], the namespaced form works for variables
-  and functions: `@use 'td/support/fa';` then `fa.fa-content(fa.$var-NAME)`.
-  Alias variable names from v5/v6 (such as `$var-external-link-alt`) remain
-  defined in v7, so namespacing is usually the only change needed. Never
-  `@use … as *`: Font Awesome's unprefixed variables collide with Bootstrap's.
+- **Loud**: two kinds of references now fail to compile, since Font Awesome 7's
+  Sass is module-based (see [Font Awesome's Sass upgrade
+  notes][fa-sass-upgrade]): `$fa-var-*` variables, alone or inside
+  `fa-content()` calls, and `@include`s of removed v6 mixins such as
+  `fa-icon-solid` and `fa-family-classic`. The fix for variables and functions
+  is the namespaced form: `@use 'td/support/fa';` then
+  `fa.fa-content(fa.$var-NAME)`.
+  - Alias variable names from v5/v6 (such as `$var-external-link-alt`) remain
+    defined in v7, so namespacing is usually the only change needed.
+  - Don't `@use … as *`: Font Awesome's unprefixed variables collide with
+    Bootstrap's.
 - **Silent**: two cases compile green but stop doing what they used to:
   - Font Awesome configuration globals set in your project Sass
     (`$fa-font-path`, `$fa-font-display`, and similar) **no longer have any
@@ -571,6 +572,5 @@ About this release:
 [update-hugo]: /docs/update/#update-hugo
 [update-node]: /docs/update/#update-node
 [update-theme]: /docs/update/#update-theme
-[resetting-internal]: /docs/content/lookandfeel/#resetting-internal-styles
 [What's changed in v7]: https://docs.fontawesome.com/web/setup/upgrade/whats-changed
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -35,7 +35,7 @@ cSpell:ignore: chromastyles libsass
   rendering predictable</span>
 - {{% _param FAS_LG tags info %}}
   <span>**[Semantic classes](#semantic-classes)**: Docsy chrome markup starts
-  moving from Bootstrap to Docsy's own `td-` classes</span>
+  moving to its own `td-` classes, a stable styling contract</span>
 - {{% _param FAS_LG globe warning %}}
   <span>**[Internationalization](#internationalization)**: complete
   translation-key coverage in every bundled locale, and more</span>

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -213,12 +213,16 @@ Free bundle.
 What you will see: **icons now render at a uniform width by default**. Font
 Awesome 7 draws every icon on a fixed-width canvas with the glyph centered,
 where v6 hugged each glyph's natural width. Icons in navbars, footers, and
-icon+label lists gain a little horizontal whitespace, and glyphs are redrawn. To
-restore natural width on a given icon, add `fa-width-auto`; the old `fa-fw`
-class is deprecated (it aliases `fa-width-fixed`, now the default). For the
-rationale and details, see [What's changed in v7][].
+icon+label lists gain a little horizontal whitespace, and some glyphs look
+different. For the rationale and details, see [What's changed in v7][].
 
 ### Actions {#fontawesome-actions}
+
+{{% _param BREAKING %}} **Applies if** the new fixed-width default changes
+spacing that your site wants to keep.
+
+- Add `fa-width-auto` to icons that should keep their natural width. The old
+  `fa-fw` class is deprecated: it aliases `fa-width-fixed`, now the default.
 
 {{% _param BREAKING %}} **Applies if** you override the
 `$td-font-awesome-font-name` theme variable with a Font Awesome family name.
@@ -481,7 +485,8 @@ In addition to the [generic site checks][check], for this release:
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).
 - [ ] Icons render, their webfont requests load (no 404s), and icon spacing
-      looks right in your navbar and footer; see [Font Awesome 7](#fontawesome).
+      looks right in your navbar and footer; see the
+      [Font Awesome 7 actions](#fontawesome-actions).
 - [ ] If your site uses Mermaid, diagrams render at the
       [pinned version](#script-dep-pins).
 - [ ] If your site is multilingual and enables the light/dark mode menu, its

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -17,6 +17,7 @@ params:
   # these aligned with the repo pins (package.json, theme/hugo.yaml).
   hugoSupportedVersion: 0.164.0
   dartSassMinVersion: 1.95.0
+  sassEmbeddedVersion: 1.102.0
   mermaidVersion: 11.17.0
   katexVersion: 0.18.4
   markmapVersion: 0.18.12
@@ -133,9 +134,12 @@ update in the [order of steps][]:
 
 - Follow [Install Dart Sass][]:
   - **npm-based sites**: install the Docsy-tested [`sass-embedded`][] package
-    version. CI builds that run through npm scripts need nothing more; GitHub
-    Pages and Netlify setups are covered in the [deployment docs][] ([GitHub
-    Pages][gh-pages-deploy], [Netlify][]).
+    version, {{% param sassEmbeddedVersion %}}. CI builds that run through npm
+    scripts need nothing more; GitHub Pages and Netlify setups are covered in
+    the [deployment docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]).
+    Note: `sass-embedded` also adds `@parcel/watcher` to your lockfile, an
+    install-script package from its pure-JS fallback; it never needs to run, so
+    projects that review or gate install scripts can deny it.
   - **Other setups**: follow the guide's pointer to Hugo's Dart Sass
     installation instructions.
 - Where your platform dictates a Dart Sass version of its own, it must be at

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -221,18 +221,20 @@ breadcrumb class names.
 ## {{% _param BREAKING %}} Font Awesome 7 {#fontawesome}
 
 Docsy's icon library is upgraded from [Font Awesome][] v6 to v7
-({{% param fontAwesomeVersion %}}): the icon set is current again (v7's new
-icons included), and the theme inherits v7's modern accessibility defaults (see
-the Actions). Existing icon markup and `icon:` config values continue to
-resolve, with one Free-icon exception noted in the Actions: the
-`fa-solid`/`fa-brands` classes and their `fas`/`fab` shorthands still ship, and
-every icon the theme uses remains in the Free bundle.
+({{% param fontAwesomeVersion %}}). What this brings:
 
-What you will see: **icons now render at a uniform width by default**. Font
-Awesome 7 draws every icon on a fixed-width canvas with the glyph centered,
-where v6 hugged each glyph's natural width. Icons in navbars, footers, and
-icon+label lists gain a little horizontal whitespace, and some glyphs look
-different. For the rationale and details, see [What's changed in v7][].
+- **A current icon set**: new icons included.
+- **Modern accessibility defaults**: icons are hidden from assistive technology
+  unless labeled; see the [Actions](#fontawesome-actions).
+- **Continuity**: existing icon markup and `icon:` config values continue to
+  resolve. The `fa-solid`/`fa-brands` classes and their `fas`/`fab` shorthands
+  still ship, and every icon the theme uses remains in the Free bundle (one
+  Free-icon exception in the Actions).
+- **Uniform icon width, by default**: v7 draws every icon on a fixed-width
+  canvas with the glyph centered, where v6 hugged each glyph's natural width.
+  Icons in navbars, footers, and icon+label lists gain a little horizontal
+  whitespace, and some glyphs look different. For the rationale and details, see
+  [What's changed in v7][].
 
 ### Actions {#fontawesome-actions}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -89,9 +89,9 @@ developed Sass implementation, instead of Hugo's deprecated embedded LibSass.
 This adds one build prerequisite: the `sass` CLI must be available on your
 build's `PATH`.
 
-Why now? Hugo deprecated its embedded LibSass in 0.153.0, with removal to
-follow, and has no plans to bundle Dart Sass; migrating now spares your site a
-forced move later.
+Why now? Hugo [deprecated its embedded LibSass in 0.153.0][hugo-libsass-depr],
+with removal to follow, and has no plans to bundle Dart Sass; migrating now
+spares your site a forced move later.
 
 Build logs stay quiet: the theme silences Sass deprecation warnings from
 dependencies, which as a side effect covers your own [project style files][] too
@@ -555,6 +555,7 @@ About this release:
 [CL@0.17.0]: /project/about/changelog/#next
 [compare-0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main
 [Dart Sass]: https://sass-lang.com/dart-sass/
+[hugo-libsass-depr]: https://github.com/gohugoio/hugo/releases/tag/v0.153.0
 [dart-sass-2413]: https://github.com/sass/dart-sass/pull/2413
 [deployment docs]: /docs/deployment/
 [experimental]: /project/about/changelog/#experimental

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -379,8 +379,9 @@ Sites that don't enable `llms.txt` are unaffected: the partial emits nothing.
 
 ### Actions {#llms-directive-actions}
 
-{{% _param NEW %}} **Applies if** your site enables `llms.txt` **and** overrides
-any of the theme's `baseof` templates ([print][print-docs] variants included).
+{{% _param BREAKING %}} **Applies if** your site enables `llms.txt` **and**
+overrides any of the theme's `baseof` templates ([print][print-docs] variants
+included).
 
 - Call the new partial from each overridden template, as the first element of
   `<body>`, passing it the page context:

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -4,9 +4,9 @@ linkTitle: Release 0.17.0
 date: 2026-08-19
 draft: true
 description: >-
-  Docsy modernizes and strengthens its foundations: builds move to Dart Sass
-  (the sass CLI joins your build), icons to Font Awesome 7, and script defaults
-  to pinned versions; breadcrumbs begin the move to semantic classes.
+  Docsy modernizes foundations: Dart Sass, Font Awesome 7, and pinned script
+  defaults. Breadcrumbs go semantic! Locales reach full translation coverage,
+  and pages can now link to llms.txt.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
@@ -35,8 +35,7 @@ cSpell:ignore: chromastyles libsass
   rendering predictable</span>
 - {{% _param FAS_LG tags info %}}
   <span>**[Semantic classes](#semantic-classes)**: Docsy chrome markup starts
-  moving from Bootstrap to Docsy's own `td-` classes, beginning with
-  breadcrumbs</span>
+  moving from Bootstrap to Docsy's own `td-` classes</span>
 - {{% _param FAS_LG globe warning %}}
   <span>**[Internationalization](#internationalization)**: complete
   translation-key coverage in every bundled locale, and more</span>
@@ -86,8 +85,9 @@ cSpell:ignore: chromastyles libsass
 ## {{% _param BREAKING %}} Dart Sass replaces LibSass {#dart-sass}
 
 Docsy's stylesheets are now transpiled with [Dart Sass][], the actively
-developed Sass implementation, instead of Hugo's embedded LibSass. This adds one
-build prerequisite: the `sass` CLI must be available on your build's `PATH`.
+developed Sass implementation, instead of Hugo's deprecated embedded LibSass.
+This adds one build prerequisite: the `sass` CLI must be available on your
+build's `PATH`.
 
 Why now? Hugo deprecated its embedded LibSass in 0.153.0, with removal to
 follow, and has no plans to bundle Dart Sass; migrating now spares your site a

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -165,7 +165,9 @@ reference theme or Bootstrap variables such as `$primary`.
 ## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
 
 Docsy's chrome markup is moving from Bootstrap utility and component classes to
-Docsy-owned `td-` [semantic classes][] over the coming releases.
+Docsy-owned `td-` [semantic classes][] over the coming releases. The win: your
+customizations key on names Docsy owns and documents, a stable contract that
+survives Bootstrap upgrades.
 
 ### Selector migration table
 
@@ -217,11 +219,12 @@ breadcrumb class names.
 
 ## {{% _param BREAKING %}} Font Awesome 7 {#fontawesome}
 
-Docsy's icon library is upgraded from [Font Awesome][] 6.7.2 to 7.3.1. Existing
-icon markup and `icon:` config values continue to resolve, with one Free-icon
-exception noted in the Actions: the `fa-solid`/`fa-brands` classes and their
-`fas`/`fab` shorthands still ship, and every icon the theme uses remains in the
-Free bundle.
+Docsy's icon library is upgraded from [Font Awesome][] 6.7.2 to 7.3.1: the icon
+set is current again (v7's new icons included), and the theme inherits v7's
+modern accessibility defaults (see the Actions). Existing icon markup and
+`icon:` config values continue to resolve, with one Free-icon exception noted in
+the Actions: the `fa-solid`/`fa-brands` classes and their `fas`/`fab` shorthands
+still ship, and every icon the theme uses remains in the Free bundle.
 
 What you will see: **icons now render at a uniform width by default**. Font
 Awesome 7 draws every icon on a fixed-width canvas with the glyph centered,
@@ -428,8 +431,9 @@ with lock-exact, script-free installs; a committed supply-chain audit, a
 script-runner lint, and an `npm audit` gate guard the dependency and workflow
 surface; and npm install hooks and the run scripts' implicit `pre`/`post` hooks
 are gone (inlined into their parent scripts; the pack-time lifecycle hooks
-remain), with the full test suite renamed to `test:full`. The changelog's
-[For-maintainers list][CL@0.17.0] itemizes these.
+remain), with the full test suite renamed to `test:full`. Consuming sites
+benefit indirectly: the theme you depend on is harder to compromise. The
+changelog's [For-maintainers list][CL@0.17.0] itemizes these.
 
 ### npm trusted publishing {#trusted-publishing}
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -385,8 +385,8 @@ Sites that don't enable `llms.txt` are unaffected: the partial emits nothing.
 
 {{% _param NEW %}} :warning: **Applies if** your site enables `llms.txt` **and**
 overrides any of the theme's `baseof` templates ([print][print-docs] variants
-included) — without the call below, the directive silently never renders on your
-pages.
+included): without the call below, the directive silently never renders on pages
+that use those overrides.
 
 - Call the new partial from each overridden template, as the first element of
   `<body>`, passing it the page context:
@@ -479,8 +479,9 @@ In addition to the [generic site checks][check], for this release:
 - [ ] If you diff built output (CSS and HTML), expect the changes this post
       describes ([Dart Sass serialization](#dart-sass-recheck),
       [Font Awesome 7](#fontawesome), [breadcrumb classes](#semantic-classes),
-      and the [agent directive](#llms-directive)), and investigate only
-      unexplained differences.
+      and, for sites that enable `llms.txt`, the
+      [agent directive](#llms-directive)), and investigate only unexplained
+      differences.
 - [ ] Breadcrumbs render styled, especially if you had custom breadcrumb CSS,
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -224,20 +224,20 @@ spacing that your site wants to keep.
 - Add `fa-width-auto` to icons that should keep their natural width. The old
   `fa-fw` class is deprecated: it aliases `fa-width-fixed`, now the default.
 
-{{% _param BREAKING %}} **Applies if** you override the
-`$td-font-awesome-font-name` theme variable with a Font Awesome family name.
+{{% _param BREAKING %}} **Applies if** you explicitly configure or load Font
+Awesome fonts: through the `$td-font-awesome-font-name` theme variable, a
+`font-family` in your project's CSS or Sass, or a hotlink to the theme's
+webfonts.
 
-- Update it to the v7 form of your family, for example `'Font Awesome 7 Free'`
-  (the new theme default). An override naming a custom, non-Font-Awesome font
-  needs no change. The variable feeds only Docsy's icon pseudo-elements, as
-  before.
-
-{{% _param BREAKING %}} **Applies if** you set `font-family` for Font Awesome in
-your project's CSS or Sass.
-
-- Change it to the matching v7 family, `'Font Awesome 7 Free'` or
-  `'Font Awesome 7 Brands'`: v7 registers no v6-named `@font-face`, so a
-  hardcoded v6 family silently falls through to another font.
+- Update a `$td-font-awesome-font-name` override to the v7 form of your family,
+  for example `'Font Awesome 7 Free'` (the new theme default). An override
+  naming a custom, non-Font-Awesome font needs no change. The variable feeds
+  only Docsy's icon pseudo-elements, as before.
+- Change a hardcoded `font-family` to the matching v7 family,
+  `'Font Awesome 7 Free'` or `'Font Awesome 7 Brands'`: v7 registers no v6-named
+  `@font-face`, so a hardcoded v6 family silently falls through to another font.
+- Webfonts are woff2-only in v7: the `.ttf` files that v6 also shipped are gone.
+  Replace any non-woff2 hotlink under `/webfonts/`.
 
 {{% _param BREAKING %}} **Applies if** your project's Sass reaches into Font
 Awesome's Sass surface: variables such as `$fa-var-*` or functions like
@@ -268,8 +268,9 @@ imports, in two modes:
     through as literal CSS: the `content` value ships as text, not a glyph.
 
 {{% _param BREAKING %}} **Applies if** any of your site's icons carry meaning on
-their own: icon-only links or buttons, or inline icons conveying information
-that nearby text doesn't repeat.
+their own (icon-only links or buttons, or inline icons conveying information
+that nearby text doesn't repeat), or your site uses Font Awesome's screen-reader
+utility classes.
 
 - Font Awesome 7 hides webfont icons from assistive technology by default (the
   glyph now ships with empty CSS alternative text), per [Font Awesome's
@@ -278,17 +279,14 @@ that nearby text doesn't repeat.
     (for example, with `aria-label`), not on the icon.
   - For a semantic inline icon, add `aria-label` and `role="img"` to the icon
     itself.
-
-{{% _param BREAKING %}} **Applies if** you hotlink theme webfonts, or use Font
-Awesome's screen-reader utility classes, layout helpers, or the `vector-square`
-icon.
-
-- Webfonts are woff2-only in v7: the `.ttf` files that v6 also shipped are gone.
-  Replace any non-woff2 hotlink under `/webfonts/`.
 - The `.sr-only`, `.sr-only-focusable`, `.fa-sr-only`, and
   `.fa-sr-only-focusable` utility classes are gone from the theme's compiled
   CSS: use Bootstrap's [`.visually-hidden` and
   `.visually-hidden-focusable`][visually-hidden] instead.
+
+{{% _param BREAKING %}} **Applies if** your site uses Font Awesome layout
+helpers or the `vector-square` icon.
+
 - Layout helpers `fa-pull-*` and `fa-ul`/`fa-li` now position via CSS logical
   properties, following text direction: recheck right-to-left pages and remove
   any RTL compensation CSS that now double-corrects.

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -39,8 +39,9 @@ cSpell:ignore: chromastyles libsass
 - {{% _param FAS_LG globe warning %}}
   <span>**[Internationalization](#internationalization)**: complete
   translation-key coverage in every bundled locale, and more</span>
-- {{% _param FAS_LG robot info %}} <span>**[Agent support](#llms-directive)**:
-  page HTML now points AI agents to your site's `llms.txt` index</span>
+- {{% _param FAS_LG robot info %}} <span>**[Agent support](#llms-directive)**
+  (experimental): page HTML can now point AI agents to your site's `llms.txt`
+  index</span>
 
 {{% /card %}}
 
@@ -249,11 +250,11 @@ imports, in two modes:
   Sass is module-based (see [Font Awesome's Sass upgrade
   notes][fa-sass-upgrade]): `$fa-var-*` variables, alone or inside
   `fa-content()` calls, and `@include`s of removed v6 mixins such as
-  `fa-icon-solid` and `fa-family-classic`. The fix for variables and functions
-  is the namespaced form: `@use 'td/support/fa';` then
+  `fa-icon-solid` and `fa-family-classic`. For variables and functions, the
+  namespaced form works: `@use 'td/support/fa';` then
   `fa.fa-content(fa.$var-NAME)`.
   - Alias variable names from v5/v6 (such as `$var-external-link-alt`) remain
-    defined in v7, so namespacing is usually the only change needed.
+    defined in v7, so namespacing is usually the only change variables need.
   - Don't `@use … as *`: Font Awesome's unprefixed variables collide with
     Bootstrap's.
 - **Silent**: two cases compile green but stop doing what they used to:
@@ -476,9 +477,9 @@ In addition to the [generic site checks][check], for this release:
       `sass --version`. See [Dart Sass actions](#dart-sass-actions).
 - [ ] If you diff built output (CSS and HTML), expect the changes this post
       describes ([Dart Sass serialization](#dart-sass-recheck),
-      [Font Awesome 7](#fontawesome), and
-      [breadcrumb classes](#semantic-classes)), and investigate only unexplained
-      differences.
+      [Font Awesome 7](#fontawesome), [breadcrumb classes](#semantic-classes),
+      and the [agent directive](#llms-directive)), and investigate only
+      unexplained differences.
 - [ ] Breadcrumbs render styled, especially if you had custom breadcrumb CSS,
       JavaScript, or overrides; see the
       [selector migration table](#selector-migration-table).

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -136,9 +136,8 @@ update in the [order of steps][]:
   - **npm-based sites**: install the Docsy-tested [`sass-embedded`][] package
     version, {{% param sassEmbeddedVersion %}}. CI builds that run through npm
     scripts need nothing more; GitHub Pages and Netlify setups are covered in
-    the [deployment docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]). the
-    [deployment docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]). For the
-    `@parcel/watcher` entry this adds to your lockfile, see the [install
+    the [deployment docs][] ([GitHub Pages][gh-pages-deploy], [Netlify][]). For
+    the `@parcel/watcher` entry this adds to your lockfile, see the [install
     note][Install Dart Sass].
   - **Other setups**: follow the guide's pointer to Hugo's Dart Sass
     installation instructions.

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -69,9 +69,9 @@ cSpell:ignore: chromastyles libsass
 - :warning: Respect the [order of steps][] to avoid breaking your build.
 - Review {{% _param BADGE BREAKING warning %}} changes:
   - {{% _param BREAKING %}} [Dart Sass replaces deprecated LibSass](#dart-sass)
-  - {{% _param BREAKING %}} [Breadcrumb semantic classes](#semantic-classes)
   - {{% _param BREAKING %}} [Font Awesome 7](#fontawesome)
   - {{% _param BREAKING %}} [Install command renamed](#install-command)
+  - {{% _param BREAKING %}} [Breadcrumb semantic classes](#semantic-classes)
 - Optionally skim:
   - [Default script-dependency versions pinned](#script-dep-pins)
   - {{% _param NEW %}} / {{% _param CLEANUP %}}
@@ -162,61 +162,6 @@ reference theme or Bootstrap variables such as `$primary`.
 
 - Inline those color values: custom Chroma files now load as isolated Sass
   modules, so such references fail with "Undefined variable".
-
-## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
-
-Docsy's chrome markup is moving from Bootstrap utility and component classes to
-Docsy-owned `td-` [semantic classes][] over the coming releases. The win: your
-customizations key on names Docsy owns and documents, a stable contract that
-survives Bootstrap upgrades.
-
-### Selector migration table
-
-| 0.16 selector                | 0.17 selector                                  |
-| ---------------------------- | ---------------------------------------------- |
-| `ol.breadcrumb`              | `ol.td-breadcrumbs__list`                      |
-| `li.breadcrumb-item`         | `li.td-breadcrumbs__item`                      |
-| `li.breadcrumb-item.active`  | `li.td-breadcrumbs__item[aria-current="page"]` |
-| `nav.td-breadcrumbs__single` | `nav.td-breadcrumbs--single`                   |
-
-Unchanged: the `td-breadcrumbs` class on the `<nav>` element. The markup no
-longer carries an `active` class: state styling keys on the standard
-`aria-current="page"` attribute, so visual state and accessibility state can't
-drift apart.
-
-One related change: breadcrumbs in taxonomy-term page summaries render without
-ARIA attributes (a page summary isn't the current page), so current-item styling
-doesn't apply there, as in 0.16.
-
-### Actions {#semantic-classes-actions}
-
-{{% _param BREAKING %}} **Applies if** you style or script against breadcrumb
-markup from outside the theme's Sass pipeline: plain CSS files, JavaScript
-`querySelector` calls, or tests matching the table's 0.16 selectors.
-
-- Update your selectors per the [table above](#selector-migration-table).
-
-{{% _param BREAKING %}} **Applies if** you override `breadcrumb.html` or
-`term.html`.
-
-- Refresh your overridden copies from the 0.17 theme: partial overrides are
-  version-coupled ([review your theme overrides][overrides]). A pre-0.17
-  `breadcrumb.html` copy also leaks the stale `active` class into term-page
-  summaries, since `term.html`'s summary sanitizer now strips ARIA attributes
-  only.
-
-{{% _param BREAKING %}} **Applies if** your project's Sass styles the old
-breadcrumb class names.
-
-- Migrate all your selectors now, per the
-  [table above](#selector-migration-table). Rules on the old **structural**
-  Bootstrap names (`.breadcrumb`, `.breadcrumb-item`) keep matching for the
-  moment, an accident of the theme's Bootstrap binding rather than a
-  compatibility promise. Rules involving the **state** class are already broken:
-  `.breadcrumb-item.active` no longer matches anything, and a `:not(.active)`
-  now also matches the current item. The `td-breadcrumbs__single` rename has no
-  keep-alive at all: the documented [single-breadcrumb display
-  override][single-override] stops matching until renamed.
 
 ## {{% _param BREAKING %}} Font Awesome 7 {#fontawesome}
 
@@ -367,6 +312,61 @@ rendering no longer changes when an upstream major ships.
 
 - Set the dependency's version param (last column above) in your site config;
   for details, see the dependency's Docsy docs (first column).
+
+## {{% _param BREAKING %}} Semantic classes: breadcrumbs {#semantic-classes}
+
+Docsy's chrome markup is moving from Bootstrap utility and component classes to
+Docsy-owned `td-` [semantic classes][] over the coming releases. The win: your
+customizations key on names Docsy owns and documents, a stable contract that
+survives Bootstrap upgrades.
+
+### Selector migration table
+
+| 0.16 selector                | 0.17 selector                                  |
+| ---------------------------- | ---------------------------------------------- |
+| `ol.breadcrumb`              | `ol.td-breadcrumbs__list`                      |
+| `li.breadcrumb-item`         | `li.td-breadcrumbs__item`                      |
+| `li.breadcrumb-item.active`  | `li.td-breadcrumbs__item[aria-current="page"]` |
+| `nav.td-breadcrumbs__single` | `nav.td-breadcrumbs--single`                   |
+
+Unchanged: the `td-breadcrumbs` class on the `<nav>` element. The markup no
+longer carries an `active` class: state styling keys on the standard
+`aria-current="page"` attribute, so visual state and accessibility state can't
+drift apart.
+
+One related change: breadcrumbs in taxonomy-term page summaries render without
+ARIA attributes (a page summary isn't the current page), so current-item styling
+doesn't apply there, as in 0.16.
+
+### Actions {#semantic-classes-actions}
+
+{{% _param BREAKING %}} **Applies if** you style or script against breadcrumb
+markup from outside the theme's Sass pipeline: plain CSS files, JavaScript
+`querySelector` calls, or tests matching the table's 0.16 selectors.
+
+- Update your selectors per the [table above](#selector-migration-table).
+
+{{% _param BREAKING %}} **Applies if** you override `breadcrumb.html` or
+`term.html`.
+
+- Refresh your overridden copies from the 0.17 theme: partial overrides are
+  version-coupled ([review your theme overrides][overrides]). A pre-0.17
+  `breadcrumb.html` copy also leaks the stale `active` class into term-page
+  summaries, since `term.html`'s summary sanitizer now strips ARIA attributes
+  only.
+
+{{% _param BREAKING %}} **Applies if** your project's Sass styles the old
+breadcrumb class names.
+
+- Migrate all your selectors now, per the
+  [table above](#selector-migration-table). Rules on the old **structural**
+  Bootstrap names (`.breadcrumb`, `.breadcrumb-item`) keep matching for the
+  moment, an accident of the theme's Bootstrap binding rather than a
+  compatibility promise. Rules involving the **state** class are already broken:
+  `.breadcrumb-item.active` no longer matches anything, and a `:not(.active)`
+  now also matches the current item. The `td-breadcrumbs__single` rename has no
+  keep-alive at all: the documented [single-breadcrumb display
+  override][single-override] stops matching until renamed.
 
 ## {{% _param FAS globe "" %}} Internationalization
 

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -57,6 +57,15 @@ Docsy is tested with:
 npm install --save-exact --save-dev sass-embedded@{{% sass-embedded-version %}}
 ```
 
+> [!NOTE]
+>
+> Installing `sass-embedded` also adds [`@parcel/watcher`][], an install-script
+> package, to your lockfile: it arrives through the optional pure-JS fallback
+> and is never installed or run on platforms with a prebuilt `sass-embedded`
+> binary. Projects that review or gate install scripts can deny it.
+
+[`@parcel/watcher`]: https://www.npmjs.com/package/@parcel/watcher
+
 The `sass` CLI is then on `PATH` for every npm-run script, so run Hugo through
 [npm scripts][]. For example, with the following in your `package.json`:
 

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -64,8 +64,6 @@ npm install --save-exact --save-dev sass-embedded@{{% sass-embedded-version %}}
 > and is never installed or run on platforms with a prebuilt `sass-embedded`
 > binary. Projects that review or gate install scripts can deny it.
 
-[`@parcel/watcher`]: https://www.npmjs.com/package/@parcel/watcher
-
 The `sass` CLI is then on `PATH` for every npm-run script, so run Hugo through
 [npm scripts][]. For example, with the following in your `package.json`:
 
@@ -157,6 +155,7 @@ site
 - [Start site from scratch (for experts)](start-from-scratch/)
 
 <!-- prettier-ignore-start -->
+[`@parcel/watcher`]: https://www.npmjs.com/package/@parcel/watcher
 [browserslist-defaults]: https://github.com/browserslist/browserslist
 [dart sass]: https://sass-lang.com/dart-sass/
 [hugo-dart-sass]: https://gohugo.io/functions/css/sass/#dart-sass

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -225,7 +225,7 @@ development or testing, you can also install:
 
   ```sh
   npm install --save-dev google/docsy
-  (cd node_modules/docsy && npm run install:theme-deps)
+  npm run install:theme-deps --prefix node_modules/docsy
   ```
 
   This installs the repository's default branch (`main`). To pin a tagged
@@ -240,7 +240,11 @@ development or testing, you can also install:
   use `theme: docsy/theme` in your site configuration. Unlike the registry
   package, the GitHub package doesn't declare Bootstrap and Font Awesome as its
   own dependencies: the `install:theme-deps` command installs them, and must be
-  rerun after every install or update of the package.
+  rerun after every install or update of the package, so for `npm ci`
+  environments wire it into your site's setup script. GitHub installs also
+  resolve outside the npm registry, so registry release gates such as
+  `min-release-age` don't apply: a cooldown-gated site can test a pre-release
+  this way without touching its gate.
 
 ## Preview your site
 

--- a/docsy.dev/content/en/docs/update/git.md
+++ b/docsy.dev/content/en/docs/update/git.md
@@ -31,6 +31,10 @@ in your project, here's how you update the submodule to the latest release:
    git -C themes/docsy checkout {{% param tdVersion.latest %}}
    ```
 
+   If your project pins the submodule through its own tooling (a pin file, npm
+   scripts, or CI submodule sync), update the pin there instead: a bare checkout
+   is reset the next time your build syncs submodules.
+
 1. Reinstall the theme's runtime dependencies:
 
    ```sh

--- a/docsy.dev/content/en/docs/update/git.md
+++ b/docsy.dev/content/en/docs/update/git.md
@@ -4,11 +4,9 @@ linkTitle: Git submodule or clone
 aliases: [/docs/updating/updating-submodules/]
 weight: 3
 description: >-
-  Update a Docsy theme vendored under `themes/` as a Git submodule or clone.
+  Choose the procedure matching how your project vendors Docsy under `themes/`:
+  submodule or clone.
 ---
-
-Use the procedure matching how Docsy was installed in your project:
-[submodule](#update-your-docsy-submodule) or [clone](#update-your-docsy-clone).
 
 > [!TIP]
 >
@@ -51,8 +49,7 @@ in your project, here's how you update the submodule to the latest release:
    Run `npm run install:theme-deps`, not `npm install`; for why, see the [setup
    note][theme-deps-note].
 
-3. Commit the change to your project (re-run the `git add` first if your tooling
-   touched the submodule since step 1):
+3. Commit the staged change to your project:
 
    ```sh
    git commit -m "Update Docsy theme to {{% param tdVersion.latest %}}"

--- a/docsy.dev/content/en/docs/update/git.md
+++ b/docsy.dev/content/en/docs/update/git.md
@@ -31,10 +31,16 @@ in your project, here's how you update the submodule to the latest release:
    git -C themes/docsy checkout {{% param tdVersion.latest %}}
    ```
 
-   If your project pins the submodule through its own tooling (a pin file or npm
-   scripts), update the pin there too, then re-sync the submodule from it before
-   continuing: such tooling resets a bare checkout to the old pin on its next
-   sync.
+   Stage the update now, before any project tooling re-syncs submodules (the
+   parent repo's staged gitlink is the durable pin; an unstaged checkout is
+   reset to the old pin on the next `git submodule update`):
+
+   ```sh
+   git add themes/docsy
+   ```
+
+   If a pin file or other project tooling names the Docsy ref separately, update
+   that source of truth too.
 
 1. Reinstall the theme's runtime dependencies:
 
@@ -45,10 +51,10 @@ in your project, here's how you update the submodule to the latest release:
    Run `npm run install:theme-deps`, not `npm install`; for why, see the [setup
    note][theme-deps-note].
 
-1. Add and then commit the change to your project:
+1. Commit the change to your project (re-run the `git add` first if your tooling
+   touched the submodule since step 1):
 
    ```sh
-   git add themes/docsy
    git commit -m "Update Docsy theme to {{% param tdVersion.latest %}}"
    ```
 

--- a/docsy.dev/content/en/docs/update/git.md
+++ b/docsy.dev/content/en/docs/update/git.md
@@ -31,9 +31,10 @@ in your project, here's how you update the submodule to the latest release:
    git -C themes/docsy checkout {{% param tdVersion.latest %}}
    ```
 
-   If your project pins the submodule through its own tooling (a pin file, npm
-   scripts, or CI submodule sync), update the pin there instead: a bare checkout
-   is reset the next time your build syncs submodules.
+   If your project pins the submodule through its own tooling (a pin file or npm
+   scripts), update the pin there too, then re-sync the submodule from it before
+   continuing: such tooling resets a bare checkout to the old pin on its next
+   sync.
 
 1. Reinstall the theme's runtime dependencies:
 

--- a/docsy.dev/content/en/docs/update/git.md
+++ b/docsy.dev/content/en/docs/update/git.md
@@ -42,7 +42,7 @@ in your project, here's how you update the submodule to the latest release:
    If a pin file or other project tooling names the Docsy ref separately, update
    that source of truth too.
 
-1. Reinstall the theme's runtime dependencies:
+2. Reinstall the theme's runtime dependencies:
 
    ```sh
    npm run install:theme-deps --prefix themes/docsy
@@ -51,14 +51,14 @@ in your project, here's how you update the submodule to the latest release:
    Run `npm run install:theme-deps`, not `npm install`; for why, see the [setup
    note][theme-deps-note].
 
-1. Commit the change to your project (re-run the `git add` first if your tooling
+3. Commit the change to your project (re-run the `git add` first if your tooling
    touched the submodule since step 1):
 
    ```sh
    git commit -m "Update Docsy theme to {{% param tdVersion.latest %}}"
    ```
 
-1. Push the commit to your project repo.
+4. Push the commit to your project repo.
 
 ## Update your Docsy clone
 
@@ -77,7 +77,7 @@ that you are targeting:
    Ensure that `origin` is set to `https://github.com/google/docsy.git`
    (`git -C themes/docsy remote -v`).
 
-1. Reinstall the theme's runtime dependencies:
+2. Reinstall the theme's runtime dependencies:
 
    ```sh
    npm run install:theme-deps --prefix themes/docsy
@@ -86,7 +86,7 @@ that you are targeting:
    As in the submodule procedure, run `npm run install:theme-deps`, not
    `npm install`.
 
-1. Persist the update to your project, the same way that your project already
+3. Persist the update to your project, the same way that your project already
    tracks the cloned theme: for example, commit the updated theme files to your
    project repository, or record the new tag where your build restores the clone
    from.

--- a/docsy.dev/content/en/docs/update/npm-package.md
+++ b/docsy.dev/content/en/docs/update/npm-package.md
@@ -27,8 +27,15 @@ npm install --save-dev @docsy/theme@latest
 >
 > If your project gates installs with npm's `min-release-age`, installing a
 > release younger than the gate fails with `ETARGET`, and the error doesn't name
-> the cause. Wait out the window, or run the update under a one-off
-> `NPM_CONFIG_MIN_RELEASE_AGE` override, noting the override in your update PR.
+> the cause. Wait out the window, or run the update under a one-off override,
+> noting it in your update PR:
+>
+> ```sh
+> NPM_CONFIG_MIN_RELEASE_AGE=RELEASE_AGE_DAYS npm install --save-dev @docsy/theme@VERSION
+> ```
+>
+> where _`RELEASE_AGE_DAYS`_ is the release's age in whole days (set it no lower
+> than needed) and _`VERSION`_ is the release you are installing.
 
 To verify the resolved version of [`@docsy/theme`][npm-package-setup], run:
 

--- a/docsy.dev/content/en/docs/update/npm-package.md
+++ b/docsy.dev/content/en/docs/update/npm-package.md
@@ -23,6 +23,13 @@ npm install --save-dev @docsy/theme@latest
 > npm install --save-dev @docsy/theme@{{% param tdVersion.latest %}}
 > ```
 
+> [!NOTE]
+>
+> If your project gates installs with npm's `min-release-age`, installing a
+> release younger than the gate fails with `ETARGET`, and the error doesn't name
+> the cause. Wait out the window, or run the update under a one-off
+> `NPM_CONFIG_MIN_RELEASE_AGE` override, noting the override in your update PR.
+
 To verify the resolved version of [`@docsy/theme`][npm-package-setup], run:
 
 ```sh

--- a/docsy.dev/content/en/docs/update/npm-package.md
+++ b/docsy.dev/content/en/docs/update/npm-package.md
@@ -8,27 +8,22 @@ description: >-
   package.
 ---
 
-Update the theme to the latest release by running the following from your
-project root:
+Update the theme to the release you are targeting, named explicitly, by running
+the following from your project root:
 
 ```sh
-npm install --save-dev @docsy/theme@latest
+npm install --save-dev @docsy/theme@{{% param tdVersion.latest %}}
 ```
-
-> [!TIP]
->
-> To pin a specific version, name it explicitly, for example:
->
-> ```sh
-> npm install --save-dev @docsy/theme@{{% param tdVersion.latest %}}
-> ```
 
 > [!NOTE]
 >
-> If your project gates installs with npm's `min-release-age`, installing a
-> release younger than the gate fails with `ETARGET`, and the error doesn't name
-> the cause. Wait out the window, or run the update under a one-off override,
-> noting it in your update PR:
+> Prefer an exact version over the `latest` dist-tag: under npm's
+> `min-release-age`, `@latest` silently resolves to the newest release that is
+> old enough, so you can end up one release behind without any warning. An exact
+> version fails visibly instead (`ETARGET`, though the error doesn't name the
+> age gate as the cause). To install a release younger than your gate, wait out
+> the window, or run the update under a one-off override, noting it in your
+> update PR:
 >
 > ```sh
 > NPM_CONFIG_MIN_RELEASE_AGE=RELEASE_AGE_DAYS npm install --save-dev @docsy/theme@VERSION

--- a/docsy.dev/content/en/examples/index.md
+++ b/docsy.dev/content/en/examples/index.md
@@ -61,10 +61,10 @@ For the site source, see [docsy.dev][docsy.dev-repo].
 
 The Docsy project provides two site starter templates:
 
-| Site                               | Repo                                      | Docsy            |
-| ---------------------------------- | ----------------------------------------- | ---------------- |
-| [Goldydocs][] - main Docsy example | <{{% param github_repo %}}-example>       | v0.16.0 (latest) |
-| [Docsy starter][]                  | <https://github.com/chalin/docsy-starter> | v0.16.0 (latest) |
+| Site                               | Repo                                      | Docsy                                   |
+| ---------------------------------- | ----------------------------------------- | --------------------------------------- |
+| [Goldydocs][] - main Docsy example | <{{% param github_repo %}}-example>       | {{% param tdVersion.latest %}} (latest) |
+| [Docsy starter][]                  | <https://github.com/chalin/docsy-starter> | {{% param tdVersion.latest %}} (latest) |
 
 In addition to these example starters, there are several live sites using the
 theme. Consider adding your Docsy-based site to this page once you have a

--- a/docsy.dev/content/en/examples/index.md
+++ b/docsy.dev/content/en/examples/index.md
@@ -61,10 +61,10 @@ For the site source, see [docsy.dev][docsy.dev-repo].
 
 The Docsy project provides two site starter templates:
 
-| Site                               | Repo                                      | Docsy                                   |
-| ---------------------------------- | ----------------------------------------- | --------------------------------------- |
-| [Goldydocs][] - main Docsy example | <{{% param github_repo %}}-example>       | {{% param tdVersion.latest %}} (latest) |
-| [Docsy starter][]                  | <https://github.com/chalin/docsy-starter> | {{% param tdVersion.latest %}} (latest) |
+| Site                              | Repo                                      | Docsy                                   |
+| --------------------------------- | ----------------------------------------- | --------------------------------------- |
+| [Goldydocs][], main Docsy example | <{{% param github_repo %}}-example>       | {{% param tdVersion.latest %}} (latest) |
+| [Docsy starter][]                 | <https://github.com/chalin/docsy-starter> | {{% param tdVersion.latest %}} (latest) |
 
 In addition to these example starters, there are several live sites using the
 theme. Consider adding your Docsy-based site to this page once you have a

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -193,7 +193,10 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 - Committed npm lockfiles; dependency installs are now lock-exact, and
   unreviewed dependency scripts are disabled ([#2700][]).
 - Guarded dependency and workflow hardening with a committed supply-chain audit;
-  removed bare-npx registry fallback paths ([#2714][]).
+  removed bare-npx registry fallback paths ([#2714][]). Later extended with the
+  opentelemetry.io audit-hardening wave: exact Node toolchain pins, lock-surface
+  bypass guards, and a manifest-wide ban on npm lifecycle script names
+  ([#2757][]).
 - Renamed the full test-suite entry point: `ci:test` → `test:full`, with
   `_test:full:pre`/`_test:full:common` phases; the freed `ci:*` names retire. A
   repo clone now installs via `npm run install:safe` ([#2712][]).
@@ -237,6 +240,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [#2748]: https://github.com/google/docsy/pull/2748
 [#2751]: https://github.com/google/docsy/pull/2751
 [#2753]: https://github.com/google/docsy/issues/2753
+[#2757]: https://github.com/google/docsy/pull/2757
 [0.17.0 release report]: /blog/2026/0.17.0/
 [0.17.0-blog-dart-sass]: /blog/2026/0.17.0/#dart-sass
 [0.17.0-blog-fontawesome]: /blog/2026/0.17.0/#fontawesome

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -192,10 +192,9 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 
 - Committed npm lockfiles; dependency installs are now lock-exact, and
   unreviewed dependency scripts are disabled ([#2700][]).
-- Guarded dependency and workflow hardening with a committed supply-chain audit:
-  removed bare-npx registry fallback paths, pinned the Node toolchain, closed
-  lock-surface bypasses, and banned unreviewed npm lifecycle script names (the
-  theme's reviewed pack-time hooks remain) ([#2714][], [#2757][]).
+- Guarded dependency and workflow hardening with a committed supply-chain audit
+  spanning package runners, the Node toolchain, the lock surface, and npm
+  lifecycle script names ([#2714][], [#2757][]).
 - Renamed the full test-suite entry point: `ci:test` → `test:full`, with
   `_test:full:pre`/`_test:full:common` phases; the freed `ci:*` names retire. A
   repo clone now installs via `npm run install:safe` ([#2712][]).

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -192,11 +192,10 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 
 - Committed npm lockfiles; dependency installs are now lock-exact, and
   unreviewed dependency scripts are disabled ([#2700][]).
-- Guarded dependency and workflow hardening with a committed supply-chain audit;
-  removed bare-npx registry fallback paths ([#2714][]). Later extended with the
-  opentelemetry.io audit-hardening wave: exact Node toolchain pins, lock-surface
-  bypass guards, and a manifest-wide ban on npm lifecycle script names
-  ([#2757][]).
+- Guarded dependency and workflow hardening with a committed supply-chain audit:
+  removed bare-npx registry fallback paths, pinned the Node toolchain, closed
+  lock-surface bypasses, and banned npm's lifecycle script names ([#2714][],
+  [#2757][]).
 - Renamed the full test-suite entry point: `ci:test` → `test:full`, with
   `_test:full:pre`/`_test:full:common` phases; the freed `ci:*` names retire. A
   repo clone now installs via `npm run install:safe` ([#2712][]).

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -194,8 +194,8 @@ full list of changes, see the [0.17.0][] release page or the [git history since
   unreviewed dependency scripts are disabled ([#2700][]).
 - Guarded dependency and workflow hardening with a committed supply-chain audit:
   removed bare-npx registry fallback paths, pinned the Node toolchain, closed
-  lock-surface bypasses, and banned npm's lifecycle script names ([#2714][],
-  [#2757][]).
+  lock-surface bypasses, and banned unreviewed npm lifecycle script names (the
+  theme's reviewed pack-time hooks remain) ([#2714][], [#2757][]).
 - Renamed the full test-suite entry point: `ci:test` → `test:full`, with
   `_test:full:pre`/`_test:full:common` phases; the freed `ci:*` names retire. A
   repo clone now installs via `npm run install:safe` ([#2712][]).

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -734,8 +734,9 @@ with the following modifications:
       to the new release.
     - To create a new release draft, visit [Docsy-example release draft][].
 
-3.  **Update the [Examples page][]** Docsy version in the Starter templates
-    table to {{% dev-version final %}}.
+3.  **Verify the [Examples page][]** Starter-templates table shows
+    {{% dev-version final %}}: its Docsy cells render the site's
+    `tdVersion.latest`, which the Docsy release advanced.
 
 [Docsy-example release draft]:
   https://github.com/google/docsy-example/releases/new

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,7 +6,7 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
-- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy modernizes foundations: Dart Sass, Font Awesome 7, and pinned script defaults. Breadcrumbs go semantic! Locales reach full translation coverage, and pages can now link to llms.txt.
+- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy modernizes foundations: Dart Sass, Font Awesome 7, and pinned script defaults. Breadcrumbs get semantic classes! Bundled locales reach full UI-string coverage, and llms.txt sites gain agent discovery.
 - [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Docsy is now on npm as @docsy/theme. This release also moves the theme into theme/, raises the Hugo minimum, and drops its default favicons in favor of discovery, each with upgrade actions.
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/): What changed in Hugo 0.158.0 through 0.164.x for Docsy sites: breaking changes, deprecations, security fixes, and known regressions, with per-version upgrade actions.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,7 +6,7 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
-- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy modernizes and strengthens its foundations: builds move to Dart Sass (the sass CLI joins your build), icons to Font Awesome 7, and script defaults to pinned versions; breadcrumbs begin the move to semantic classes.
+- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy modernizes foundations: Dart Sass, Font Awesome 7, and pinned script defaults. Breadcrumbs go semantic! Locales reach full translation coverage, and pages can now link to llms.txt.
 - [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Docsy is now on npm as @docsy/theme. This release also moves the theme into theme/, raises the Hugo minimum, and drops its default favicons in favor of discovery, each with upgrade actions.
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/): What changed in Hugo 0.158.0 through 0.164.x for Docsy sites: breaking changes, deprecations, security fixes, and known regressions, with per-version upgrade actions.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.


### PR DESCRIPTION
- Contributes to #2691
- **Update guide (git.md)**: stages the submodule gitlink right after checkout (the parent repo's staged gitlink is the durable pin); separately named pins become the narrow exception
- **Update guide (npm-package.md)**: makes the exact-version install the primary path (under `min-release-age`, `@latest` silently resolves to an older eligible release) and documents the one-off cooldown override
- **Release post**:
  - Reworks the description as a scoped thumbnail pitch; restructures the Dart Sass and Font Awesome intros as lede plus benefit bullets, claiming the consumer wins (semantic-class stable contract, supply chain); body-section order now matches the highlights card
  - Regroups the FA7 Actions by reader concern, with the width-default remedy as the first gate; FA version becomes a frozen page param
  - Adds Agent support to the Highlights card (experimental, opt-in scoped); its action stays `NEW` with an explicit silent-failure warning
- **Changelog**: supply-chain For-maintainers entry extended with the otel.io hardening port (#2757), which carried no changelog line of its own
- **Install prerequisites**: documents the `@parcel/watcher` lockfile entry that `sass-embedded` brings (deniable install script)
- **Examples page**: starter-version cells read `tdVersion.latest` (one home for the version stamp); the maintainer-notes docsy-example step becomes verify-only
- **Preview(s)**:
  - [0.17.0 release post](https://deploy-preview-2759--docsydocs.netlify.app/blog/2026/0.17.0/)
  - [Update guide: Git submodule or clone](https://deploy-preview-2759--docsydocs.netlify.app/docs/update/git/)
  - [Update guide: NPM package](https://deploy-preview-2759--docsydocs.netlify.app/docs/update/npm-package/)
  - [Installation prerequisites](https://deploy-preview-2759--docsydocs.netlify.app/docs/get-started/docsy-as-module/installation-prerequisites/)
  - [Changelog](https://deploy-preview-2759--docsydocs.netlify.app/project/about/changelog/)
  - [Examples](https://deploy-preview-2759--docsydocs.netlify.app/examples/)
