### PR TITLE
Apply open Renovate updates: devDep pins and bumps, actions v7

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -101,8 +101,10 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
-          # This pin exports a dummy NODE_AUTH_TOKEN so the registry-url
-          # config template always resolves; re-verify on setup-node bumps.
+          # Writes the fresh userconfig the publish step relies on. Since v7,
+          # setup-node exports no dummy NODE_AUTH_TOKEN (setup-node#1558: a
+          # token can corrupt OIDC trusted publishing); npm tolerates the
+          # unresolved auth template. Re-verify on setup-node bumps.
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -39,7 +39,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
           # Full history: the main-ancestry check below needs it.
@@ -53,7 +53,7 @@ jobs:
         # 2026-08-09); widen deliberately if a release-branch flow returns.
         run: git merge-base --is-ancestor HEAD origin/main
 
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
@@ -94,11 +94,11 @@ jobs:
       contents: read # For the checkout, which only feeds setup-node .nvmrc.
       id-token: write
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
           # This pin exports a dummy NODE_AUTH_TOKEN so the registry-url

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -26,10 +26,10 @@ jobs:
     # if: github.event_name != 'pull_request' && matrix.os != 'windows-latest'
     if: github.event_name != 'push' || github.repository == 'google/docsy'
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with: { persist-credentials: false }
 
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,10 +16,10 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with: { persist-credentials: false }
 
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -64,10 +64,10 @@ jobs:
   visual:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with: { persist-credentials: false }
 
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -45,11 +45,11 @@
   },
   "dependencies-note": "Dependencies installed from ../theme; see the root install:theme-deps script",
   "devDependencies": {
-    "afdocs": "^0.19.0",
-    "cross-env": "^10.1.0",
-    "link-cache": "^0.3.0",
-    "npm-check-updates": "^19.6.3",
-    "rtlcss": "^4.3.0"
+    "afdocs": "0.20.0",
+    "cross-env": "10.1.0",
+    "link-cache": "0.3.0",
+    "npm-check-updates": "23.0.2",
+    "rtlcss": "4.3.0"
   },
   "cSpell:ignore": "- favicons goldens postbuild -"
 }

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -48,7 +48,7 @@
     "afdocs": "0.20.0",
     "cross-env": "10.1.0",
     "link-cache": "0.3.0",
-    "npm-check-updates": "23.0.2",
+    "npm-check-updates": "23.1.0",
     "rtlcss": "4.3.0"
   },
   "cSpell:ignore": "- favicons goldens postbuild -"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "afdocs": "0.20.0",
         "cross-env": "10.1.0",
         "link-cache": "0.3.0",
-        "npm-check-updates": "23.0.2",
+        "npm-check-updates": "23.1.0",
         "rtlcss": "4.3.0"
       }
     },
@@ -2520,9 +2520,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "23.0.2",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-23.0.2.tgz",
-      "integrity": "sha512-t5tv+d4sP+WbSwcDAFBwDxSUJRomc+TJoURPu7q5B/19toUsR/7eshRxBdWdE7iYw80iE4O4D/7OvCvIcaG8ug==",
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-23.1.0.tgz",
+      "integrity": "sha512-u6Odx/JDpDXNqXp5pPsVN0RhuWkNrBe4Sz26J7yWJcEadopKhQgcB+bFq2PK35iJY6vc6h1PbnXmnwfiOFQl/w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3421,22 +3421,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.4.10",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
-      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.4.tgz",
+      "integrity": "sha512-kFXFK7O4WPextIUAOk8qtnw9dxR9UIXP9CjuH1cTBVBZMDeQcUPgr/IazGiw1B0Yiw5L75gHLWeW4iD793r90g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.10"
+        "tldts-core": "^7.4.4"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.10",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
-      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.4.tgz",
+      "integrity": "sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,18 +16,18 @@
         "gen-favicons": "theme/scripts/gen-favicons/cli.mjs"
       },
       "devDependencies": {
-        "@cspell/dict-fr-fr": "^2.3.2",
-        "@pchalin/markdownlint-rule-link-pattern": "^0.3.0",
+        "@cspell/dict-fr-fr": "2.3.2",
+        "@pchalin/markdownlint-rule-link-pattern": "0.3.0",
         "hugo-extended": "0.164.0",
-        "jsdom": "^29.1.1",
-        "markdownlint-cli2": "^0.23.2",
-        "markdownlint-rule-no-shortcut-ref-link": "^0.3.1",
+        "jsdom": "30.0.1",
+        "markdownlint-cli2": "0.23.2",
+        "markdownlint-rule-no-shortcut-ref-link": "0.4.0",
         "pixelmatch": "7.2.0",
         "pngjs": "7.0.0",
-        "prettier": "^3.9.3",
-        "puppeteer": "25.5.0",
-        "sass-embedded": "1.102.0",
-        "yaml": "^2.9.0"
+        "prettier": "3.9.3",
+        "puppeteer": "25.8.0",
+        "sass-embedded": "1.103.1",
+        "yaml": "2.9.0"
       },
       "engines": {
         "node": ">=24",
@@ -37,63 +37,45 @@
     "docsy.dev": {
       "name": "@docsy/docsy.dev",
       "devDependencies": {
-        "afdocs": "^0.19.0",
-        "cross-env": "^10.1.0",
-        "link-cache": "^0.3.0",
-        "npm-check-updates": "^19.6.3",
-        "rtlcss": "^4.3.0"
+        "afdocs": "0.20.0",
+        "cross-env": "10.1.0",
+        "link-cache": "0.3.0",
+        "npm-check-updates": "23.0.2",
+        "rtlcss": "4.3.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@csstools/css-calc": "^3.2.0",
-        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^22.13.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
-      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1"
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^22.13.0 || >=24.0.0"
       }
-    },
-    "node_modules/@asamuzakjp/generational-cache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
-      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -123,9 +105,9 @@
       "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
-      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
       "dev": true,
       "funding": [
         {
@@ -143,9 +125,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
       "dev": true,
       "funding": [
         {
@@ -167,9 +149,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
-      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
       "dev": true,
       "funding": [
         {
@@ -183,8 +165,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.1.0",
-        "@csstools/css-calc": "^3.2.1"
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -218,9 +200,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
-      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
       "dev": true,
       "funding": [
         {
@@ -704,13 +686,13 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.1.0.tgz",
-      "integrity": "sha512-RDLpio3fH/qrj5k4DVY6eyiN8tCS0Zovd/6jW//n605oeqkWcUjn+3k+9ZtZBnbwMpsu0F7xDIiKXvVmG5c5Bw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.1.tgz",
+      "integrity": "sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "modern-tar": "^0.7.6",
+        "modern-tar": "^0.8.0",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -787,9 +769,9 @@
       }
     },
     "node_modules/afdocs": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/afdocs/-/afdocs-0.19.0.tgz",
-      "integrity": "sha512-r9WhOOgf4hyDKFpipQD/lcuLB+HLM22CYeYdZWDfBV477FA4uJxaNyzQHBVQs8m2Yfav+P1UDBjZYp4D6OKwEQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/afdocs/-/afdocs-0.20.0.tgz",
+      "integrity": "sha512-jq+Sj4kDVJfzKb2+T+FN3BT8pWWS54m+F1pMvjyBTBvVLUw5wF8QHcd1FWyyuZgTls9Wg8rvqMNzyNMJF0qqmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1223,9 +1205,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1653615",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1653615.tgz",
-      "integrity": "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==",
+      "version": "0.0.1666840",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
+      "integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1616,44 +1598,59 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
-      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.1.11",
-        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
-        "@exodus/bytes": "^1.15.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.3.5",
+        "lru-cache": "^11.5.2",
         "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.1",
-        "undici": "^7.25.0",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.1",
+        "whatwg-url": "^17.1.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "canvas": "^3.0.0"
+        "canvas": "^3.2.3"
       },
       "peerDependenciesMeta": {
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/jsonc-parser": {
@@ -1738,9 +1735,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1854,9 +1851,9 @@
       }
     },
     "node_modules/markdownlint-rule-no-shortcut-ref-link": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-rule-no-shortcut-ref-link/-/markdownlint-rule-no-shortcut-ref-link-0.3.1.tgz",
-      "integrity": "sha512-cgeeU9YZ3mPL85lQGCTGNUIhkSe+yaVMpAXyy8oL42k9Mg4dbM0I9I96S7E+ZPSqApBRic52ql9H1RgqGdX9Xg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-no-shortcut-ref-link/-/markdownlint-rule-no-shortcut-ref-link-0.4.0.tgz",
+      "integrity": "sha512-mcsmuwPRhYOCcwCtAte4K9i8Pcs+1yMi/U5IDL85VEvNjvopPF0FYi3uy9jCvl7L/fJRjWGanDJBXl8A9+IKaw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -2468,9 +2465,9 @@
       "license": "MIT"
     },
     "node_modules/modern-tar": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
-      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2523,9 +2520,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "19.6.6",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-19.6.6.tgz",
-      "integrity": "sha512-AvlRcnlUEyBEJfblUSjYMJwYKvCIWDRuCDa6x3hyUMTMkI3kslmFm0LDqwgzQfshfNh0Z3ouKiA4fLjRN7HejQ==",
+      "version": "23.0.2",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-23.0.2.tgz",
+      "integrity": "sha512-t5tv+d4sP+WbSwcDAFBwDxSUJRomc+TJoURPu7q5B/19toUsR/7eshRxBdWdE7iYw80iE4O4D/7OvCvIcaG8ug==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2533,8 +2530,8 @@
         "npm-check-updates": "build/cli.js"
       },
       "engines": {
-        "node": ">=20.0.0",
-        "npm": ">=8.12.1"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/nth-check": {
@@ -2715,18 +2712,18 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.5.0.tgz",
-      "integrity": "sha512-qpp73xblxNr+bF0nSXTodM3v+zcK5IPo/GkjLsdUqRf/qpLJp/1KxBUbstoMMnwnPw9xD6OMei8kmYf6CLWfGw==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.8.0.tgz",
+      "integrity": "sha512-3gcUJ+Jfodb5zNa/lWLZukBUwYiRIwAc8WRICoqfi+ZYmNWqpsPFyanTU3Gw/lhgII9aotVbAmhT6/NKHWgyUA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "3.1.0",
+        "@puppeteer/browsers": "3.2.1",
         "chromium-bidi": "17.0.2",
-        "devtools-protocol": "0.0.1653615",
+        "devtools-protocol": "0.0.1666840",
         "lilconfig": "^3.1.3",
-        "puppeteer-core": "25.5.0",
+        "puppeteer-core": "25.8.0",
         "typed-query-selector": "^2.12.2"
       },
       "bin": {
@@ -2737,15 +2734,15 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.5.0.tgz",
-      "integrity": "sha512-XPNT0dQJtphqQ4I29zxlG4IIPbg1iEHAQKWuQgtMJGXjACV77pZSmJvDi51IIIfd+DTKICcopJwUx4upVQ4XbA==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.8.0.tgz",
+      "integrity": "sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "3.1.0",
+        "@puppeteer/browsers": "3.2.1",
         "chromium-bidi": "17.0.2",
-        "devtools-protocol": "0.0.1653615",
+        "devtools-protocol": "0.0.1666840",
         "typed-query-selector": "^2.12.2",
         "webdriver-bidi-protocol": "0.4.2",
         "ws": "^8.21.1"
@@ -2865,9 +2862,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.102.0.tgz",
-      "integrity": "sha512-NSOyTnaQF7rTAEOtI2fwb386vL+akyiQLBZu8Na7hXCb+umJy0GAqlcMIaqACZ6Z1VgTBS4K9PG6B3IdjHGJsw==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.103.1.tgz",
+      "integrity": "sha512-9icZURbP51S6S0QGoyaeqk9uB06GNWxsFYWfH5RgpFgqK5FA8tJcM3AdVxrZEVJ7dz+L87nG95gBKf4VuaMHGw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2887,9 +2884,9 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.102.0.tgz",
-      "integrity": "sha512-7xZ7jbsGTpA+oRIJ3HKeiYy+RIrwHltIjKMdnRTAZiPpqvKzwy80zZqR532yk5bpHn1lTqWdZ6Fh4KI+GWSsKA==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.103.1.tgz",
+      "integrity": "sha512-UVIuFZPzz+4DXYbHzQ5gKaKkyP2IH3Sc/WoF63N2V7QIfnC2E9UpQAtiKlCVJTfBe43HRgHDBLnXpZkYAEBsNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2908,30 +2905,30 @@
         "node": ">=20.19.0"
       },
       "optionalDependencies": {
-        "sass-embedded-all-unknown": "1.102.0",
-        "sass-embedded-android-arm": "1.102.0",
-        "sass-embedded-android-arm64": "1.102.0",
-        "sass-embedded-android-riscv64": "1.102.0",
-        "sass-embedded-android-x64": "1.102.0",
-        "sass-embedded-darwin-arm64": "1.102.0",
-        "sass-embedded-darwin-x64": "1.102.0",
-        "sass-embedded-linux-arm": "1.102.0",
-        "sass-embedded-linux-arm64": "1.102.0",
-        "sass-embedded-linux-musl-arm": "1.102.0",
-        "sass-embedded-linux-musl-arm64": "1.102.0",
-        "sass-embedded-linux-musl-riscv64": "1.102.0",
-        "sass-embedded-linux-musl-x64": "1.102.0",
-        "sass-embedded-linux-riscv64": "1.102.0",
-        "sass-embedded-linux-x64": "1.102.0",
-        "sass-embedded-unknown-all": "1.102.0",
-        "sass-embedded-win32-arm64": "1.102.0",
-        "sass-embedded-win32-x64": "1.102.0"
+        "sass-embedded-all-unknown": "1.103.1",
+        "sass-embedded-android-arm": "1.103.1",
+        "sass-embedded-android-arm64": "1.103.1",
+        "sass-embedded-android-riscv64": "1.103.1",
+        "sass-embedded-android-x64": "1.103.1",
+        "sass-embedded-darwin-arm64": "1.103.1",
+        "sass-embedded-darwin-x64": "1.103.1",
+        "sass-embedded-linux-arm": "1.103.1",
+        "sass-embedded-linux-arm64": "1.103.1",
+        "sass-embedded-linux-musl-arm": "1.103.1",
+        "sass-embedded-linux-musl-arm64": "1.103.1",
+        "sass-embedded-linux-musl-riscv64": "1.103.1",
+        "sass-embedded-linux-musl-x64": "1.103.1",
+        "sass-embedded-linux-riscv64": "1.103.1",
+        "sass-embedded-linux-x64": "1.103.1",
+        "sass-embedded-unknown-all": "1.103.1",
+        "sass-embedded-win32-arm64": "1.103.1",
+        "sass-embedded-win32-x64": "1.103.1"
       }
     },
     "node_modules/sass-embedded-all-unknown": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.102.0.tgz",
-      "integrity": "sha512-BpaRCODYILywdCOI8++Q63+/ptsnWdwYuKyD5gMH0cJblXj85EePdeTTOM7Hl2PP6d4dIojg8GS9fIZhD2x8qA==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.103.1.tgz",
+      "integrity": "sha512-MwX2ap06TbImAqlbnH6EndgBBejk6Eq2QB6Ae2hukCn9wmXf9cRu27um3mz3tyB4oJOOku0xfHqFH/+ckYj6YA==",
       "cpu": [
         "!arm",
         "!arm64",
@@ -2942,13 +2939,13 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "sass": "1.102.0"
+        "sass": "1.103.1"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.102.0.tgz",
-      "integrity": "sha512-QM6sPMUtUvFopVR15qXWdobSTYW/sPrXJLxa7eaIbqr/0EtNBZirEXdiOFdDNcsFIEFX3NeZjDq8ZkBAQrxR1w==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.103.1.tgz",
+      "integrity": "sha512-p36WHpsu5HEo2+NVNbI2Nmb8VgVH0xwOQyzghvZhF7ikGCzEVYI5BP28vHUZlCcgj2TUvMEJKI2lV336a+F/sg==",
       "cpu": [
         "arm"
       ],
@@ -2963,9 +2960,9 @@
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.102.0.tgz",
-      "integrity": "sha512-p34iJl04ksTA/6/NZNKv4Bda710hvpoUNUK6vgHKe53tTGhL5XOfYyTjX95lpKPSvGm4BlPEVSSo6CBhyNSDpw==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.103.1.tgz",
+      "integrity": "sha512-jBXWMksyz55XeLOWvQs64BqiG5DcqflmMxcvMoA2oHtQT/7XZ02hBn502qpcF/q8Qd+qqG/hU5ccM+hGXrbQZw==",
       "cpu": [
         "arm64"
       ],
@@ -2980,9 +2977,9 @@
       }
     },
     "node_modules/sass-embedded-android-riscv64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.102.0.tgz",
-      "integrity": "sha512-wcT5N3B6fIwCKCicDcUP6Jol+e1R3WxHMGU7Swp9Ds9VV8di7HYOKIFcasT25dKJv4l17SA7x5Oum0FlRnMPkg==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.103.1.tgz",
+      "integrity": "sha512-rzrH7RNntk0rx+zCE9xOiAIUt37D1cQKvFfcoX0xiePdGbNHBN8DWKaWN9vaCRfbgKCmxPjevzaqFNI/G/8E1A==",
       "cpu": [
         "riscv64"
       ],
@@ -2997,9 +2994,9 @@
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.102.0.tgz",
-      "integrity": "sha512-IF4eJmoM4uzOborahHp8D4PlCIvumr6IGEbe1XkedwE57qRdk/GENiYZjGwYUQP0uy+pfb+WfvTNhMxkD2VhJg==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.103.1.tgz",
+      "integrity": "sha512-EQglAJXJutuIcqgZf7YOwzao2ND6ow/OgqN+cM48/Qaeb6AimYmZiUJmM9FFcmS3Q2n1k6/2OU3l3Hlin7bFpw==",
       "cpu": [
         "x64"
       ],
@@ -3014,9 +3011,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.102.0.tgz",
-      "integrity": "sha512-txaURnQp3L/5mGgSkg6zFrI/H1BgwPxH+7fv/HMuFT1fTXGi7i5++OJNCFVPL7gFB50WFmpf02bCvgec3/gxMA==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.103.1.tgz",
+      "integrity": "sha512-rlaBeCul8pLbDRKdBAxdDxSBwFU5fbX42ci6CxW2Vbs34jWTMQ72+nE2v2KkGGce+JnYbb7UV6xDP/4uDWWi+w==",
       "cpu": [
         "arm64"
       ],
@@ -3031,9 +3028,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.102.0.tgz",
-      "integrity": "sha512-KXs/y/bCVTxRy6NbgC2kK2JwmYnu4+EcDu+DVpHHIfiRgClTca++jYEqcxkthqK9ufkCgwMmrhb3tllyw5l1dw==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.103.1.tgz",
+      "integrity": "sha512-VSKFfhI//AOct6ppFmAaSH7tlW2LOFECMGs77jIoWf0ZjvGch/3sc9lUTTdIaYIOnTS4qpZck+8OcI2D0G92QA==",
       "cpu": [
         "x64"
       ],
@@ -3048,9 +3045,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.102.0.tgz",
-      "integrity": "sha512-1nqC2lrn91fjEsf6gSr/KigU15FrhUSDGWdSWowLXvNG8KbYUNRKjfypn+8u4P0SrL+R/v4VSVZguZiVVTI94A==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.103.1.tgz",
+      "integrity": "sha512-tJRLPUtBwXHTnBnG7I39gQvCLreuOHLLCMyKHPR1hQ7aFNwiZjADYzKMRQPNMUqti/Os9z+6I7V13FqgQHfuzg==",
       "cpu": [
         "arm"
       ],
@@ -3066,9 +3063,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.102.0.tgz",
-      "integrity": "sha512-Yg3Ga1deV+igVqjyK5gHMKbC6fdtKkVYBnzkPVbn/W2/DeActR2JFBfMwVtZJdLpNneMye3dRzOVO2QFegsTbQ==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.103.1.tgz",
+      "integrity": "sha512-rC+80/Xr9svo0ka2Zr/sjD+N1zEHTw2Urm/nsEjaVp5HSH2i22jwhTKTIqie2OLl6ti+qdYnbI0sSfxOYRtgrg==",
       "cpu": [
         "arm64"
       ],
@@ -3084,9 +3081,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.102.0.tgz",
-      "integrity": "sha512-WULwlrLbhHsJzGBcfztoXK47VyJugcWDmLXF893+yrMj6dF4/zJP6JqootT3EmAx9JAUdAppXI6ma7aGlnV8jw==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.103.1.tgz",
+      "integrity": "sha512-N8L/kgVzXpnH+8d6ErIzqvb0l8kHODR3OfPaf0Azw6DOLGtEjwDRUbHno+G7iogGzyPOjKsM8OdyqHJj/bpTdw==",
       "cpu": [
         "arm"
       ],
@@ -3102,9 +3099,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.102.0.tgz",
-      "integrity": "sha512-UFvRNJcYFOqo0X525vXG3Buue+waoqiG58xx7J6tMHSj5K/38t+9YbbgppKGLRoKoAwZTIdW8pxPA8qBSzQC6Q==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.103.1.tgz",
+      "integrity": "sha512-jMgG/C/VMo7+ShMFdk0xjJmQmYkj1PbJu/yrQiaQHpuo5pE2G+vnkEgsuM5EM3lTQ4MbMfnf715qy1fkbNPiUQ==",
       "cpu": [
         "arm64"
       ],
@@ -3120,9 +3117,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-riscv64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.102.0.tgz",
-      "integrity": "sha512-7EmAMt5cX0SEN/qTNHD4VBHyjJXmFMAGuNR9R4YJR/SWGj/OZJw9VWryMfzEnMgNbG6HykiIttGfr9CyNKmZbA==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.103.1.tgz",
+      "integrity": "sha512-LZm8rEvI6sKU87qPOlODsYeAs7CmWy0B4ShYkjG4OMcGCcV4Ffxn25XW4TFqmruThITQvJ8WT+WGblzdoxYgbA==",
       "cpu": [
         "riscv64"
       ],
@@ -3138,9 +3135,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.102.0.tgz",
-      "integrity": "sha512-HHzU5/g/MT1edbHfDzZleKcX19l6LMGk0KhZFLy66cxQl1iRLUaL22jfGstmHOdRUmVzWF3VevjSflSGvAjr4Q==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.103.1.tgz",
+      "integrity": "sha512-rmKzgk4t6RpaDhSefbbnk5yrA4pk1nHlVhJECGay8yMfzK8eglATeY9fzPgt89xCuQk6rkOiy11e+m8tLYOW5Q==",
       "cpu": [
         "x64"
       ],
@@ -3156,9 +3153,9 @@
       }
     },
     "node_modules/sass-embedded-linux-riscv64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.102.0.tgz",
-      "integrity": "sha512-AUc4wHQ7IUo9/0mcZQn7Xkl1t1+NZlTF+v5i3GX93HNoQUGIFic7q6qjSERLkdwQ0dLnWrMqe8KhV98V8v0ZoA==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.103.1.tgz",
+      "integrity": "sha512-xydQmtxla31uMrmN6z+mAogVGdEMDmkUElVq2+udomX/TPZDYJBkApEyJl237M2VLWVv29v1N4U4i2Z4xa7SDA==",
       "cpu": [
         "riscv64"
       ],
@@ -3174,9 +3171,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.102.0.tgz",
-      "integrity": "sha512-CxfhMwwbQFBCTjGysByvOw4PIOCYZ/jtz9uBU0UR5sfHtQvqqnsNyb1fVCIUsZ7piimxQAwcLV5H3Skj96QiVg==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.103.1.tgz",
+      "integrity": "sha512-Rln1oWm0MWKzzemOgQWrRFzfVBARwS9qxAidZPpCQHSohzPnWizFkmY1CUJad/YJNsA7sscueMdX63OEvxoM8w==",
       "cpu": [
         "x64"
       ],
@@ -3192,9 +3189,9 @@
       }
     },
     "node_modules/sass-embedded-unknown-all": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.102.0.tgz",
-      "integrity": "sha512-qhqfvFD/7X0c6e5rwvzABkGlaYJju1G+hDPCiB0HdK+S7JF+YDDb9XpRYJ9+tGIopWzEHhoNnJDPtPs9IX1lOQ==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.103.1.tgz",
+      "integrity": "sha512-p7kI4US8+n+YguKczXh+4KcodJnk+8cwv+QFdvMaz3OfPrdHV0EnhPsaVDWD9qXb1XXCEdUhpp6vQwGk3eKc3A==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3205,13 +3202,13 @@
         "!win32"
       ],
       "dependencies": {
-        "sass": "1.102.0"
+        "sass": "1.103.1"
       }
     },
     "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.102.0.tgz",
-      "integrity": "sha512-EQOTKStMf7ervyhe3AX10Pa6F7CQMN3IgmpBkfgjy9HQG4Iyt34zCl/4vNJLVBWLW03b7/KJacy2I9SRz26X9g==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.103.1.tgz",
+      "integrity": "sha512-/0renOj3SpZGu4TA8CZJ6qZbTxGZk1khkPfiBTmV1uFB40ESYM5VsdXNj76P07bsAjIj9X2fCjTafLQFLSd9Nw==",
       "cpu": [
         "arm64"
       ],
@@ -3226,9 +3223,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.102.0.tgz",
-      "integrity": "sha512-e+26mgR+O4g/m7r+WGuvygsjgZEsfgWntIOgaNhkSa9b7vVas70l2RB/SipUM4zGXQk1jX06aOEz0w0Pq1pprQ==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.103.1.tgz",
+      "integrity": "sha512-fIg60j9u5YlLUU3W8FvySMR4HHIo9R12HHFQTW7njyQ8nXqgR+t+XfCzGJloQka8g583BlAfu31Q76Ljr5o+9g==",
       "cpu": [
         "x64"
       ],
@@ -3424,22 +3421,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.4.tgz",
-      "integrity": "sha512-kFXFK7O4WPextIUAOk8qtnw9dxR9UIXP9CjuH1cTBVBZMDeQcUPgr/IazGiw1B0Yiw5L75gHLWeW4iD793r90g==",
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.4"
+        "tldts-core": "^7.4.10"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.4.tgz",
-      "integrity": "sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==",
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3457,9 +3454,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3525,13 +3522,13 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -92,18 +92,18 @@
     "zzz": "echo 'This is just a placeholder that is the last script in this script collection.'"
   },
   "devDependencies": {
-    "@cspell/dict-fr-fr": "^2.3.2",
-    "@pchalin/markdownlint-rule-link-pattern": "^0.3.0",
+    "@cspell/dict-fr-fr": "2.3.2",
+    "@pchalin/markdownlint-rule-link-pattern": "0.3.0",
     "hugo-extended": "0.164.0",
-    "jsdom": "^29.1.1",
-    "markdownlint-cli2": "^0.23.2",
-    "markdownlint-rule-no-shortcut-ref-link": "^0.3.1",
+    "jsdom": "30.0.1",
+    "markdownlint-cli2": "0.23.2",
+    "markdownlint-rule-no-shortcut-ref-link": "0.4.0",
     "pixelmatch": "7.2.0",
     "pngjs": "7.0.0",
-    "prettier": "^3.9.3",
-    "puppeteer": "25.5.0",
-    "sass-embedded": "1.102.0",
-    "yaml": "^2.9.0"
+    "prettier": "3.9.3",
+    "puppeteer": "25.8.0",
+    "sass-embedded": "1.103.1",
+    "yaml": "2.9.0"
   },
   "engines": {
     "node": ">=24",


### PR DESCRIPTION
- Closes #2761, closes #2762, closes #2763, closes #2764, closes #2765, closes #2766, closes #2768, closes #2769, closes #2771
- **Folds the nine open Renovate PRs** into one post-0.17.0 change: maintainer-side and CI-only, `theme/` deps untouched
- **Pins first** (#2761's policy), so the version bumps land as exact pins; single lockfile regen under the repo's `ignore-scripts` + 7-day-cooldown `.npmrc`
- **Majors vetted**: jsdom v30 (Node >=24 floor met), npm-check-updates v23 (`update:packages` flag surface verified, and v23 natively honors the `.npmrc` cooldown), checkout/setup-node v7 (ESM; fine on GH-hosted runners)
- Full test suite green locally (241 pass / 0 fail)
