### PR TITLE
Renovate: group patch and minor updates

### DIFF
--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -190,6 +190,8 @@ Automated updates are configured through Renovate. Settings rationale:
 - `lockFileMaintenance` off: wholesale lock re-resolves would churn the
   committed lockfiles; transitive security fixes arrive alert-driven instead.
 - Package rules:
+  - Patch and minor updates are each grouped into a single PR per wave, to cut
+    review overhead; majors stay individual for one-by-one scrutiny.
   - `hugo-extended` updates are [carefully chosen](#official-hugo-version) at
     Docsy release time.
   - Bootstrap and Font Awesome are updated deliberately via

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,6 +10,14 @@
   minimumReleaseAge: '7 days',
   packageRules: [
     {
+      groupName: 'all patch versions',
+      matchUpdateTypes: ['patch'],
+    },
+    {
+      groupName: 'all minor versions',
+      matchUpdateTypes: ['minor'],
+    },
+    {
       matchPackageNames: ['hugo-extended'],
       enabled: false,
     },


### PR DESCRIPTION
- **Groups** patch updates and minor updates into one Renovate PR each per weekly wave, mirroring opentelemetry.io's config; majors stay individual, except families Renovate's presets keep in lockstep (e.g. the GitHub artifact actions)
- **Motivation**: on the 08-30 wave, grouping would have turned its 9 PRs into 6
- **Scope notes**:
  - CDN-pinned script deps (the JSONata custom manager) deliberately stay in the groups
  - otel.io's patch-automerge is not ported: it conflicts with this repo's required-approval protection
