### PR TITLE
Release 0.17.0 preparation

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -271,6 +271,7 @@ https://github.com/google/docsy/commits/main,200,1782563369
 https://github.com/google/docsy/compare/v0.15.0...main,200,1782563370
 https://github.com/google/docsy/compare/v0.15.0...v0.16.0,200,1785360538
 https://github.com/google/docsy/compare/v0.16.0...main,200,1787153684
+https://github.com/google/docsy/compare/v0.16.0...v0.17.0,206,1788114730
 https://github.com/google/docsy/compare/v0.8.0...v0.9.0,200,1782498238
 https://github.com/google/docsy/discussions,200,1782563367
 https://github.com/google/docsy/discussions/1308,200,1782498228

--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -11,8 +11,8 @@
 #   status: archived # Then fetch include
 
 tdVersion:
-  latest: &tdLatestVers v0.16.0
-  dev: &tdDevVers v0.16.1-dev
+  latest: &tdLatestVers v0.17.0
+  dev: &tdDevVers v0.17.1-dev
   buildId: ''
 
 version: *tdDevVers

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -1,8 +1,8 @@
 # cSpell:ignore pagelinks
 
 tdVersion:
-  latest: &tdLatestVers v0.16.0
-  dev: &tdDevVers v0.16.1-dev
+  latest: &tdLatestVers v0.17.0
+  dev: &tdDevVers v0.17.1-dev
   buildId: ''
 
 version: &tdDocRootedVers Doc-rooted of Next

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -1,8 +1,8 @@
 # cSpell:ignore pagelinks
 
 tdVersion:
-  latest: &tdLatestVers v0.16.0
-  dev: &tdDevVers v0.16.1-dev
+  latest: &tdLatestVers v0.17.0
+  dev: &tdDevVers v0.17.1-dev
   buildId: ''
 
 version: *tdLatestVers

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -345,13 +345,14 @@ default favicon files.
 {{% _param BREAKING %}} **Applies if** your site keeps its own icon files under
 `static/favicons/` and does not override `favicons.html`.
 
-- Move [supported favicon files][Add your favicons] to `static/`.
+- Move [supported favicon files][Add your favicons] directly under `static/`.
 
 **Applies if** your site overrides `layouts/_partials/favicons.html`.
 
 - Keep your override if you need custom link tags, non-default filenames, a web
   app manifest, or additional platform icons.
-- Otherwise, delete the override and follow [Add your favicons][].
+- Otherwise, delete the override and follow [Add your favicons][]. Remember to
+  move supported favicon files directly under `static/`.
 
 If you have a source SVG and ImageMagick installed, you can generate the common
 raster files with the new helper. For an npm package install of Docsy:
@@ -512,13 +513,11 @@ About this release:
 <!-- prettier-ignore-start -->
 [#2615]: https://github.com/google/docsy/issues/2615
 [#2691]: https://github.com/google/docsy/issues/2691
-[0.15.0]: https://github.com/google/docsy/releases/v0.15.0
-[0.16.0]: https://github.com/google/docsy/releases/v0.16.0
-[0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
-[0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
-[hugo-supported-version]:
-  <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoSupportedVersion %}}>
 [`@docsy/theme`]: https://www.npmjs.com/package/@docsy/theme
+[0.15.0]: https://github.com/google/docsy/releases/v0.15.0
+[0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
+[0.16.0]: https://github.com/google/docsy/releases/v0.16.0
+[0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
 [check]: /docs/update/#check
 [chrome]: /docs/deployment/chrome/
@@ -528,15 +527,16 @@ About this release:
 [docsy-example]: https://github.com/google/docsy-example
 [experimental]: /project/about/changelog/#experimental
 [hugo-language-apis]: hugo-0.158.0+/#language-apis
-[hugo-upgrade]: hugo-0.158.0+/
-[hugo-upgrade-install]: hugo-0.158.0+/#upgrade
 [hugo-npm-pack]: https://gohugo.io/hugo-modules/nodejs-dependencies/
+[hugo-supported-version]: <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoSupportedVersion %}}>
+[hugo-upgrade-install]: hugo-0.158.0+/#upgrade
+[hugo-upgrade]: hugo-0.158.0+/
 [Install PostCSS]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss
 [Lychee]: https://github.com/lycheeverse/lychee
 [more]: #npm-deps
 [official support policy]: /project/about/changelog/#official-support
-[Other installation options]: /docs/get-started/other-options/
 [order of steps]: /docs/update/#update-order
+[Other installation options]: /docs/get-started/other-options/
 [overrides]: /docs/update/#update-overrides
 [Update Docsy]: /docs/update/
 [update-hugo]: /docs/update/#update-hugo

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -2,7 +2,7 @@
 title: Release 0.16.0 report and upgrade guide
 linkTitle: Release 0.16.0
 date: 2026-07-29
-lastmod: 2026-07-29
+lastmod: 2026-08-30
 description: >-
   Docsy is now on npm as @docsy/theme. This release also moves the theme into
   theme/, raises the Hugo minimum, and drops its default favicons in favor of
@@ -341,6 +341,13 @@ default favicon files.
 - Add your own favicon files under `static/`.
 - Build your site and inspect the generated page `<head>` to confirm the icon
   links you expect are present.
+
+{{% _param BREAKING %}} **Applies if** your site keeps its own icon files under
+`static/favicons/`.
+
+- Move the conventionally named files to `static/`: discovery only links icons
+  found directly under `static/`, so files left in `static/favicons/` silently
+  stop being linked.
 
 **Applies if** your site overrides `layouts/_partials/favicons.html`.
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -351,7 +351,7 @@ default favicon files.
 
 - Keep your override if you need custom link tags, non-default filenames, a web
   app manifest, or additional platform icons.
-- Otherwise, consider deleting the override and following [Add your favicons][].
+- Otherwise, delete the override and follow [Add your favicons][].
 
 If you have a source SVG and ImageMagick installed, you can generate the common
 raster files with the new helper. For an npm package install of Docsy:

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -343,16 +343,15 @@ default favicon files.
   links you expect are present.
 
 {{% _param BREAKING %}} **Applies if** your site keeps its own icon files under
-`static/favicons/`.
+`static/favicons/` and does not override `favicons.html`.
 
-- Move the conventionally named files to `static/`.
+- Move [supported favicon files][] to `static/`.
 
 **Applies if** your site overrides `layouts/_partials/favicons.html`.
 
 - Keep your override if you need custom link tags, non-default filenames, a web
   app manifest, or additional platform icons.
-- Otherwise, consider deleting the override and using the default discovery
-  behavior.
+- Otherwise, consider deleting the override and following [Add your favicons][].
 
 If you have a source SVG and ImageMagick installed, you can generate the common
 raster files with the new helper. For an npm package install of Docsy:
@@ -521,6 +520,7 @@ About this release:
   <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoSupportedVersion %}}>
 [`@docsy/theme`]: https://www.npmjs.com/package/@docsy/theme
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
+[supported favicon files]: /docs/content/iconsimages/#add-your-favicons
 [check]: /docs/update/#check
 [chrome]: /docs/deployment/chrome/
 [CL@0.16.0]: /project/about/changelog/#v0.16.0

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -345,7 +345,7 @@ default favicon files.
 {{% _param BREAKING %}} **Applies if** your site keeps its own icon files under
 `static/favicons/` and does not override `favicons.html`.
 
-- Move [supported favicon files][] to `static/`.
+- Move [supported favicon files][Add your favicons] to `static/`.
 
 **Applies if** your site overrides `layouts/_partials/favicons.html`.
 
@@ -520,7 +520,6 @@ About this release:
   <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoSupportedVersion %}}>
 [`@docsy/theme`]: https://www.npmjs.com/package/@docsy/theme
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
-[supported favicon files]: /docs/content/iconsimages/#add-your-favicons
 [check]: /docs/update/#check
 [chrome]: /docs/deployment/chrome/
 [CL@0.16.0]: /project/about/changelog/#v0.16.0

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -345,9 +345,7 @@ default favicon files.
 {{% _param BREAKING %}} **Applies if** your site keeps its own icon files under
 `static/favicons/`.
 
-- Move the conventionally named files to `static/`: discovery only links icons
-  found directly under `static/`, so files left in `static/favicons/` silently
-  stop being linked.
+- Move the conventionally named files to `static/`.
 
 **Applies if** your site overrides `layouts/_partials/favicons.html`.
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -308,6 +308,10 @@ npm (development and testing only).
   clean install or update (wire it into your setup steps, since a fresh `npm ci`
   discards the result), or switch to the [`@docsy/theme`][] registry package,
   which needs no install step.
+- If your setup ran `npm rebuild docsy` to trigger the old install hook, replace
+  it with `npm run install:theme-deps --prefix node_modules/docsy`: after this
+  release the rebuild silently does nothing, and the missing theme dependencies
+  surface only on your next fresh install.
 
 Hugo-module and `@docsy/theme` registry installs are unaffected.
 
@@ -412,6 +416,9 @@ that use those overrides.
   {{ partial "llms-directive.html" . -}}
   ```
 
+  The call is safe to add unconditionally: on pages of sites that don't enable
+  `llms.txt`, the partial renders nothing.
+
 ## Other notable changes
 
 - **Footer copyright**: a same-year range now renders as the single year
@@ -470,7 +477,8 @@ section. {{< /comment >}}
 - Remember to [review your theme overrides][overrides]: this release reworks
   theme files that sites commonly override, including `head-css.html`,
   `breadcrumb.html`, and the `baseof` templates (see the
-  [agent directive](#llms-directive-actions)).
+  [agent directive](#llms-directive-actions)). If your update crosses 0.16, add
+  `favicons.html` to that list.
 
 [^vers-note]:
     Matches `docsy.dev`'s tested Hugo pin and the theme's declared minimum Hugo

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -308,10 +308,8 @@ npm (development and testing only).
   clean install or update (wire it into your setup steps, since a fresh `npm ci`
   discards the result), or switch to the [`@docsy/theme`][] registry package,
   which needs no install step.
-- If your setup ran `npm rebuild docsy` to trigger the old install hook, replace
-  it with `npm run install:theme-deps --prefix node_modules/docsy`: after this
-  release the rebuild silently does nothing, and the missing theme dependencies
-  surface only on your next fresh install.
+- Replace any `npm rebuild docsy` wiring that triggered the old install hook:
+  after this release, the rebuild silently does nothing.
 
 Hugo-module and `@docsy/theme` registry installs are unaffected.
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -12,8 +12,7 @@ author: >-
 body_class: release-highlights
 tags: [release, upgrade]
 params:
-  # Frozen at publication; until tag time, the release-prep refresh keeps
-  # these aligned with the repo pins (package.json, theme/hugo.yaml).
+  # Frozen at publication (repo pins at release time).
   hugoSupportedVersion: 0.164.0
   dartSassMinVersion: 1.95.0
   sassEmbeddedVersion: 1.102.0
@@ -411,9 +410,6 @@ that use those overrides.
   ```go-html-template
   {{ partial "llms-directive.html" . -}}
   ```
-
-  The call is safe to add unconditionally: on pages of sites that don't enable
-  `llms.txt`, the partial renders nothing.
 
 ## Other notable changes
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -308,8 +308,6 @@ npm (development and testing only).
   clean install or update (wire it into your setup steps, since a fresh `npm ci`
   discards the result), or switch to the [`@docsy/theme`][] registry package,
   which needs no install step.
-- Replace any `npm rebuild docsy` wiring that triggered the old install hook:
-  after this release, the rebuild silently does nothing.
 
 Hugo-module and `@docsy/theme` registry installs are unaffected.
 

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -3,9 +3,9 @@ title: Release 0.17.0 report and upgrade guide
 linkTitle: Release 0.17.0
 date: 2026-08-30
 description: >-
-  Docsy modernizes foundations: Dart Sass, Font Awesome 7, and pinned script
-  defaults. Breadcrumbs get semantic classes! Bundled locales reach full
-  UI-string coverage, and llms.txt sites gain agent discovery.
+  Docsy modernizes and strengthens its foundations: Dart Sass, Font Awesome 7,
+  and pinned script defaults. Breadcrumbs get semantic classes, bundled locales
+  reach full UI-string coverage, and llms.txt sites gain agent discovery.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -1,8 +1,7 @@
 ---
 title: Release 0.17.0 report and upgrade guide
 linkTitle: Release 0.17.0
-date: 2026-08-19
-draft: true
+date: 2026-08-30
 description: >-
   Docsy modernizes foundations: Dart Sass, Font Awesome 7, and pinned script
   defaults. Breadcrumbs get semantic classes! Bundled locales reach full
@@ -568,8 +567,8 @@ About this release:
 [lightdark]: /docs/content/lookandfeel/#lightdark-mode-menu
 [fa-a11y]: https://docs.fontawesome.com/web/dig-deeper/accessibility
 [fa-sass-upgrade]: https://docs.fontawesome.com/upgrade/scss
-[CL@0.17.0]: /project/about/changelog/#next
-[compare-0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main
+[CL@0.17.0]: /project/about/changelog/#v0.17.0
+[compare-0.16.0]: https://github.com/google/docsy/compare/v0.16.0...v0.17.0
 [Dart Sass]: https://sass-lang.com/dart-sass/
 [hugo-libsass-depr]: https://github.com/gohugoio/hugo/releases/tag/v0.153.0
 [hugo-no-bundle]: https://github.com/gohugoio/hugo/issues/8299

--- a/docsy.dev/content/en/blog/2026/0.17.0.md
+++ b/docsy.dev/content/en/blog/2026/0.17.0.md
@@ -473,8 +473,7 @@ section. {{< /comment >}}
 - Remember to [review your theme overrides][overrides]: this release reworks
   theme files that sites commonly override, including `head-css.html`,
   `breadcrumb.html`, and the `baseof` templates (see the
-  [agent directive](#llms-directive-actions)). If your update crosses 0.16, add
-  `favicons.html` to that list.
+  [agent directive](#llms-directive-actions)).
 
 [^vers-note]:
     Matches `docsy.dev`'s tested Hugo pin and the theme's declared minimum Hugo

--- a/docsy.dev/content/en/docs/content/iconsimages.md
+++ b/docsy.dev/content/en/docs/content/iconsimages.md
@@ -79,9 +79,8 @@ whichever of these files it finds, in this order:
 If you have any square-size variants listed above, Docsy adds them in ascending
 size order.
 
-Docsy discovers these files only at the top level of `static/`: files in
-subdirectories, such as the `static/favicons/` location that pre-0.16 Docsy
-sites used, aren't linked.
+Docsy discovers these files _only_ at the **top level** of `static/`, not in
+subdirectories.
 
 [^ico-link]:
     The `.ico` link carries no `sizes`: the file is self-describing (browsers

--- a/docsy.dev/content/en/docs/content/iconsimages.md
+++ b/docsy.dev/content/en/docs/content/iconsimages.md
@@ -79,6 +79,10 @@ whichever of these files it finds, in this order:
 If you have any square-size variants listed above, Docsy adds them in ascending
 size order.
 
+Docsy discovers these files only at the top level of `static/`: files in
+subdirectories, such as the `static/favicons/` location that pre-0.16 Docsy
+sites used, aren't linked.
+
 [^ico-link]:
     The `.ico` link carries no `sizes`: the file is self-describing (browsers
     read the frame sizes it contains), so declaring sizes here would only risk

--- a/docsy.dev/content/en/docs/update/_index.md
+++ b/docsy.dev/content/en/docs/update/_index.md
@@ -23,8 +23,8 @@ actions, see the [upgrade blog posts](/tags/upgrade/).
 
 Perform the update steps in the order given by this page:
 
-1. [Node.js](#update-node) and [Hugo](#update-hugo), when your target release
-   calls for it
+1. [Node.js](#update-node), [Hugo](#update-hugo), and any other build
+   prerequisite that your target release calls for
 2. [The theme](#update-theme), by install mode
 3. [Review your theme overrides](#update-overrides)
 4. [Check your site](#check)

--- a/docsy.dev/content/en/docs/update/_index.md
+++ b/docsy.dev/content/en/docs/update/_index.md
@@ -15,9 +15,14 @@ actions, see the [upgrade blog posts](/tags/upgrade/).
 - **Backup or safeguard your project's current state**: for example, work from a
   Git branch, merging only after [checking your site](#check), or back up your
   project files first. Rolling back is then a simple restore.
-- **Updating from Docsy [0.15](/blog/2026/0.15.0/) or earlier?** First apply the
-  theme-path config changes, and only those, from the 0.16.0 post's [theme
-  folder actions][tfa]; this page's steps cover the rest.
+- **Updating across more than one release?** Apply each release's
+  [upgrade post](/tags/upgrade/) in turn, oldest first: each post assumes you
+  are coming from the release just before it.
+- **Updating from Docsy [0.15](/blog/2026/0.15.0/) or earlier?** First apply,
+  from the 0.16.0 post, the theme-path config changes ([theme folder
+  actions][tfa]) and, if your site keeps its own icon files under
+  `static/favicons/`, the favicon move ([favicon actions][ffa]); this page's
+  steps cover the rest.
 - **Updating from Docsy [0.16](/blog/2026/0.16.0/) or earlier?** Before updating
   the theme, provide the [Dart Sass][] compiler in every environment that builds
   your site; see the 0.17.0 post's
@@ -124,5 +129,6 @@ Also perform any release-specific checks listed in the release's
 [hugo-override]: https://gohugo.io/getting-started/directory-structure/#theme-skeleton
 [lookandfeel]: /docs/content/lookandfeel/#project-style-files
 [nvm]: https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
+[ffa]: /blog/2026/0.16.0/#favicons-actions
 [tfa]: /blog/2026/0.16.0/#theme-folder-actions
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/update/_index.md
+++ b/docsy.dev/content/en/docs/update/_index.md
@@ -18,17 +18,6 @@ actions, see the [upgrade blog posts](/tags/upgrade/).
 - **Updating across more than one release?** Apply each release's
   [upgrade post](/tags/upgrade/) in turn, oldest first: each post assumes you
   are coming from the release just before it.
-- **Updating from Docsy [0.15](/blog/2026/0.15.0/) or earlier?** First apply the
-  0.16.0 post's [theme folder][tfa] and [favicon][ffa] actions; this page's
-  steps cover the rest.
-- **Updating from Docsy [0.16](/blog/2026/0.16.0/) or earlier?** Before updating
-  the theme, provide the [Dart Sass][] compiler in every environment that builds
-  your site; see the 0.17.0 post's
-  [Dart Sass actions](/blog/2026/0.17.0/#dart-sass-actions).
-
-<!-- TODO(0.18-ish): drop the 0.15 crossing bullet above once 0.15-to-0.16
-     upgrade traffic fades; release history lives in the blog posts.
-     (2026-07-28) -->
 
 ## Order of steps {#update-order}
 
@@ -122,11 +111,8 @@ Also perform any release-specific checks listed in the release's
 
 <!-- prettier-ignore-start -->
 [Heading self-links]: /docs/content/navigation/#heading-self-links
-[Dart Sass]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass
 [hugo-extended]: /docs/get-started/docsy-as-module/installation-prerequisites/#as-an-npm-module
 [hugo-override]: https://gohugo.io/getting-started/directory-structure/#theme-skeleton
 [lookandfeel]: /docs/content/lookandfeel/#project-style-files
 [nvm]: https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
-[ffa]: /blog/2026/0.16.0/#favicons-actions
-[tfa]: /blog/2026/0.16.0/#theme-folder-actions
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/update/_index.md
+++ b/docsy.dev/content/en/docs/update/_index.md
@@ -17,7 +17,7 @@ actions, see the [upgrade blog posts](/tags/upgrade/).
   project files first. Rolling back is then a simple restore.
 - **Updating across more than one release?** Apply each release's
   [upgrade post](/tags/upgrade/) in turn, oldest first: each post assumes you
-  are coming from the release just before it.
+  are coming from the release just before it, unless stated otherwise.
 
 ## Order of steps {#update-order}
 

--- a/docsy.dev/content/en/docs/update/_index.md
+++ b/docsy.dev/content/en/docs/update/_index.md
@@ -18,10 +18,8 @@ actions, see the [upgrade blog posts](/tags/upgrade/).
 - **Updating across more than one release?** Apply each release's
   [upgrade post](/tags/upgrade/) in turn, oldest first: each post assumes you
   are coming from the release just before it.
-- **Updating from Docsy [0.15](/blog/2026/0.15.0/) or earlier?** First apply,
-  from the 0.16.0 post, the theme-path config changes ([theme folder
-  actions][tfa]) and, if your site keeps its own icon files under
-  `static/favicons/`, the favicon move ([favicon actions][ffa]); this page's
+- **Updating from Docsy [0.15](/blog/2026/0.15.0/) or earlier?** First apply the
+  0.16.0 post's [theme folder][tfa] and [favicon][ffa] actions; this page's
   steps cover the rest.
 - **Updating from Docsy [0.16](/blog/2026/0.16.0/) or earlier?** Before updating
   the theme, provide the [Dart Sass][] compiler in every environment that builds

--- a/docsy.dev/content/en/docs/update/npm-package.md
+++ b/docsy.dev/content/en/docs/update/npm-package.md
@@ -40,7 +40,9 @@ npm ls @docsy/theme --depth=0
 
 If your site installs Docsy [from GitHub with npm][github-npm] (a mode reserved
 for Docsy development and testing), update by re-running the install command
-with the desired [revision selector][github-npm].
+with the desired [revision selector][github-npm]. After the update, rerun the
+theme-dependencies install command:
+`npm run install:theme-deps --prefix node_modules/docsy`.
 
 After updating the theme, continue with the remaining update steps, starting
 with [Review your theme overrides](/docs/update/#update-overrides).

--- a/docsy.dev/content/en/docs/update/npm-package.md
+++ b/docsy.dev/content/en/docs/update/npm-package.md
@@ -40,9 +40,8 @@ npm ls @docsy/theme --depth=0
 
 If your site installs Docsy [from GitHub with npm][github-npm] (a mode reserved
 for Docsy development and testing), update by re-running the install command
-with the desired [revision selector][github-npm]. After the update, rerun the
-theme-dependencies install command:
-`npm run install:theme-deps --prefix node_modules/docsy`.
+with the desired [revision selector][github-npm], then rerun the
+`install:theme-deps` command as shown there.
 
 After updating the theme, continue with the remaining update steps, starting
 with [Review your theme overrides](/docs/update/#update-overrides).

--- a/docsy.dev/content/en/docs/update/npm-package.md
+++ b/docsy.dev/content/en/docs/update/npm-package.md
@@ -40,7 +40,7 @@ npm ls @docsy/theme --depth=0
 
 If your site installs Docsy [from GitHub with npm][github-npm] (a mode reserved
 for Docsy development and testing), update by re-running the install command
-with the desired [revision selector][github-npm], then rerun the
+with the desired [revision selector][github-npm], then re-run the
 `install:theme-deps` command as shown there.
 
 After updating the theme, continue with the remaining update steps, starting

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -141,9 +141,7 @@ functionality, depending on scope. Prefer narrow, focused PRs where possible.
 
 </details>
 
-## v0.17.0 - UNRELEASED {#next}
-
-> **UNRELEASED: this planned version is still under development**
+## v0.17.0 {#v0.17.0}
 
 For an introduction to this release, see the [0.17.0 release report][]. For the
 full list of changes, see the [0.17.0][] release page or the [git history since
@@ -248,7 +246,7 @@ full list of changes, see the [0.17.0][] release page or the [git history since
 [0.17.0-blog-script-pins]: /blog/2026/0.17.0/#script-dep-pins
 [0.17.0]: https://github.com/google/docsy/releases/tag/v0.17.0
 [footer copyright docs]: /docs/content/lookandfeel/#footer-copyright
-[git history since 0.16.0]: https://github.com/google/docsy/compare/v0.16.0...main
+[git history since 0.16.0]: https://github.com/google/docsy/compare/v0.16.0...v0.17.0
 [hugo-version-notes]: /project/about/maintainer-notes/#official-hugo-version
 [Install Dart Sass]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass
 [script-versions-notes]: /project/about/maintainer-notes/#script-versions

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -782,15 +782,21 @@ before any further changes are merged into the `main` branch:
    - **Fix the new release URL**, which ends with `latest?FIXME=...`, so that it
      refers to the actual release, now that it exists.
 
-4. **Submit a PR with your changes**, using a title like:
+4. **Create a draft release report post** for the next release
+   (`docsy.dev/content/en/blog/YYYY/X.Y.Z.md`, `draft: true`), modeled on the
+   shipped release's post. Like the changelog's new entry, the draft gives
+   next-cycle changes a single home to land on as release prep works through
+   them.
+
+5. **Submit a PR with your changes**, using a title like:
 
    ```text
    Set version to {{% param version %}}
    ```
 
-5. **Get PR approved and merged**.
+6. **Get PR approved and merged**.
 
-6. **Validate the published release from [docsy-starter][]** (npm package mode),
+7. **Validate the published release from [docsy-starter][]** (npm package mode),
    per the [consumer-site test procedure](#consumer-site-test), and follow with
    the starter's own Docsy-update PR. Post-tag; doesn't block `main`.
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -27,9 +27,10 @@ restating them:
   link an open tracker only where it adds follow-up context. Upgrades are a
   chore, so keep posts maximally actionable yet lean: the release summary reads
   like a selective table of contents (a link per section with a clause of
-  guiding glue) and each fact appears in one section, its home.
-  Maintainer-facing changes are summarized in a **For maintainers** section at
-  the end of the documented changes.
+  guiding glue) and each fact appears in one section, its home. Each post
+  targets upgraders coming from the release just before it; a post that assumes
+  otherwise says so. Maintainer-facing changes are summarized in a **For
+  maintainers** section at the end of the documented changes.
 - **Site docs** (`docs/`): Docsy _as it is now_. Minimal historical references
   or links to issues and PRs.
 - **[Release notes][] and [milestones][]**: exhaustive records. Generated
@@ -294,6 +295,10 @@ site build doesn't need it.
   the updated `.lycheecache`.
 - **Inspect or prune** with `npm run refcache` (`-- -s` for a summary,
   `-- -p 10%` to drop the oldest tenth).
+- **Seed** a URL that only goes live later (such as release-tag links during
+  release prep) by adding a row with placeholder status `206`. Redeem the seed
+  once the URL is live: delete the row and re-run the check. The release process
+  tracks redemption as a post-deploy step.
 
 Both scripts work from the repo root or `docsy.dev/`.
 
@@ -785,8 +790,7 @@ before any further changes are merged into the `main` branch:
 4. **Create a draft release report post** for the next release
    (`docsy.dev/content/en/blog/YYYY/X.Y.Z.md`, `draft: true`), modeled on the
    shipped release's post. Like the changelog's new entry, the draft gives
-   next-cycle changes a single home to land on as release prep works through
-   them.
+   next-cycle changes a single home to land on.
 
 5. **Submit a PR with your changes**, using a title like:
 

--- a/docsy.dev/lychee.toml
+++ b/docsy.dev/lychee.toml
@@ -38,6 +38,7 @@ exclude = [
   # Remove after 0.17.0 ships: the release tag and links to pages new/draft in
   # this cycle (absent on v0.16.0 prod).
   '^https://github\.com/google/docsy/releases/(tag/)?v0\.17\.0$',
+  '^https://github\.com/google/docsy/compare/v0\.16\.0\.\.\.v0\.17\.0$',
   '^https://www\.docsy\.dev/blog/2026/0\.17\.0/$',
   '^https://main--docsydocs\.netlify\.app/blog/2026/0\.17\.0/$',
   '^https://www\.docsy\.dev/tests/layouts/swagger/$',

--- a/docsy.dev/lychee.toml
+++ b/docsy.dev/lychee.toml
@@ -38,7 +38,6 @@ exclude = [
   # Remove after 0.17.0 ships: the release tag and links to pages new/draft in
   # this cycle (absent on v0.16.0 prod).
   '^https://github\.com/google/docsy/releases/(tag/)?v0\.17\.0$',
-  '^https://github\.com/google/docsy/compare/v0\.16\.0\.\.\.v0\.17\.0$',
   '^https://www\.docsy\.dev/blog/2026/0\.17\.0/$',
   '^https://main--docsydocs\.netlify\.app/blog/2026/0\.17\.0/$',
   '^https://www\.docsy\.dev/tests/layouts/swagger/$',

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,7 +6,7 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
-- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy modernizes foundations: Dart Sass, Font Awesome 7, and pinned script defaults. Breadcrumbs get semantic classes! Bundled locales reach full UI-string coverage, and llms.txt sites gain agent discovery.
+- [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy modernizes and strengthens its foundations: Dart Sass, Font Awesome 7, and pinned script defaults. Breadcrumbs get semantic classes, bundled locales reach full UI-string coverage, and llms.txt sites gain agent discovery.
 - [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Docsy is now on npm as @docsy/theme. This release also moves the theme into theme/, raises the Hugo minimum, and drops its default favicons in favor of discovery, each with upgrade actions.
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/): What changed in Hugo 0.158.0 through 0.164.x for Docsy sites: breaking changes, deprecations, security fixes, and known regressions, with per-version upgrade actions.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.

--- a/docsy.dev/tests/md-output/goldens/docs/index.md
+++ b/docsy.dev/tests/md-output/goldens/docs/index.md
@@ -6,10 +6,10 @@ LLMS index: [llms.txt](/llms.txt)
 
 <!-- markdownlint-disable-next-line no-space-in-links -->
 
-<span class="badge bg-primary text-bg-primary fs-6">v0.16.1-dev
+<span class="badge bg-primary text-bg-primary fs-6">v0.17.1-dev
 </span>
 
-Welcome to the Docsy theme user guide for version `v0.16.1-dev`. This
+Welcome to the Docsy theme user guide for version `v0.17.1-dev`. This
 guide shows you how to get started creating technical documentation sites using
 Docsy, including site customization and how to use Docsy's blocks and templates.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docsy",
-  "version": "0.16.1-dev",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docsy",
-      "version": "0.16.1-dev",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "workspaces": [
         "docsy.dev",
@@ -3776,7 +3776,7 @@
     },
     "theme": {
       "name": "@docsy/theme",
-      "version": "0.16.1-dev",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.16.1-dev",
+  "version": "0.17.0",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@docsy/theme",
-  "version": "0.16.1-dev",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@docsy/theme",
-      "version": "0.16.1-dev",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "7.3.1",

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docsy/theme",
-  "version": "0.16.1-dev",
+  "version": "0.17.0",
   "description": "A Hugo theme for technical documentation sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Contributes to #2691
- **Release prep** (maintainer notes § Publishing a release, steps 1–7): post undrafted and dated, changelog v0.17.0 section finalized, compare links pinned to the tag range, version stamped 0.17.0 (next dev v0.17.1-dev)
- **Link check**: seeds the v0.16.0...v0.17.0 compare link as a 206 cache row until the tag exists (self-cleaning on regeneration)
- **Maintainer notes**: adds a post-release step: create the next release's draft report post, giving next-cycle changes one home during release prep
- **Jaeger upgrade-run feedback** (guide defect fixes, verified in the run, trimmed in review): 0.16 post gains the missing favicon gate for `static/favicons/` sites (gates decoupled for overriders), GitHub-npm updates route to the theme-deps rerun, agent-directive call noted safe to add unconditionally
- **Update docs**: Before-you-begin reduced to backup + a general stepwise-crossing rule; per-release crossing detail now lives only in each release post's applies-if gates
- **Post description**: verb pair matches the enumeration (modernizes and strengthens)
- **Tests**: md-output golden refreshed, it embeds the dev-version stamp
- **Preview(s)**:
  - <https://deploy-preview-2770--docsydocs.netlify.app/blog/2026/0.17.0/>
  - <https://deploy-preview-2770--docsydocs.netlify.app/blog/2026/0.16.0/>
  - <https://deploy-preview-2770--docsydocs.netlify.app/docs/update/>
  - <https://deploy-preview-2770--docsydocs.netlify.app/project/about/changelog/>
  - <https://deploy-preview-2770--docsydocs.netlify.app/project/about/maintainer-notes/>
