### PR TITLE
Set version to v0.17.1-dev

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -271,7 +271,8 @@ https://github.com/google/docsy/commits/main,200,1782563369
 https://github.com/google/docsy/compare/v0.15.0...main,200,1782563370
 https://github.com/google/docsy/compare/v0.15.0...v0.16.0,200,1785360538
 https://github.com/google/docsy/compare/v0.16.0...main,200,1787153684
-https://github.com/google/docsy/compare/v0.16.0...v0.17.0,206,1788114730
+https://github.com/google/docsy/compare/v0.16.0...v0.17.0,200,1788123507
+https://github.com/google/docsy/compare/v0.17.0...main,200,1788123580
 https://github.com/google/docsy/compare/v0.8.0...v0.9.0,200,1782498238
 https://github.com/google/docsy/discussions,200,1782563367
 https://github.com/google/docsy/discussions/1308,200,1782498228
@@ -425,6 +426,7 @@ https://github.com/google/docsy/issues/new?title=Release%200.14.0%20report%20and
 https://github.com/google/docsy/issues/new?title=Release%200.15.0%20report%20and%20upgrade%20guide,200,1782498546
 https://github.com/google/docsy/issues/new?title=Release%200.16.0%20report%20and%20upgrade%20guide,200,1782498546
 https://github.com/google/docsy/issues/new?title=Release%200.17.0%20report%20and%20upgrade%20guide,200,1787153684
+https://github.com/google/docsy/issues/new?title=Release%200.18.0%20report%20and%20upgrade%20guide,200,1788123580
 https://github.com/google/docsy/issues/new?title=Repository%20Links%20and%20other%20page%20information,200,1782498241
 https://github.com/google/docsy/issues/new?title=Repository-root%20markdown%20files,200,1782498547
 https://github.com/google/docsy/issues/new?title=ScrollSpy%20patch,200,1782498547
@@ -571,10 +573,13 @@ https://github.com/google/docsy/releases,200,1782563368
 https://github.com/google/docsy/releases/latest,200,1782563369
 https://github.com/google/docsy/releases/latest?FIXME=v0.16.1,200,1785360538
 https://github.com/google/docsy/releases/latest?FIXME=v0.17.0,200,1785360538
+https://github.com/google/docsy/releases/latest?FIXME=v0.18.0,200,1788123580
 https://github.com/google/docsy/releases/new,200,1782498229
 https://github.com/google/docsy/releases/tag/v0.10.0,200,1782498237
 https://github.com/google/docsy/releases/tag/v0.11.0,200,1782498235
 https://github.com/google/docsy/releases/tag/v0.16.0,200,1785360538
+https://github.com/google/docsy/releases/tag/v0.17.0,200,1788123507
+https://github.com/google/docsy/releases/tag/v0.18.0,206,1788123604
 https://github.com/google/docsy/releases/tag/v0.7.0,200,1782498239
 https://github.com/google/docsy/releases/tag/v0.9.0,200,1782498237
 https://github.com/google/docsy/releases/v0.10.0,200,1782498226
@@ -587,6 +592,7 @@ https://github.com/google/docsy/releases/v0.14.2,200,1782498222
 https://github.com/google/docsy/releases/v0.14.3,200,1782498222
 https://github.com/google/docsy/releases/v0.15.0,200,1782563370
 https://github.com/google/docsy/releases/v0.16.0,200,1785360538
+https://github.com/google/docsy/releases/v0.17.0,200,1788123508
 https://github.com/google/docsy/releases/v0.2.0,200,1782498229
 https://github.com/google/docsy/releases/v0.3.0,200,1782498229
 https://github.com/google/docsy/releases/v0.4.0,200,1782498229
@@ -806,6 +812,8 @@ https://main--docsydocs.netlify.app/blog/2026/0.16.0/#npm-deps,200,1785243426
 https://main--docsydocs.netlify.app/blog/2026/0.16.0/#rollback,200,1785191587
 https://main--docsydocs.netlify.app/blog/2026/0.16.0/#theme-folder-actions,200,1785191587
 https://main--docsydocs.netlify.app/blog/2026/0.16.0/,200,1782498244
+https://main--docsydocs.netlify.app/blog/2026/0.17.0/,200,1788123507
+https://main--docsydocs.netlify.app/blog/2026/0.18.0/,206,1788123604
 https://main--docsydocs.netlify.app/blog/2026/hugo-0.152.0+/,200,1782498244
 https://main--docsydocs.netlify.app/blog/2026/hugo-0.158.0+/,200,1782498244
 https://main--docsydocs.netlify.app/community/,200,1782563367
@@ -843,7 +851,7 @@ https://main--docsydocs.netlify.app/docs/get-started/docsy-as-module/start-from-
 https://main--docsydocs.netlify.app/docs/get-started/known_issues/,200,1782498243
 https://main--docsydocs.netlify.app/docs/get-started/other-options/,200,1782498243
 https://main--docsydocs.netlify.app/docs/get-started/quickstart-docker/,200,1782498245
-https://main--docsydocs.netlify.app/docs/get-started/troubleshooting/,206,1784212116
+https://main--docsydocs.netlify.app/docs/get-started/troubleshooting/,200,1788123507
 https://main--docsydocs.netlify.app/docs/language/,200,1782498243
 https://main--docsydocs.netlify.app/docs/update/,200,1782563367
 https://main--docsydocs.netlify.app/docs/update/convert-site-to-module/,200,1782498243
@@ -859,7 +867,7 @@ https://main--docsydocs.netlify.app/project/about/readme/,200,1782498244
 https://main--docsydocs.netlify.app/project/build/,200,1782563367
 https://main--docsydocs.netlify.app/project/build/ci-cd/,200,1782498244
 https://main--docsydocs.netlify.app/project/build/git-repo/,200,1782498244
-https://main--docsydocs.netlify.app/project/design/,206,1787249523
+https://main--docsydocs.netlify.app/project/design/,200,1788123507
 https://main--docsydocs.netlify.app/project/design/semantic-classes/,200,1787669024
 https://main--docsydocs.netlify.app/project/implementation/,200,1782563367
 https://main--docsydocs.netlify.app/project/implementation/scrollspy-patch/,200,1782498244
@@ -879,6 +887,7 @@ https://main--docsydocs.netlify.app/tests/blocks-cover/height-full/,200,17824982
 https://main--docsydocs.netlify.app/tests/blocks-cover/height-min/,200,1782498222
 https://main--docsydocs.netlify.app/tests/layouts/,200,1782563367
 https://main--docsydocs.netlify.app/tests/layouts/no-left-sidebar/,200,1782563368
+https://main--docsydocs.netlify.app/tests/layouts/swagger/,200,1788123507
 https://markmap.js.org/,200,1782498237
 https://martinfowler.com/bliki/TechnicalDebt.html,200,1782498228
 https://mentorship.lfx.linuxfoundation.org/project/34314eb1-0fc3-4802-ab04-2265418c2e48,200,1782498230
@@ -964,6 +973,8 @@ https://www.docsy.dev/blog/2025/0.13.0/,200,1782498244
 https://www.docsy.dev/blog/2026/0.14.0/,200,1782498244
 https://www.docsy.dev/blog/2026/0.15.0/,200,1782498244
 https://www.docsy.dev/blog/2026/0.16.0/,200,1785360538
+https://www.docsy.dev/blog/2026/0.17.0/,200,1788123507
+https://www.docsy.dev/blog/2026/0.18.0/,206,1788123604
 https://www.docsy.dev/blog/2026/hugo-0.152.0+/,200,1782498244
 https://www.docsy.dev/blog/2026/hugo-0.158.0+/,200,1785360538
 https://www.docsy.dev/community/,200,1782563367
@@ -1002,7 +1013,7 @@ https://www.docsy.dev/docs/get-started/docsy-as-module/start-from-scratch/,200,1
 https://www.docsy.dev/docs/get-started/known_issues/,200,1782498243
 https://www.docsy.dev/docs/get-started/other-options/,200,1782498243
 https://www.docsy.dev/docs/get-started/quickstart-docker/,200,1782498243
-https://www.docsy.dev/docs/get-started/troubleshooting/,206,1784212116
+https://www.docsy.dev/docs/get-started/troubleshooting/,200,1788123507
 https://www.docsy.dev/docs/language/,200,1782498243
 https://www.docsy.dev/docs/update/,200,1782563367
 https://www.docsy.dev/docs/update/convert-site-to-module/,200,1782498243
@@ -1019,8 +1030,8 @@ https://www.docsy.dev/project/about/readme/,200,1782498244
 https://www.docsy.dev/project/build/,200,1782563367
 https://www.docsy.dev/project/build/ci-cd/,200,1782498244
 https://www.docsy.dev/project/build/git-repo/,200,1782498245
-https://www.docsy.dev/project/design/,206,1787249523
-https://www.docsy.dev/project/design/semantic-classes/,206,1787150440
+https://www.docsy.dev/project/design/,200,1788123507
+https://www.docsy.dev/project/design/semantic-classes/,200,1788123507
 https://www.docsy.dev/project/implementation/,200,1782563367
 https://www.docsy.dev/project/implementation/scrollspy-patch/,200,1782498244
 https://www.docsy.dev/project/repo/,200,1782563367
@@ -1039,6 +1050,7 @@ https://www.docsy.dev/tests/blocks-cover/height-full/,200,1782498226
 https://www.docsy.dev/tests/blocks-cover/height-min/,200,1782563368
 https://www.docsy.dev/tests/layouts/,200,1782563367
 https://www.docsy.dev/tests/layouts/no-left-sidebar/,200,1782563368
+https://www.docsy.dev/tests/layouts/swagger/,200,1788123507
 https://www.google.com/search?q=mac+os+launchctl+limit+maxfiles+site%3Aapple.stackexchange.com&oq=mac+os+launchctl+limit+maxfiles+site%3Aapple.stackexchange.com,200,1782563368
 https://www.grpc.io/,200,1782498245
 https://www.kubeflow.org/,200,1782498245

--- a/docsy.dev/content/en/blog/2026/0.18.0.md
+++ b/docsy.dev/content/en/blog/2026/0.18.0.md
@@ -1,0 +1,54 @@
+---
+title: Release 0.18.0 report and upgrade guide
+linkTitle: Release 0.18.0
+date: 2026-08-30
+draft: true
+description: >-
+  FIXME: ~4 named features, headline first (~25-30 words).
+author: >-
+  [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
+  for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
+body_class: release-highlights
+tags: [release, upgrade]
+params:
+  # Frozen at publication (repo pins at release time).
+  hugoSupportedVersion: 0.164.0
+---
+
+<!--
+  Next-cycle landing home (created at 0.17.0 post-release followup, maintainer
+  notes § Post Docsy-release followup): route each landed change's post
+  coverage here as release prep works the 0.18 cycle. Model sections on the
+  0.17.0 post.
+-->
+
+{{% card header="Highlights" %}}
+
+- FIXME: three one-clause entries.
+
+{{% /card %}}
+
+## Release summary
+
+FIXME: two-level map of the post.
+
+## Ready to upgrade? {#ready-to-upgrade}
+
+FIXME: triage list + version table (Docsy 0.17.0 -> 0.18.0).
+
+## What's next
+
+FIXME.
+
+## References
+
+- Changelog entry for [0.18.0][CL@0.18.0]
+- [Docsy 0.18.0 release page][release]
+- Release-prep tracker: FIXME
+- [Changes since 0.17.0][compare-0.17.0]
+
+<!-- prettier-ignore-start -->
+[CL@0.18.0]: /project/about/changelog/#next
+[compare-0.17.0]: https://github.com/google/docsy/compare/v0.17.0...main
+[release]: https://github.com/google/docsy/releases/tag/v0.18.0
+<!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/blog/2026/0.18.0.md
+++ b/docsy.dev/content/en/blog/2026/0.18.0.md
@@ -32,7 +32,7 @@ params:
 
 FIXME: two-level map of the post.
 
-## Ready to upgrade? {#ready-to-upgrade}
+## Ready to upgrade?
 
 FIXME: triage list + version table (Docsy 0.17.0 -> 0.18.0).
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -141,6 +141,17 @@ functionality, depending on scope. Prefer narrow, focused PRs where possible.
 
 </details>
 
+## v0.18.0 {#next}
+
+> **UNRELEASED: this planned version is still under development**
+
+For the full list of changes, see the [0.18.0][] release page or the [git
+history since 0.17.0][].
+
+[0.18.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.18.0
+[git history since 0.17.0]:
+  https://github.com/google/docsy/compare/v0.17.0...main
+
 ## v0.17.0 {#v0.17.0}
 
 For an introduction to this release, see the [0.17.0 release report][]. For the

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -148,6 +148,22 @@ functionality, depending on scope. Prefer narrow, focused PRs where possible.
 For the full list of changes, see the [0.18.0][] release page or the [git
 history since 0.17.0][].
 
+[**Breaking changes**](#breaking-change):
+
+- ...
+
+**New**:
+
+- ...
+
+**Other changes**:
+
+- ...
+
+[**Experimental**](#experimental):
+
+- ...
+
 [0.18.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.18.0
 [git history since 0.17.0]:
   https://github.com/google/docsy/compare/v0.17.0...main

--- a/docsy.dev/lychee.toml
+++ b/docsy.dev/lychee.toml
@@ -34,12 +34,4 @@ exclude = [
   '^https://docsearch\.algolia\.com/',               # bot-wall (403) on the apply page
   '^https://prismjs\.com/download\.html#',           # download-builder state hash, not an anchor
   '^https://portal\.aws\.amazon\.com/',              # SPA signup flow, fragment is a client route
-
-  # Remove after 0.17.0 ships: the release tag and links to pages new/draft in
-  # this cycle (absent on v0.16.0 prod).
-  '^https://github\.com/google/docsy/releases/(tag/)?v0\.17\.0$',
-  '^https://www\.docsy\.dev/blog/2026/0\.17\.0/$',
-  '^https://main--docsydocs\.netlify\.app/blog/2026/0\.17\.0/$',
-  '^https://www\.docsy\.dev/tests/layouts/swagger/$',
-  '^https://main--docsydocs\.netlify\.app/tests/layouts/swagger/$',
 ]

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -7,6 +7,7 @@ LLMS index: [llms.txt](/llms.txt)
 Section pages:
 
 - [Release 0.17.0 report and upgrade guide](/blog/2026/0.17.0/): Docsy modernizes and strengthens its foundations: Dart Sass, Font Awesome 7, and pinned script defaults. Breadcrumbs get semantic classes, bundled locales reach full UI-string coverage, and llms.txt sites gain agent discovery.
+- [Release 0.18.0 report and upgrade guide](/blog/2026/0.18.0/): FIXME: ~4 named features, headline first (~25-30 words).
 - [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Docsy is now on npm as @docsy/theme. This release also moves the theme into theme/, raises the Hugo minimum, and drops its default favicons in favor of discovery, each with upgrade actions.
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/): What changed in Hugo 0.158.0 through 0.164.x for Docsy sites: breaking changes, deprecations, security fixes, and known regressions, with per-version upgrade actions.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docsy",
-  "version": "0.17.0",
+  "version": "0.17.1-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docsy",
-      "version": "0.17.0",
+      "version": "0.17.1-dev",
       "license": "Apache-2.0",
       "workspaces": [
         "docsy.dev",
@@ -3776,7 +3776,7 @@
     },
     "theme": {
       "name": "@docsy/theme",
-      "version": "0.17.0",
+      "version": "0.17.1-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.17.0",
+  "version": "0.17.1-dev",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@docsy/theme",
-  "version": "0.17.0",
+  "version": "0.17.1-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@docsy/theme",
-      "version": "0.17.0",
+      "version": "0.17.1-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "7.3.1",

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docsy/theme",
-  "version": "0.17.0",
+  "version": "0.17.1-dev",
   "description": "A Hugo theme for technical documentation sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Post-release followup per maintainer notes § Post Docsy-release followup, for [v0.17.0](https://github.com/google/docsy/releases/tag/v0.17.0)
- **Version**: 0.17.0 → 0.17.1-dev
- **Link check**: retires the shipped release's temporary excludes and redeems all six 206 cache seeds (URLs now live); the 0.18 draft's not-yet-live links get fresh seeds per the documented convention
- **Next cycle's landing homes** (first run of the new followup step): v0.18.0 changelog placeholder + 0.18.0 draft report post
- **Tests**: blog md-output golden refreshed — dev builds list the new draft
