### PR TITLE
Default-deny npm lifecycle scripts; add release cooldown (.npmrc)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,10 @@
 # npm supply-chain controls; shared rationale (cross-repo one-home):
 # https://opentelemetry.io/site/design/supply-chain-security/
+#
+# This file has a byte-identical mirror at theme/.npmrc, because --prefix/-C
+# runs read only the target directory's .npmrc (they suppress the workspace
+# walk-up that normally resolves config at the root). Edit the two files
+# together; the supply-chain audit enforces the sync.
 
 min-release-age=7
 strict-allow-scripts=true
@@ -7,8 +12,8 @@ engine-strict=true
 
 # Execution default-deny for every install (CI, Netlify, contributors).
 # Reviewed exceptions re-enable scripts at their call sites: the theme's own
-# pack lifecycle (publish.yaml, scripts/npm-pack.test.mjs) and hugo-extended's
-# installer (install:safe).
+# pack lifecycle (publish.yaml, scripts/npm-pack.test.mjs, tests/smoke.mjs)
+# and hugo-extended's installer (install:safe).
 ignore-scripts=true
 
 # One script interpreter on every platform (Windows npm defaults to cmd.exe,

--- a/.npmrc
+++ b/.npmrc
@@ -1,18 +1,21 @@
-# The npm engines floor (package.json) is the version where the allowScripts
-# policy landed; on older npm the key is silently ignored, an unprotected
-# install that looks protected. engine-strict turns that floor into a hard
-# install-time failure.
-engine-strict=true
-strict-allow-scripts=true
+# npm supply-chain controls; shared rationale (cross-repo one-home):
+# https://opentelemetry.io/site/design/supply-chain-security/
 
-# One script interpreter on every platform: without this, Windows npm hands
-# scripts to cmd.exe, whose quoting rules silently diverge from sh (Git Bash
-# is on PATH on Windows CI runners and ships with Git for Windows). Covers
-# workspace runs too: npm resolves config at the workspace root and ignores
-# per-workspace .npmrc files.
+min-release-age=7
+strict-allow-scripts=true
+engine-strict=true
+
+# Execution default-deny for every install (CI, Netlify, contributors).
+# Reviewed exceptions re-enable scripts at their call sites: the theme's own
+# pack lifecycle (publish.yaml, scripts/npm-pack.test.mjs) and hugo-extended's
+# installer (install:safe).
+ignore-scripts=true
+
+# One script interpreter on every platform (Windows npm defaults to cmd.exe,
+# whose quoting silently diverges from sh); resolved at the workspace root,
+# covering workspace runs.
 script-shell=bash
 
-# Pin the @docsy scope registry for manual publish/dist-tag/view commands: a
-# user-level @docsy:registry mapping would outrank even --registry, but this
-# project-level pin outranks the user level. Applies to in-repo cwds only.
+# Outranks a user-level @docsy:registry mapping (which would outrank even
+# --registry) for manual publish/dist-tag/view commands run in-repo.
 @docsy:registry=https://registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -1,10 +1,11 @@
 # npm supply-chain controls; shared rationale (cross-repo one-home):
 # https://opentelemetry.io/site/design/supply-chain-security/
 #
-# This file has a byte-identical mirror at theme/.npmrc, because --prefix/-C
-# runs read only the target directory's .npmrc (they suppress the workspace
-# walk-up that normally resolves config at the root). Edit the two files
-# together; the supply-chain audit enforces the sync.
+# The root .npmrc and theme/.npmrc are byte-identical mirrors (the audit
+# enforces the sync): --prefix/-C runs read only the target directory's
+# .npmrc (they suppress the workspace walk-up that normally resolves config
+# at the root), so theme-prefix installs need their own copy. Edit the two
+# files together.
 
 min-release-age=7
 strict-allow-scripts=true

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -53,6 +53,7 @@
     "nvmrc",
     "Occitan",
     "onedark",
+    "opentelemetry",
     "pageinfo",
     "pexels",
     "prereq",

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -561,6 +561,7 @@ https://github.com/google/docsy/pull/2731,200,1787331617
 https://github.com/google/docsy/pull/2747,200,1787929767
 https://github.com/google/docsy/pull/2748,200,1787848215
 https://github.com/google/docsy/pull/2751,200,1787929767
+https://github.com/google/docsy/pull/2760,200,1788020072
 https://github.com/google/docsy/pull/941,200,1782498225
 https://github.com/google/docsy/pulls,200,1782563369
 https://github.com/google/docsy/releases,200,1782563368

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -200,6 +200,9 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 - Inlined npm `pre*`/`post*` run-hooks into their parent scripts, so
   `check:links` still builds the site under user-level `ignore-scripts`
   ([#2726][]).
+- Committed `ignore-scripts=true` and a 7-day release cooldown to `.npmrc`:
+  installs are script-free by default everywhere, and version resolution ignores
+  releases younger than a week ([#2760][]).
 - Switched stable `@docsy/theme` publishing to CI-based npm trusted publishing
   (OIDC). See the [0.17.0 release report][0.17.0-blog-maintainers] ([#2708][]).
 - Moved the default Mermaid version to `theme/hugo.yaml`
@@ -228,6 +231,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [#2714]: https://github.com/google/docsy/pull/2714
 [#2279]: https://github.com/google/docsy/issues/2279
 [#2726]: https://github.com/google/docsy/pull/2726
+[#2760]: https://github.com/google/docsy/pull/2760
 [#2731]: https://github.com/google/docsy/pull/2731
 [#2747]: https://github.com/google/docsy/pull/2747
 [#2748]: https://github.com/google/docsy/pull/2748

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -2,7 +2,8 @@
 title: Maintainer notes
 description: Release, dependency-update, and Hugo-support procedures
 aliases: [contributing, ../contributing]
-cSpell:ignore: hugo creatordate lycheecache opentelemetry prebuild worktree
+# prettier-ignore
+cSpell:ignore: creatordate lycheecache prebuild ETARGET unkeyed
 ---
 
 For our main contributing page covering license agreements, code of conduct and
@@ -209,7 +210,11 @@ Dependabot security updates; a rare duplicate PR is accepted. These PRs bypass
 Renovate's own cooldown but not npm's: lock regeneration for a fix younger than
 `min-release-age` (`.npmrc`) fails with `ETARGET` until the release ages. For a
 fix that can't wait, bump manually under a per-invocation
-`NPM_CONFIG_MIN_RELEASE_AGE` environment override.
+`NPM_CONFIG_MIN_RELEASE_AGE` environment override, for example:
+
+```sh
+NPM_CONFIG_MIN_RELEASE_AGE=3 npm run update:hugo
+```
 
 ## Test suites
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -208,8 +208,8 @@ Renovate's vulnerability-alert PRs stay on, beside GitHub's config-free
 Dependabot security updates; a rare duplicate PR is accepted. These PRs bypass
 Renovate's own cooldown but not npm's: lock regeneration for a fix younger than
 `min-release-age` (`.npmrc`) fails with `ETARGET` until the release ages. For a
-fix that can't wait, bump manually under the per-invocation
-`NPM_CONFIG_MIN_RELEASE_AGE=0` environment override.
+fix that can't wait, bump manually under a per-invocation
+`NPM_CONFIG_MIN_RELEASE_AGE` environment override.
 
 ## Test suites
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -205,6 +205,11 @@ platform constraint: workflows and nvm read the root file, while Netlify reads
 only its base directory's (`docsy.dev/.nvmrc`), with no root fallback. The
 toolchain-versions test guards the sync.
 
+The npm config follows the same two-homes pattern: `theme/.npmrc` is a
+byte-identical mirror of the root `.npmrc`, because `--prefix`/`-C` npm runs
+(`install:theme-deps`, `_sync:theme-lock`) read only the target directory's
+file. Edit the two together; the supply-chain audit guards the sync.
+
 Renovate's vulnerability-alert PRs stay on, beside GitHub's config-free
 Dependabot security updates; a rare duplicate PR is accepted. Renovate's alert
 PRs bypass its own cooldown but not npm's: lock regeneration for a fix younger

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -204,9 +204,12 @@ platform constraint: workflows and nvm read the root file, while Netlify reads
 only its base directory's (`docsy.dev/.nvmrc`), with no root fallback. The
 toolchain-versions test guards the sync.
 
-Renovate's vulnerability-alert PRs stay on (immediate, cooldown-exempt), beside
-GitHub's config-free Dependabot security updates; a rare duplicate PR is
-accepted.
+Renovate's vulnerability-alert PRs stay on, beside GitHub's config-free
+Dependabot security updates; a rare duplicate PR is accepted. These PRs bypass
+Renovate's own cooldown but not npm's: lock regeneration for a fix younger than
+`min-release-age` (`.npmrc`) fails with `ETARGET` until the release ages. For a
+fix that can't wait, bump manually under the per-invocation
+`NPM_CONFIG_MIN_RELEASE_AGE=0` environment override.
 
 ## Test suites
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -209,11 +209,13 @@ Renovate's vulnerability-alert PRs stay on, beside GitHub's config-free
 Dependabot security updates; a rare duplicate PR is accepted. These PRs bypass
 Renovate's own cooldown but not npm's: lock regeneration for a fix younger than
 `min-release-age` (`.npmrc`) fails with `ETARGET` until the release ages. For a
-fix that can't wait, bump manually under a per-invocation
-`NPM_CONFIG_MIN_RELEASE_AGE` environment override, for example:
+fix that can't wait, run the dependency's manual bump under a per-invocation
+`NPM_CONFIG_MIN_RELEASE_AGE` override, set no lower than the fix's age requires
+(the override relaxes the cooldown for everything the invocation resolves). For
+example, for a three-day-old hugo-extended release:
 
 ```sh
-NPM_CONFIG_MIN_RELEASE_AGE=3 npm run update:hugo
+NPM_CONFIG_MIN_RELEASE_AGE=3 npm run update:hugo -- X.Y.Z
 ```
 
 ## Test suites

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -206,13 +206,13 @@ only its base directory's (`docsy.dev/.nvmrc`), with no root fallback. The
 toolchain-versions test guards the sync.
 
 Renovate's vulnerability-alert PRs stay on, beside GitHub's config-free
-Dependabot security updates; a rare duplicate PR is accepted. These PRs bypass
-Renovate's own cooldown but not npm's: lock regeneration for a fix younger than
-`min-release-age` (`.npmrc`) fails with `ETARGET` until the release ages. For a
-fix that can't wait, run the dependency's manual bump under a per-invocation
-`NPM_CONFIG_MIN_RELEASE_AGE` override, set no lower than the fix's age requires
-(the override relaxes the cooldown for everything the invocation resolves). For
-example, for a three-day-old hugo-extended release:
+Dependabot security updates; a rare duplicate PR is accepted. Renovate's alert
+PRs bypass its own cooldown but not npm's: lock regeneration for a fix younger
+than `min-release-age` (`.npmrc`) fails with `ETARGET` until the release ages.
+For a fix that can't wait, run the dependency's manual bump under a
+per-invocation `NPM_CONFIG_MIN_RELEASE_AGE` override, set no lower than the
+fix's age requires (the override relaxes the cooldown for everything the
+invocation resolves). For example, for a three-day-old hugo-extended release:
 
 ```sh
 NPM_CONFIG_MIN_RELEASE_AGE=3 npm run update:hugo -- X.Y.Z

--- a/docsy.dev/netlify.toml
+++ b/docsy.dev/netlify.toml
@@ -13,7 +13,7 @@ HUGO_THEME = "repo/theme"
 # Constrain Netlify's automatic npm install to resolution only: no tree
 # writes, no bin linking; install:safe does the real install. Netlify offers
 # no way to skip the automatic install, so if NPM_FLAGS ever stops being
-# honored, it runs for real: strict-allow-scripts (.npmrc) still gates its
+# honored, it runs for real: ignore-scripts (.npmrc) still denies its
 # scripts, and the is:clean bracket in _netlify:prepare flags its tree writes.
 NPM_FLAGS = "--dry-run --ignore-scripts"
 

--- a/docsy.dev/netlify.toml
+++ b/docsy.dev/netlify.toml
@@ -14,7 +14,9 @@ HUGO_THEME = "repo/theme"
 # writes, no bin linking; install:safe does the real install. Netlify offers
 # no way to skip the automatic install, so if NPM_FLAGS ever stops being
 # honored, it runs for real: ignore-scripts (.npmrc) still denies its
-# scripts, and the is:clean bracket in _netlify:prepare flags its tree writes.
+# scripts, the is:clean bracket in _netlify:prepare flags its lock rewrites,
+# and install:safe's npm ci replaces node_modules wholesale, so git-invisible
+# residue there never reaches the build.
 NPM_FLAGS = "--dry-run --ignore-scripts"
 
 [context.production]

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "_serve": "npm run -C docsy.dev _serve --",
     "_spv:example": "echo TBC - npm run -s __spv docsy.dev/config/example/params.yaml --",
     "_spv": "npm run -s __spv docsy.dev/config/*/params.yaml --",
-    "_sync:theme-lock": "npm install --prefix theme --package-lock-only --ignore-scripts --min-release-age=\"${NPM_CONFIG_MIN_RELEASE_AGE:-${npm_config_min_release_age:-7}}\"",
+    "_sync:theme-lock": "npm install --prefix theme --package-lock-only --ignore-scripts",
     "_test:fix-clean": "npm run fix-for-test && npm run -s is:clean",
     "_test:full:common": "npm run _test:fix-clean && npm run test:repo",
     "_test:full:pre": "npm run _prepare && npm run -s is:clean",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "_serve": "npm run -C docsy.dev _serve --",
     "_spv:example": "echo TBC - npm run -s __spv docsy.dev/config/example/params.yaml --",
     "_spv": "npm run -s __spv docsy.dev/config/*/params.yaml --",
-    "_sync:theme-lock": "npm install --prefix theme --package-lock-only --ignore-scripts",
+    "_sync:theme-lock": "npm install --prefix theme --package-lock-only --ignore-scripts --min-release-age=7",
     "_test:fix-clean": "npm run fix-for-test && npm run -s is:clean",
     "_test:full:common": "npm run _test:fix-clean && npm run test:repo",
     "_test:full:pre": "npm run _prepare && npm run -s is:clean",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "_serve": "npm run -C docsy.dev _serve --",
     "_spv:example": "echo TBC - npm run -s __spv docsy.dev/config/example/params.yaml --",
     "_spv": "npm run -s __spv docsy.dev/config/*/params.yaml --",
-    "_sync:theme-lock": "npm install --prefix theme --package-lock-only --ignore-scripts --min-release-age=7",
+    "_sync:theme-lock": "npm install --prefix theme --package-lock-only --ignore-scripts --min-release-age=\"${NPM_CONFIG_MIN_RELEASE_AGE:-${npm_config_min_release_age:-7}}\"",
     "_test:fix-clean": "npm run fix-for-test && npm run -s is:clean",
     "_test:full:common": "npm run _test:fix-clean && npm run test:repo",
     "_test:full:pre": "npm run _prepare && npm run -s is:clean",

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -291,9 +291,19 @@ test('tarball install of @docsy/theme packed from this checkout', () => {
   rmSync(packDest, { recursive: true, force: true });
   mkdirSync(packDest, { recursive: true });
   progress('tarball: npm pack theme/…');
+  // Force the theme's own pack lifecycle (LICENSE copy, pack-stamp) so the
+  // packed tarball matches what publish.yaml ships, under any npm config
+  // (the repo .npmrc sets ignore-scripts=true). Safe: packing a local
+  // directory installs nothing, so only this repo's own lifecycle runs.
   const pack = run(
     'npm',
-    ['pack', '--pack-destination', packDest, '--silent'],
+    [
+      'pack',
+      '--ignore-scripts=false',
+      '--pack-destination',
+      packDest,
+      '--silent',
+    ],
     {
       cwd: path.join(repoRoot, 'theme'),
       shell: winShell,

--- a/tests/supply-chain-audit.test.mjs
+++ b/tests/supply-chain-audit.test.mjs
@@ -222,12 +222,14 @@ test('locks and manifests: install scripts stay inventoried and version-pinned',
   // a later line, and any unpinned addition (node-options=--require …,
   // ignore-scripts=false) changes install behavior: pin the full
   // assignment set. Each setting's rationale lives beside it in .npmrc.
-  assert.deepEqual(
+  const npmrcAssignments = (relPath) =>
     fs
-      .readFileSync(path.join(repoRoot, '.npmrc'), 'utf8')
+      .readFileSync(path.join(repoRoot, relPath), 'utf8')
       .split('\n')
       .map((line) => line.trim())
-      .filter((line) => line !== '' && !line.startsWith('#')),
+      .filter((line) => line !== '' && !line.startsWith('#'));
+  assert.deepEqual(
+    npmrcAssignments('.npmrc'),
     [
       'min-release-age=7',
       'strict-allow-scripts=true',
@@ -238,15 +240,22 @@ test('locks and manifests: install scripts stay inventoried and version-pinned',
     ],
     '.npmrc carries exactly the reviewed npm settings',
   );
-  // npm resolves workspace config at the root, but --prefix/-C runs read
-  // the target directory's .npmrc as project config: their absence keeps
-  // the root file the one audited home.
-  for (const dir of ['docsy.dev', 'theme']) {
-    assert.ok(
-      !fs.existsSync(path.join(repoRoot, dir, '.npmrc')),
-      `${dir} defers .npmrc to the workspace root`,
-    );
-  }
+  // npm resolves workspace config at the root, but --prefix/-C runs
+  // suppress the workspace walk-up and read only the target directory's
+  // .npmrc: theme (the prefix-install target: install:theme-deps,
+  // _sync:theme-lock) mirrors the root file so those runs keep the same
+  // posture (the .nvmrc-pair pattern, toolchain-versions.test.mjs), while
+  // docsy.dev (no prefix installs) stays absent so the root file remains
+  // its one home.
+  assert.deepEqual(
+    npmrcAssignments('theme/.npmrc'),
+    npmrcAssignments('.npmrc'),
+    'theme/.npmrc mirrors the root assignment set',
+  );
+  assert.ok(
+    !fs.existsSync(path.join(repoRoot, 'docsy.dev/.npmrc')),
+    'docsy.dev defers .npmrc to the workspace root',
+  );
   // Close the lockfile set: npm prefers npm-shrinkwrap.json over
   // package-lock.json at an install root, and a lock added anywhere else
   // (docsy.dev, a new directory) would define an installable tree outside
@@ -397,12 +406,12 @@ test('scripts: install and approval entries keep their reviewed forms', () => {
 });
 
 test('workspaces: the reviewed member set, bound identities, no shadow config', () => {
-  // npm resolves config and the root lock at the workspace root, so a
-  // member carrying its own .npmrc would be dead weight that reads as a
-  // control; and a new member widens the audited install surface, so the
-  // list itself is pinned. theme/package-lock.json is the one sanctioned
-  // member lock: install:theme-deps consumes it as a standalone prefix
-  // install (this file audits it in `locks`).
+  // npm resolves config and the root lock at the workspace root; member
+  // .npmrc files are governed by the mirror-or-absent assertions in the
+  // install-scripts test above. A new member widens the audited install
+  // surface, so the list itself is pinned. theme/package-lock.json is the
+  // one sanctioned member lock: install:theme-deps consumes it as a
+  // standalone prefix install (this file audits it in `locks`).
   const reviewedWorkspaces = {
     'docsy.dev': '@docsy/docsy.dev',
     theme: '@docsy/theme',

--- a/tests/supply-chain-audit.test.mjs
+++ b/tests/supply-chain-audit.test.mjs
@@ -222,14 +222,12 @@ test('locks and manifests: install scripts stay inventoried and version-pinned',
   // a later line, and any unpinned addition (node-options=--require …,
   // ignore-scripts=false) changes install behavior: pin the full
   // assignment set. Each setting's rationale lives beside it in .npmrc.
-  const npmrcAssignments = (relPath) =>
+  assert.deepEqual(
     fs
-      .readFileSync(path.join(repoRoot, relPath), 'utf8')
+      .readFileSync(path.join(repoRoot, '.npmrc'), 'utf8')
       .split('\n')
       .map((line) => line.trim())
-      .filter((line) => line !== '' && !line.startsWith('#'));
-  assert.deepEqual(
-    npmrcAssignments('.npmrc'),
+      .filter((line) => line !== '' && !line.startsWith('#')),
     [
       'min-release-age=7',
       'strict-allow-scripts=true',
@@ -243,14 +241,15 @@ test('locks and manifests: install scripts stay inventoried and version-pinned',
   // npm resolves workspace config at the root, but --prefix/-C runs
   // suppress the workspace walk-up and read only the target directory's
   // .npmrc: theme (the prefix-install target: install:theme-deps,
-  // _sync:theme-lock) mirrors the root file so those runs keep the same
-  // posture (the .nvmrc-pair pattern, toolchain-versions.test.mjs), while
-  // docsy.dev (no prefix installs) stays absent so the root file remains
-  // its one home.
-  assert.deepEqual(
-    npmrcAssignments('theme/.npmrc'),
-    npmrcAssignments('.npmrc'),
-    'theme/.npmrc mirrors the root assignment set',
+  // _sync:theme-lock) carries a byte-identical mirror of the root file so
+  // those runs keep the same posture (the .nvmrc-pair pattern,
+  // toolchain-versions.test.mjs), while docsy.dev (no prefix installs)
+  // stays absent so the root file remains its one home. On a mismatch:
+  // cp .npmrc theme/.npmrc.
+  assert.equal(
+    fs.readFileSync(path.join(repoRoot, 'theme/.npmrc'), 'utf8'),
+    fs.readFileSync(path.join(repoRoot, '.npmrc'), 'utf8'),
+    'theme/.npmrc is a byte-identical mirror of the root .npmrc',
   );
   assert.ok(
     !fs.existsSync(path.join(repoRoot, 'docsy.dev/.npmrc')),

--- a/tests/supply-chain-audit.test.mjs
+++ b/tests/supply-chain-audit.test.mjs
@@ -225,8 +225,10 @@ test('locks and manifests: install scripts stay inventoried and version-pinned',
       .map((line) => line.trim())
       .filter((line) => line !== '' && !line.startsWith('#')),
     [
-      'engine-strict=true',
+      'min-release-age=7',
       'strict-allow-scripts=true',
+      'engine-strict=true',
+      'ignore-scripts=true',
       'script-shell=bash',
       '@docsy:registry=https://registry.npmjs.org/',
     ],

--- a/tests/supply-chain-audit.test.mjs
+++ b/tests/supply-chain-audit.test.mjs
@@ -192,8 +192,12 @@ test('locks and manifests: install scripts stay inventoried and version-pinned',
   );
 
   // Allow entries are version-pinned so a bump's new (unreviewed) script
-  // fails npm ci under strict-allow-scripts; the assertion names the fix in
-  // the bump PR itself (#2712). Deny entries are unversioned: the answer is
+  // fails the scripts-enabled installs (install:safe's rebuild step,
+  // approve:hugo) under strict-allow-scripts; the assertion names the fix
+  // in the bump PR itself (#2712). Ordinary installs skip all scripts
+  // (ignore-scripts, .npmrc) without consulting the allowlist, and a new
+  // script-bearing package fails the inventory assertion above in CI.
+  // Deny entries are unversioned: the answer is
   // false for every version, so a pin would only add bump churn.
   // puppeteer's postinstall (browser download) is deliberately denied:
   // the visual suite installs its browser on demand (install:browser).

--- a/theme/.npmrc
+++ b/theme/.npmrc
@@ -1,0 +1,12 @@
+# Mirror of the root .npmrc (assignment-for-assignment; the audit enforces
+# the sync). Two homes by npm constraint: --prefix/-C runs suppress the
+# workspace walk-up and read only this directory's .npmrc, so without the
+# mirror the theme-lock resolve and theme-prefix installs run unconfigured.
+# Rationale for the settings themselves: the root file.
+
+min-release-age=7
+strict-allow-scripts=true
+engine-strict=true
+ignore-scripts=true
+script-shell=bash
+@docsy:registry=https://registry.npmjs.org/

--- a/theme/.npmrc
+++ b/theme/.npmrc
@@ -1,10 +1,11 @@
 # npm supply-chain controls; shared rationale (cross-repo one-home):
 # https://opentelemetry.io/site/design/supply-chain-security/
 #
-# This file has a byte-identical mirror at theme/.npmrc, because --prefix/-C
-# runs read only the target directory's .npmrc (they suppress the workspace
-# walk-up that normally resolves config at the root). Edit the two files
-# together; the supply-chain audit enforces the sync.
+# The root .npmrc and theme/.npmrc are byte-identical mirrors (the audit
+# enforces the sync): --prefix/-C runs read only the target directory's
+# .npmrc (they suppress the workspace walk-up that normally resolves config
+# at the root), so theme-prefix installs need their own copy. Edit the two
+# files together.
 
 min-release-age=7
 strict-allow-scripts=true

--- a/theme/.npmrc
+++ b/theme/.npmrc
@@ -1,12 +1,26 @@
-# Mirror of the root .npmrc (assignment-for-assignment; the audit enforces
-# the sync). Two homes by npm constraint: --prefix/-C runs suppress the
-# workspace walk-up and read only this directory's .npmrc, so without the
-# mirror the theme-lock resolve and theme-prefix installs run unconfigured.
-# Rationale for the settings themselves: the root file.
+# npm supply-chain controls; shared rationale (cross-repo one-home):
+# https://opentelemetry.io/site/design/supply-chain-security/
+#
+# This file has a byte-identical mirror at theme/.npmrc, because --prefix/-C
+# runs read only the target directory's .npmrc (they suppress the workspace
+# walk-up that normally resolves config at the root). Edit the two files
+# together; the supply-chain audit enforces the sync.
 
 min-release-age=7
 strict-allow-scripts=true
 engine-strict=true
+
+# Execution default-deny for every install (CI, Netlify, contributors).
+# Reviewed exceptions re-enable scripts at their call sites: the theme's own
+# pack lifecycle (publish.yaml, scripts/npm-pack.test.mjs, tests/smoke.mjs)
+# and hugo-extended's installer (install:safe).
 ignore-scripts=true
+
+# One script interpreter on every platform (Windows npm defaults to cmd.exe,
+# whose quoting silently diverges from sh); resolved at the workspace root,
+# covering workspace runs.
 script-shell=bash
+
+# Outranks a user-level @docsy:registry mapping (which would outrank even
+# --registry) for manual publish/dist-tag/view commands run in-repo.
 @docsy:registry=https://registry.npmjs.org/


### PR DESCRIPTION
- **Closes the last script-enabled install path**, contributor installs: CI, Netlify, and `install:safe` already install script-less; the theme's own pack lifecycle stays explicitly re-enabled at both pack call sites, so publish and the pack contract are unaffected.
- **Adds the npm-side release cooldown**, matching Renovate's: a vulnerability-alert lock bump inside the window now fails until the release ages; maintainer notes document the deliberate env override for fixes that can't wait.
- **Repoints `.npmrc` rationale at the [otel.io supply-chain design page](https://opentelemetry.io/site/design/supply-chain-security/)**, the cross-repo home for these controls; only docsy-specific notes stay inline.
