### PR TITLE
Add the scheduled link-cache-refresh workflow

### DIFF
--- a/.github/workflows/link-cache-refresh.yaml
+++ b/.github/workflows/link-cache-refresh.yaml
@@ -10,9 +10,9 @@
 # current with main and re-runs the check (refreshing the PR body), but
 # prunes further only when dispatched with prune_more set. If the branch
 # exists without an open same-repo PR, it is reset to main and treated as
-# new. A merge conflict confined to the link cache self-heals (main's
-# version wins; the run's own check refreshes it); any wider conflict fails
-# the run for a human.
+# new. A merge conflict confined to the link cache self-heals: main's whole
+# cache wins — which voids the branch's pending refresh, so the run
+# re-prunes to redo it; any wider conflict fails the run for a human.
 #
 # When pruning ran but the refresh changed nothing, the run fails: an empty
 # refresh after pruning means the workflow is broken.
@@ -36,7 +36,7 @@ on:
     inputs:
       refresh_count:
         description: Number of (oldest) link-cache entries to refresh.
-        default: 75
+        default: &default_refresh_count 75
         type: number
       prune_more:
         description: Prune more entries from the existing PR branch (if any).
@@ -61,7 +61,9 @@ jobs:
     env:
       BRANCH: bot/link-cache-refresh
       CACHE_FILE: docsy.dev/link-cache.jsonc
-      REFRESH_COUNT: ${{ github.event.inputs.refresh_count || 75 }}
+      # Empty on scheduled runs; consumers fall back to the anchored default.
+      REFRESH_COUNT: ${{ github.event.inputs.refresh_count }}
+      DEFAULT_REFRESH_COUNT: *default_refresh_count
       PRUNE_MORE: ${{ github.event.inputs.prune_more || 'false' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -71,8 +73,9 @@ jobs:
 
       - name: Validate inputs
         run: |
-          if [[ ! "$REFRESH_COUNT" =~ ^[0-9]+$ || "$REFRESH_COUNT" -eq 0 ]]; then
-            echo "Error: refresh_count must be a positive number, got: $REFRESH_COUNT"
+          count="${REFRESH_COUNT:-$DEFAULT_REFRESH_COUNT}"
+          if [[ ! "$count" =~ ^[0-9]+$ || "$count" -eq 0 ]]; then
+            echo "Error: refresh_count must be a positive number, got: $count"
             exit 1
           fi
 
@@ -81,6 +84,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # pipefail: a gh API failure in pr_url must fail the run, not read
+          # as "no open PR" and trigger the reset below. head never SIGPIPEs
+          # here: the jq-filtered output is at most a few lines.
+          set -o pipefail
           # Authenticated pushes go to the origin remote (so tracking refs
           # update) with a command-scoped auth header; the remote config
           # itself stays credential-free.
@@ -121,18 +128,22 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
       - name: Merge from main
+        id: merge
         run: |
           git fetch origin
           if ! git merge origin/main; then
             # A conflict confined to the link cache self-heals: take main's
-            # version; this run's own check refreshes it either way. Any
-            # wider conflict needs a human.
+            # whole cache file. That voids this branch's pending refresh
+            # (main's entries keep their old timestamps, which lychee trusts
+            # within max_cache_age), so signal the prune step to redo it.
+            # Any wider conflict needs a human.
             conflicts=$(git diff --name-only --diff-filter=U)
             if [[ "$conflicts" == "$CACHE_FILE" ]]; then
-              echo "Cache-only merge conflict: taking main's version."
+              echo "Cache-only merge conflict: taking main's version and re-pruning."
               git checkout --theirs "$CACHE_FILE"
               git add "$CACHE_FILE"
               git commit --no-edit
+              echo "self_healed=true" >> "$GITHUB_OUTPUT"
             else
               echo "::error::Merge from main conflicts beyond the link" \
                 "cache ($conflicts): resolve manually."
@@ -164,10 +175,11 @@ jobs:
         id: prune
         if:
           ${{ env.PRUNE_MORE == 'true' || steps.branch.outputs.is_new == 'true'
-          }}
+          || steps.merge.outputs.self_healed == 'true' }}
         run: |
-          echo "Oldest entry before pruning, then pruning $REFRESH_COUNT oldest entries:"
-          npm run link-cache -- --list 1 --prune "$REFRESH_COUNT"
+          count="${REFRESH_COUNT:-$DEFAULT_REFRESH_COUNT}"
+          echo "Oldest entry before pruning, then pruning $count oldest entries:"
+          npm run link-cache -- --list 1 --prune "$count"
           echo "did_prune=true" >> "$GITHUB_OUTPUT"
 
       - name: Build the site
@@ -239,7 +251,7 @@ jobs:
           # Cache data flows into Markdown here: strip backticks so a
           # hostile URL can't escape the inline-code span.
           entry=${OLDEST_ENTRY//\`/}
-          PR_BODY="Refreshes the oldest ${REFRESH_COUNT} lychee-verified link-cache entries; see the link-cache-refresh workflow header for the model."
+          PR_BODY="Refreshes the oldest lychee-verified link-cache entries (default $DEFAULT_REFRESH_COUNT per rotation); see the link-cache-refresh workflow header for the model."
           PR_BODY="$PR_BODY"$'\n\n'"Oldest entry after this refresh:"$'\n'"\`${entry}\`"
           if [[ "${DEAD_LINKS:-false}" == 'true' ]]; then
             PR_BODY="$PR_BODY"$'\n\n'"The refresh found failing links, recorded with negative statuses in the cache diff: triage before merging."

--- a/.github/workflows/link-cache-refresh.yaml
+++ b/.github/workflows/link-cache-refresh.yaml
@@ -5,22 +5,27 @@
 # refresh PRs merge roughly daily); manual (seeded) entries are exempt from
 # pruning and retire via their expires dates.
 #
-# There is at most one refresh PR at a time (branch bot/link-cache-refresh):
-# a scheduled run while the PR is open brings the branch current with main
-# and re-runs the check (refreshing the PR body), but prunes further only
-# when dispatched with prune_more set. If the branch exists without an open
-# same-repo PR, it is reset to main and treated as new.
+# There is at most one refresh PR at a time (branch bot/link-cache-refresh,
+# PR against main): a scheduled run while the PR is open brings the branch
+# current with main and re-runs the check (refreshing the PR body), but
+# prunes further only when dispatched with prune_more set. If the branch
+# exists without an open same-repo PR, it is reset to main and treated as
+# new. A merge conflict confined to the link cache self-heals (main's
+# version wins; the run's own check refreshes it); any wider conflict fails
+# the run for a human.
 #
 # When pruning ran but the refresh changed nothing, the run fails: an empty
 # refresh after pruning means the workflow is broken.
 #
-# Token notes: the PR is created with the workflow's GITHUB_TOKEN, so the
-# repo's regular CI does not auto-run on it (GitHub suppresses
-# workflow-triggered workflows); the link check that matters runs here, and a
-# maintainer review gates the merge. The same token (with this job's write
-# permissions) is exposed to lychee for authenticated github.com checks; the
-# lychee binary is release-pinned and checksum-verified, and the alternative
-# (a separate app/bot token) is deliberately out of scope for this repo.
+# Token notes: the checkout is credential-free; pushes authenticate
+# per-command through a step-scoped auth header. The PR is created with the
+# workflow's GITHUB_TOKEN, so the repo's regular CI does not auto-run on it
+# (GitHub suppresses workflow-triggered workflows); the link check that
+# matters runs here, and a maintainer review gates the merge. The same token
+# (with this job's write permissions) is exposed to lychee for authenticated
+# github.com checks; the lychee binary is release-pinned and
+# checksum-verified, and the alternative (a separate app/bot token) is
+# deliberately out of scope for this repo.
 
 name: link-cache-refresh
 
@@ -55,11 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BRANCH: bot/link-cache-refresh
+      CACHE_FILE: docsy.dev/link-cache.jsonc
       REFRESH_COUNT: ${{ github.event.inputs.refresh_count || 75 }}
       PRUNE_MORE: ${{ github.event.inputs.prune_more || 'false' }}
-      PUSH_REMOTE:
-        https://x-access-token:${{ github.token }}@github.com/${{
-        github.repository }}.git
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -78,30 +81,37 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Only a same-repo PR counts: a fork can open a same-named branch,
-          # and matching it would strand the refresh commits.
+          # Authenticated pushes go to the origin remote (so tracking refs
+          # update) with a command-scoped auth header; the remote config
+          # itself stays credential-free.
+          auth=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)
+          auth_push() {
+            git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth" push "$@"
+          }
+          # Only the same-repo PR against main counts: a fork can open a
+          # same-named branch, and a same-repo PR against another base is
+          # not the refresh PR.
           pr_url() {
-            gh pr list --state open --head "$BRANCH" \
+            gh pr list --state open --base main --head "$BRANCH" \
               --json url,isCrossRepository \
-              --jq '.[] | select(.isCrossRepository == false) | .url'
+              --jq '.[] | select(.isCrossRepository == false) | .url' \
+              | head -n1
           }
           if ! git ls-remote --exit-code --heads origin "$BRANCH"; then
             echo "is_new=true" >> "$GITHUB_OUTPUT"
             git checkout -b "$BRANCH" origin/main
-            git push "$PUSH_REMOTE" "$BRANCH"
+            auth_push origin "$BRANCH"
           else
             git checkout "$BRANCH"
             PR_URL=$(pr_url)
             if [[ -n "$PR_URL" ]]; then
               echo "Branch PR: $PR_URL"
             else
-              echo "Branch has no open same-repo PR: resetting it to" \
-                "origin/main and treating it as a new branch."
+              echo "Branch has no open same-repo PR against main: resetting" \
+                "it to origin/main and treating it as a new branch."
               echo "is_new=true" >> "$GITHUB_OUTPUT"
-              expected=$(git rev-parse "origin/$BRANCH")
               git reset --hard origin/main
-              git push --force-with-lease="$BRANCH:$expected" \
-                "$PUSH_REMOTE" "$BRANCH"
+              auth_push --force-with-lease origin "$BRANCH"
             fi
           fi
 
@@ -113,7 +123,22 @@ jobs:
       - name: Merge from main
         run: |
           git fetch origin
-          git merge origin/main
+          if ! git merge origin/main; then
+            # A conflict confined to the link cache self-heals: take main's
+            # version; this run's own check refreshes it either way. Any
+            # wider conflict needs a human.
+            conflicts=$(git diff --name-only --diff-filter=U)
+            if [[ "$conflicts" == "$CACHE_FILE" ]]; then
+              echo "Cache-only merge conflict: taking main's version."
+              git checkout --theirs "$CACHE_FILE"
+              git add "$CACHE_FILE"
+              git commit --no-edit
+            else
+              echo "::error::Merge from main conflicts beyond the link" \
+                "cache ($conflicts): resolve manually."
+              exit 1
+            fi
+          fi
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
@@ -145,19 +170,24 @@ jobs:
           npm run link-cache -- --list 1 --prune "$REFRESH_COUNT"
           echo "did_prune=true" >> "$GITHUB_OUTPUT"
 
-      - name: Build the site and refresh the link cache
+      - name: Build the site
+        run: npm run -C docsy.dev build
+
+      - name: Refresh the link cache
         id: check
         env:
           # Authenticated github.com checks (rate limits); see the header's
           # token notes.
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          # Exit 1 (dead links) doesn't fail the run: the merge-back has
-          # already recorded the failures in the owned cache, and the PR is
-          # where a maintainer triages them. Exit 2 (preflight: tool/config
-          # broken, zero links verified) is a workflow defect: fail hard.
+          # The build already succeeded (previous step, fails hard), so the
+          # exit code here is the link checker's own contract. Exit 1 (dead
+          # links) doesn't fail the run: the merge-back has already recorded
+          # the failures in the owned cache, and the PR is where a maintainer
+          # triages them. Exit 2 (preflight: tool/config broken, zero links
+          # verified) is a workflow defect: fail hard.
           LINK_CHECK_STATUS=0
-          npm run -C docsy.dev check:links || LINK_CHECK_STATUS=$?
+          npm run -C docsy.dev _check:links || LINK_CHECK_STATUS=$?
           echo "Link check exit status: $LINK_CHECK_STATUS"
           if [[ "$LINK_CHECK_STATUS" -ge 2 ]]; then
             exit "$LINK_CHECK_STATUS"
@@ -168,14 +198,20 @@ jobs:
       - name: Report the oldest entry after the refresh
         id: oldest
         run: |
-          npm run link-cache -- --list 1
-          echo "entry=$(npm run -s link-cache -- --list 1 | grep '^ ' | head -n1)" >> "$GITHUB_OUTPUT"
+          entry=$(npm run -s link-cache -- --list 1 | grep -m1 '^ ' || true)
+          if [[ -z "$entry" ]]; then
+            echo "::error::Reading the oldest cache entry failed: the cache" \
+              "or the list output format is broken."
+            exit 1
+          fi
+          echo "Oldest entry after the refresh: $entry"
+          echo "entry=$entry" >> "$GITHUB_OUTPUT"
 
       - name: Commit link-cache updates
         env:
           DID_PRUNE: ${{ steps.prune.outputs.did_prune }}
         run: |
-          git add docsy.dev/link-cache.jsonc
+          git add "$CACHE_FILE"
           if ! git diff-index --quiet --cached HEAD; then
             git commit -m 'Refresh link cache'
           elif [[ "${DID_PRUNE:-false}" == 'true' ]]; then
@@ -185,9 +221,13 @@ jobs:
           fi
 
       - name: Push, if the branch has anything new
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [[ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$BRANCH")" ]]; then
-            git push "$PUSH_REMOTE" "HEAD:$BRANCH"
+            auth=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)
+            git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth" \
+              push origin "HEAD:$BRANCH"
           fi
 
       - name: Create the PR, or refresh its body
@@ -196,18 +236,22 @@ jobs:
           DEAD_LINKS: ${{ steps.check.outputs.dead_links }}
           OLDEST_ENTRY: ${{ steps.oldest.outputs.entry }}
         run: |
+          # Cache data flows into Markdown here: strip backticks so a
+          # hostile URL can't escape the inline-code span.
+          entry=${OLDEST_ENTRY//\`/}
           PR_BODY="Refreshes the oldest ${REFRESH_COUNT} lychee-verified link-cache entries; see the link-cache-refresh workflow header for the model."
-          PR_BODY="$PR_BODY"$'\n\n'"Oldest entry after this refresh:"$'\n'"\`${OLDEST_ENTRY:-none}\`"
+          PR_BODY="$PR_BODY"$'\n\n'"Oldest entry after this refresh:"$'\n'"\`${entry}\`"
           if [[ "${DEAD_LINKS:-false}" == 'true' ]]; then
             PR_BODY="$PR_BODY"$'\n\n'"The refresh found failing links, recorded with negative statuses in the cache diff: triage before merging."
           fi
-          PR_URL=$(gh pr list --state open --head "$BRANCH" \
+          PR_URL=$(gh pr list --state open --base main --head "$BRANCH" \
             --json url,isCrossRepository \
-            --jq '.[] | select(.isCrossRepository == false) | .url')
+            --jq '.[] | select(.isCrossRepository == false) | .url' \
+            | head -n1)
           if [[ -n "$PR_URL" ]]; then
             echo "Refreshing the body of $PR_URL"
             gh pr edit "$PR_URL" --body "$PR_BODY"
             exit 0
           fi
-          gh pr create --title 'Refresh link cache' --body "$PR_BODY"
-          gh pr view --json url --jq '.url'
+          gh pr create --base main --head "$BRANCH" \
+            --title 'Refresh link cache' --body "$PR_BODY"

--- a/.github/workflows/link-cache-refresh.yaml
+++ b/.github/workflows/link-cache-refresh.yaml
@@ -1,21 +1,26 @@
 # Opens (or updates) the PR that refreshes the oldest entries of the
 # committed link cache (docsy.dev/link-cache.jsonc). Pruning the N oldest
 # lychee-verified entries and re-running the link checker re-verifies them,
-# rotating through the full cache over a few weeks; manual (seeded) entries
-# are exempt from pruning and retire via their expires date.
+# rotating through the lychee-verified entries over a few weeks (assuming
+# refresh PRs merge roughly daily); manual (seeded) entries are exempt from
+# pruning and retire via their expires dates.
 #
 # There is at most one refresh PR at a time (branch bot/link-cache-refresh):
-# a scheduled run while the PR is open only brings the branch current with
-# main; it prunes further only when dispatched with prune_more set. If the
-# branch exists without an open PR, it is reset to main and treated as new.
+# a scheduled run while the PR is open brings the branch current with main
+# and re-runs the check (refreshing the PR body), but prunes further only
+# when dispatched with prune_more set. If the branch exists without an open
+# same-repo PR, it is reset to main and treated as new.
 #
-# When pruning ran but the run ends with nothing to commit, the run fails: an
-# empty refresh after pruning means the workflow is broken.
+# When pruning ran but the refresh changed nothing, the run fails: an empty
+# refresh after pruning means the workflow is broken.
 #
-# PRs are created with the workflow's GITHUB_TOKEN, so the repo's regular CI
-# does not auto-run on them (GitHub suppresses workflow-triggered workflows);
-# the link check that matters runs in this workflow, and a maintainer review
-# gates the merge.
+# Token notes: the PR is created with the workflow's GITHUB_TOKEN, so the
+# repo's regular CI does not auto-run on it (GitHub suppresses
+# workflow-triggered workflows); the link check that matters runs here, and a
+# maintainer review gates the merge. The same token (with this job's write
+# permissions) is exposed to lychee for authenticated github.com checks; the
+# lychee binary is release-pinned and checksum-verified, and the alternative
+# (a separate app/bot token) is deliberately out of scope for this repo.
 
 name: link-cache-refresh
 
@@ -50,14 +55,16 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BRANCH: bot/link-cache-refresh
-      IS_NEW_BRANCH: 'false'
       REFRESH_COUNT: ${{ github.event.inputs.refresh_count || 75 }}
       PRUNE_MORE: ${{ github.event.inputs.prune_more || 'false' }}
+      PUSH_REMOTE:
+        https://x-access-token:${{ github.token }}@github.com/${{
+        github.repository }}.git
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          persist-credentials: true # zizmor: ignore[artipacked] Required by this job's later git pushes.
+          persist-credentials: false
 
       - name: Validate inputs
         run: |
@@ -67,24 +74,34 @@ jobs:
           fi
 
       - name: Checkout or create the refresh branch
+        id: branch
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Only a same-repo PR counts: a fork can open a same-named branch,
+          # and matching it would strand the refresh commits.
+          pr_url() {
+            gh pr list --state open --head "$BRANCH" \
+              --json url,isCrossRepository \
+              --jq '.[] | select(.isCrossRepository == false) | .url'
+          }
           if ! git ls-remote --exit-code --heads origin "$BRANCH"; then
-            echo "IS_NEW_BRANCH=true" >> "$GITHUB_ENV"
+            echo "is_new=true" >> "$GITHUB_OUTPUT"
             git checkout -b "$BRANCH" origin/main
-            git push -u origin "$BRANCH"
+            git push "$PUSH_REMOTE" "$BRANCH"
           else
             git checkout "$BRANCH"
-            PR_URL=$(gh pr list --state open --head "$BRANCH" --json url --jq '.[].url')
+            PR_URL=$(pr_url)
             if [[ -n "$PR_URL" ]]; then
               echo "Branch PR: $PR_URL"
             else
-              echo "Branch has no open PR: resetting it to origin/main" \
-                "and treating it as a new branch."
-              echo "IS_NEW_BRANCH=true" >> "$GITHUB_ENV"
+              echo "Branch has no open same-repo PR: resetting it to" \
+                "origin/main and treating it as a new branch."
+              echo "is_new=true" >> "$GITHUB_OUTPUT"
+              expected=$(git rev-parse "origin/$BRANCH")
               git reset --hard origin/main
-              git push --force-with-lease origin "$BRANCH"
+              git push --force-with-lease="$BRANCH:$expected" \
+                "$PUSH_REMOTE" "$BRANCH"
             fi
           fi
 
@@ -95,13 +112,8 @@ jobs:
 
       - name: Merge from main
         run: |
-          previous=$(git rev-parse HEAD)
           git fetch origin
           git merge origin/main
-          if [[ "$(git rev-parse HEAD)" != "$previous" ]]; then
-            echo "Merged from main; the push below carries it."
-            echo "NEEDS_PUSH=true" >> "$GITHUB_ENV"
-          fi
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
@@ -113,24 +125,31 @@ jobs:
       - name: Install lychee
         env:
           LYCHEE_VERSION: v0.24.2
+          LYCHEE_SHA256: 1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
         run: |
           tmp="$(mktemp -d)"
-          curl -sfL "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
-            | tar -xz -C "$tmp"
+          curl -sfL -o "$tmp/lychee.tar.gz" \
+            "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${LYCHEE_SHA256}  $tmp/lychee.tar.gz" | sha256sum -c -
+          tar -xzf "$tmp/lychee.tar.gz" -C "$tmp"
           install -D "$(find "$tmp" -type f -name lychee | head -n1)" "$HOME/.local/bin/lychee"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          lychee --version
 
       - name: Prune link cache
-        if: ${{ env.PRUNE_MORE == 'true' || env.IS_NEW_BRANCH == 'true' }}
+        id: prune
+        if:
+          ${{ env.PRUNE_MORE == 'true' || steps.branch.outputs.is_new == 'true'
+          }}
         run: |
           echo "Oldest entry before pruning, then pruning $REFRESH_COUNT oldest entries:"
           npm run link-cache -- --list 1 --prune "$REFRESH_COUNT"
-          echo "DID_PRUNE=true" >> "$GITHUB_ENV"
+          echo "did_prune=true" >> "$GITHUB_OUTPUT"
 
       - name: Build the site and refresh the link cache
+        id: check
         env:
-          # Authenticated github.com checks (rate limits)
+          # Authenticated github.com checks (rate limits); see the header's
+          # token notes.
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           # Exit 1 (dead links) doesn't fail the run: the merge-back has
@@ -143,45 +162,52 @@ jobs:
           if [[ "$LINK_CHECK_STATUS" -ge 2 ]]; then
             exit "$LINK_CHECK_STATUS"
           elif [[ "$LINK_CHECK_STATUS" -eq 1 ]]; then
-            echo "DEAD_LINKS_FOUND=true" >> "$GITHUB_ENV"
+            echo "dead_links=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Report the oldest entry after the refresh
-        run: npm run link-cache -- --list 1
+        id: oldest
+        run: |
+          npm run link-cache -- --list 1
+          echo "entry=$(npm run -s link-cache -- --list 1 | grep '^ ' | head -n1)" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push link-cache updates, if any
+      - name: Commit link-cache updates
+        env:
+          DID_PRUNE: ${{ steps.prune.outputs.did_prune }}
         run: |
           git add docsy.dev/link-cache.jsonc
           if ! git diff-index --quiet --cached HEAD; then
             git commit -m 'Refresh link cache'
-          fi
-          if [[ "${NEEDS_PUSH:-false}" == 'true' ]] || ! git diff --quiet "origin/$BRANCH"; then
-            git push origin "$BRANCH"
+          elif [[ "${DID_PRUNE:-false}" == 'true' ]]; then
+            echo "::error::Pruning ran but the refresh changed nothing: an" \
+              "empty refresh after pruning means the workflow is broken."
+            exit 1
           fi
 
-      - name: Create the PR if needed
+      - name: Push, if the branch has anything new
+        run: |
+          if [[ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$BRANCH")" ]]; then
+            git push "$PUSH_REMOTE" "HEAD:$BRANCH"
+          fi
+
+      - name: Create the PR, or refresh its body
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_BODY: |-
-            Refreshes the oldest ${{ env.REFRESH_COUNT }} link-cache entries;
-            see the link-cache-refresh workflow header for the model.
+          DEAD_LINKS: ${{ steps.check.outputs.dead_links }}
+          OLDEST_ENTRY: ${{ steps.oldest.outputs.entry }}
         run: |
-          if [[ "${DEAD_LINKS_FOUND:-false}" == 'true' ]]; then
+          PR_BODY="Refreshes the oldest ${REFRESH_COUNT} lychee-verified link-cache entries; see the link-cache-refresh workflow header for the model."
+          PR_BODY="$PR_BODY"$'\n\n'"Oldest entry after this refresh:"$'\n'"\`${OLDEST_ENTRY:-none}\`"
+          if [[ "${DEAD_LINKS:-false}" == 'true' ]]; then
             PR_BODY="$PR_BODY"$'\n\n'"The refresh found failing links, recorded with negative statuses in the cache diff: triage before merging."
           fi
-          prs=$(gh pr list --state open --head "$BRANCH")
-          if [[ -n "$prs" ]]; then
-            echo "PR already exists:"
-            echo "$prs"
+          PR_URL=$(gh pr list --state open --head "$BRANCH" \
+            --json url,isCrossRepository \
+            --jq '.[] | select(.isCrossRepository == false) | .url')
+          if [[ -n "$PR_URL" ]]; then
+            echo "Refreshing the body of $PR_URL"
+            gh pr edit "$PR_URL" --body "$PR_BODY"
             exit 0
           fi
-
-          if gh pr create --title 'Refresh link cache' --body "$PR_BODY"; then
-            gh pr view --json url --jq '.url'
-          elif [[ "${DID_PRUNE:-false}" == 'true' ]]; then
-            echo "::error::Pruning ran but produced no PR: an empty refresh" \
-              "after pruning means the workflow is broken."
-            exit 1
-          else
-            echo "No changes to PR."
-          fi
+          gh pr create --title 'Refresh link cache' --body "$PR_BODY"
+          gh pr view --json url --jq '.url'

--- a/.github/workflows/link-cache-refresh.yaml
+++ b/.github/workflows/link-cache-refresh.yaml
@@ -1,9 +1,10 @@
 # Opens (or updates) the PR that refreshes the oldest entries of the
 # committed link cache (docsy.dev/link-cache.jsonc). Pruning the N oldest
-# lychee-verified entries and re-running the link checker re-verifies them,
-# rotating through the lychee-verified entries over a few weeks (assuming
-# refresh PRs merge roughly daily); manual (seeded) entries are exempt from
-# pruning and retire via their expires dates.
+# lychee-verified entries and re-running the link checker re-verifies them
+# (or retires URLs no longer in the site), rotating through the
+# lychee-verified entries over a few weeks (assuming refresh PRs merge
+# roughly daily); manual (seeded) entries are exempt from pruning and retire
+# via their expires dates.
 #
 # There is at most one refresh PR at a time (branch bot/link-cache-refresh,
 # PR against main): a scheduled run while the PR is open brings the branch
@@ -14,8 +15,11 @@
 # cache wins — which voids the branch's pending refresh, so the run
 # re-prunes to redo it; any wider conflict fails the run for a human.
 #
-# When pruning ran but the refresh changed nothing, the run fails: an empty
-# refresh after pruning means the workflow is broken.
+# When pruning turned out to be a no-op (nothing eligible to prune), the run
+# fails: rotation throughput silently reaching zero means the workflow or
+# the cache is broken. (A prune that removed entries always changes the
+# file; catching "pruned but not re-verified" is the link checker's job —
+# its zero-verdict runs exit 2 above.)
 #
 # Token notes: the checkout is credential-free; pushes authenticate
 # per-command through a step-scoped auth header. The PR is created with the
@@ -192,6 +196,11 @@ jobs:
           # token notes.
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          # Guard against script drift: if _check:links is renamed, npm run
+          # exits 1 — indistinguishable from the dead-links exit below. The
+          # --help probe (exit 0 without lychee or a build) fails the run
+          # here instead, outside the tolerated-exit interpretation.
+          npm run -s -C docsy.dev _check:links -- --help > /dev/null
           # The build already succeeded (previous step, fails hard), so the
           # exit code here is the link checker's own contract. Exit 1 (dead
           # links) doesn't fail the run: the merge-back has already recorded
@@ -227,8 +236,10 @@ jobs:
           if ! git diff-index --quiet --cached HEAD; then
             git commit -m 'Refresh link cache'
           elif [[ "${DID_PRUNE:-false}" == 'true' ]]; then
-            echo "::error::Pruning ran but the refresh changed nothing: an" \
-              "empty refresh after pruning means the workflow is broken."
+            # Only reachable when the prune itself was a no-op (nothing
+            # eligible): a prune that removed entries always changes the file.
+            echo "::error::Pruning was a no-op: nothing eligible to prune" \
+              "means rotation throughput is zero; investigate."
             exit 1
           fi
 
@@ -248,11 +259,15 @@ jobs:
           DEAD_LINKS: ${{ steps.check.outputs.dead_links }}
           OLDEST_ENTRY: ${{ steps.oldest.outputs.entry }}
         run: |
+          # pipefail for the same reason as the branch step: a transient gh
+          # failure below must fail the run, not read as "no open PR" and
+          # duplicate-create.
+          set -o pipefail
           # Cache data flows into Markdown here: strip backticks so a
           # hostile URL can't escape the inline-code span.
           entry=${OLDEST_ENTRY//\`/}
           PR_BODY="Refreshes the oldest lychee-verified link-cache entries (default $DEFAULT_REFRESH_COUNT per rotation); see the link-cache-refresh workflow header for the model."
-          PR_BODY="$PR_BODY"$'\n\n'"Oldest entry after this refresh:"$'\n'"\`${entry}\`"
+          PR_BODY="$PR_BODY"$'\n\n'"Oldest entry after this refresh (prune-exempt manual seeds keep their dates, so one may sit here):"$'\n'"\`${entry}\`"
           if [[ "${DEAD_LINKS:-false}" == 'true' ]]; then
             PR_BODY="$PR_BODY"$'\n\n'"The refresh found failing links, recorded with negative statuses in the cache diff: triage before merging."
           fi

--- a/.github/workflows/link-cache-refresh.yaml
+++ b/.github/workflows/link-cache-refresh.yaml
@@ -1,35 +1,25 @@
 # Opens (or updates) the PR that refreshes the oldest entries of the
-# committed link cache (docsy.dev/link-cache.jsonc). Pruning the N oldest
-# lychee-verified entries and re-running the link checker re-verifies them
-# (or retires URLs no longer in the site), rotating through the
-# lychee-verified entries over a few weeks (assuming refresh PRs merge
-# roughly daily); manual (seeded) entries are exempt from pruning and retire
-# via their expires dates.
+# committed link cache (docsy.dev/link-cache.jsonc), maintained by the
+# link-cache npm package. Pruning the N oldest lychee-verified entries and
+# re-running the link checker re-verifies them (or retires URLs no longer in
+# the site), rotating through them over a few weeks (assuming refresh PRs
+# merge roughly daily); manual (seeded) entries are exempt from pruning and
+# retire via their expires dates.
 #
 # There is at most one refresh PR at a time (branch bot/link-cache-refresh,
 # PR against main): a scheduled run while the PR is open brings the branch
 # current with main and re-runs the check (refreshing the PR body), but
 # prunes further only when dispatched with prune_more set. If the branch
 # exists without an open same-repo PR, it is reset to main and treated as
-# new. A merge conflict confined to the link cache self-heals: main's whole
-# cache wins — which voids the branch's pending refresh, so the run
-# re-prunes to redo it; any wider conflict fails the run for a human.
+# new. Merge conflicts, tolerated exit codes, and push auth are handled
+# per-step; the step comments carry the rationale.
 #
-# When pruning turned out to be a no-op (nothing eligible to prune), the run
-# fails: rotation throughput silently reaching zero means the workflow or
-# the cache is broken. (A prune that removed entries always changes the
-# file; catching "pruned but not re-verified" is the link checker's job —
-# its zero-verdict runs exit 2 above.)
-#
-# Token notes: the checkout is credential-free; pushes authenticate
-# per-command through a step-scoped auth header. The PR is created with the
-# workflow's GITHUB_TOKEN, so the repo's regular CI does not auto-run on it
-# (GitHub suppresses workflow-triggered workflows); the link check that
-# matters runs here, and a maintainer review gates the merge. The same token
-# (with this job's write permissions) is exposed to lychee for authenticated
-# github.com checks; the lychee binary is release-pinned and
-# checksum-verified, and the alternative (a separate app/bot token) is
-# deliberately out of scope for this repo.
+# The PR is created with the workflow's GITHUB_TOKEN, so the repo's regular
+# CI does not auto-run on it (GitHub suppresses workflow-triggered
+# workflows); the link check that matters runs here, and a maintainer review
+# gates the merge. That token (with this job's write permissions) is exposed
+# to lychee for authenticated github.com checks; the alternative (a separate
+# app/bot token) is deliberately out of scope for this repo.
 
 name: link-cache-refresh
 
@@ -162,6 +152,9 @@ jobs:
 
       - run: npm run install:safe
 
+      # Twin of test.yaml's lychee install (keep versions in step), plus a
+      # checksum: this job holds a write-capable token, so the downloaded
+      # binary is verified before it runs.
       - name: Install lychee
         env:
           LYCHEE_VERSION: v0.24.2
@@ -197,7 +190,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           # Guard against script drift: if _check:links is renamed, npm run
-          # exits 1 — indistinguishable from the dead-links exit below. The
+          # exits 1, indistinguishable from the dead-links exit below. The
           # --help probe (exit 0 without lychee or a build) fails the run
           # here instead, outside the tolerated-exit interpretation.
           npm run -s -C docsy.dev _check:links -- --help > /dev/null
@@ -266,7 +259,7 @@ jobs:
           # Cache data flows into Markdown here: strip backticks so a
           # hostile URL can't escape the inline-code span.
           entry=${OLDEST_ENTRY//\`/}
-          PR_BODY="Refreshes the oldest lychee-verified link-cache entries (default $DEFAULT_REFRESH_COUNT per rotation); see the link-cache-refresh workflow header for the model."
+          PR_BODY="Refreshes the oldest lychee-verified link-cache entries (default $DEFAULT_REFRESH_COUNT per rotation); for the model, see the [workflow header](https://github.com/${GITHUB_REPOSITORY}/blob/main/.github/workflows/link-cache-refresh.yaml)."
           PR_BODY="$PR_BODY"$'\n\n'"Oldest entry after this refresh (prune-exempt manual seeds keep their dates, so one may sit here):"$'\n'"\`${entry}\`"
           if [[ "${DEAD_LINKS:-false}" == 'true' ]]; then
             PR_BODY="$PR_BODY"$'\n\n'"The refresh found failing links, recorded with negative statuses in the cache diff: triage before merging."

--- a/.github/workflows/link-cache-refresh.yaml
+++ b/.github/workflows/link-cache-refresh.yaml
@@ -1,0 +1,187 @@
+# Opens (or updates) the PR that refreshes the oldest entries of the
+# committed link cache (docsy.dev/link-cache.jsonc). Pruning the N oldest
+# lychee-verified entries and re-running the link checker re-verifies them,
+# rotating through the full cache over a few weeks; manual (seeded) entries
+# are exempt from pruning and retire via their expires date.
+#
+# There is at most one refresh PR at a time (branch bot/link-cache-refresh):
+# a scheduled run while the PR is open only brings the branch current with
+# main; it prunes further only when dispatched with prune_more set. If the
+# branch exists without an open PR, it is reset to main and treated as new.
+#
+# When pruning ran but the run ends with nothing to commit, the run fails: an
+# empty refresh after pruning means the workflow is broken.
+#
+# PRs are created with the workflow's GITHUB_TOKEN, so the repo's regular CI
+# does not auto-run on them (GitHub suppresses workflow-triggered workflows);
+# the link check that matters runs in this workflow, and a maintainer review
+# gates the merge.
+
+name: link-cache-refresh
+
+on:
+  schedule:
+    - cron: '17 4 * * *' # daily at 4:17 UTC
+  workflow_dispatch:
+    inputs:
+      refresh_count:
+        description: Number of (oldest) link-cache entries to refresh.
+        default: 75
+        type: number
+      prune_more:
+        description: Prune more entries from the existing PR branch (if any).
+        default: false
+        type: boolean
+
+permissions: { contents: read }
+
+# Overlapping runs would race updates to the shared refresh branch.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Refresh link cache
+    if: github.repository == 'google/docsy'
+    permissions:
+      contents: write # push the refresh branch
+      pull-requests: write # open the refresh PR
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: bot/link-cache-refresh
+      IS_NEW_BRANCH: 'false'
+      REFRESH_COUNT: ${{ github.event.inputs.refresh_count || 75 }}
+      PRUNE_MORE: ${{ github.event.inputs.prune_more || 'false' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: true # zizmor: ignore[artipacked] Required by this job's later git pushes.
+
+      - name: Validate inputs
+        run: |
+          if [[ ! "$REFRESH_COUNT" =~ ^[0-9]+$ || "$REFRESH_COUNT" -eq 0 ]]; then
+            echo "Error: refresh_count must be a positive number, got: $REFRESH_COUNT"
+            exit 1
+          fi
+
+      - name: Checkout or create the refresh branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! git ls-remote --exit-code --heads origin "$BRANCH"; then
+            echo "IS_NEW_BRANCH=true" >> "$GITHUB_ENV"
+            git checkout -b "$BRANCH" origin/main
+            git push -u origin "$BRANCH"
+          else
+            git checkout "$BRANCH"
+            PR_URL=$(gh pr list --state open --head "$BRANCH" --json url --jq '.[].url')
+            if [[ -n "$PR_URL" ]]; then
+              echo "Branch PR: $PR_URL"
+            else
+              echo "Branch has no open PR: resetting it to origin/main" \
+                "and treating it as a new branch."
+              echo "IS_NEW_BRANCH=true" >> "$GITHUB_ENV"
+              git reset --hard origin/main
+              git push --force-with-lease origin "$BRANCH"
+            fi
+          fi
+
+      - name: Set git identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Merge from main
+        run: |
+          previous=$(git rev-parse HEAD)
+          git fetch origin
+          git merge origin/main
+          if [[ "$(git rev-parse HEAD)" != "$previous" ]]; then
+            echo "Merged from main; the push below carries it."
+            echo "NEEDS_PUSH=true" >> "$GITHUB_ENV"
+          fi
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm run install:safe
+
+      - name: Install lychee
+        env:
+          LYCHEE_VERSION: v0.24.2
+        run: |
+          tmp="$(mktemp -d)"
+          curl -sfL "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz -C "$tmp"
+          install -D "$(find "$tmp" -type f -name lychee | head -n1)" "$HOME/.local/bin/lychee"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          lychee --version
+
+      - name: Prune link cache
+        if: ${{ env.PRUNE_MORE == 'true' || env.IS_NEW_BRANCH == 'true' }}
+        run: |
+          echo "Oldest entry before pruning, then pruning $REFRESH_COUNT oldest entries:"
+          npm run link-cache -- --list 1 --prune "$REFRESH_COUNT"
+          echo "DID_PRUNE=true" >> "$GITHUB_ENV"
+
+      - name: Build the site and refresh the link cache
+        env:
+          # Authenticated github.com checks (rate limits)
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # Exit 1 (dead links) doesn't fail the run: the merge-back has
+          # already recorded the failures in the owned cache, and the PR is
+          # where a maintainer triages them. Exit 2 (preflight: tool/config
+          # broken, zero links verified) is a workflow defect: fail hard.
+          LINK_CHECK_STATUS=0
+          npm run -C docsy.dev check:links || LINK_CHECK_STATUS=$?
+          echo "Link check exit status: $LINK_CHECK_STATUS"
+          if [[ "$LINK_CHECK_STATUS" -ge 2 ]]; then
+            exit "$LINK_CHECK_STATUS"
+          elif [[ "$LINK_CHECK_STATUS" -eq 1 ]]; then
+            echo "DEAD_LINKS_FOUND=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Report the oldest entry after the refresh
+        run: npm run link-cache -- --list 1
+
+      - name: Commit and push link-cache updates, if any
+        run: |
+          git add docsy.dev/link-cache.jsonc
+          if ! git diff-index --quiet --cached HEAD; then
+            git commit -m 'Refresh link cache'
+          fi
+          if [[ "${NEEDS_PUSH:-false}" == 'true' ]] || ! git diff --quiet "origin/$BRANCH"; then
+            git push origin "$BRANCH"
+          fi
+
+      - name: Create the PR if needed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: |-
+            Refreshes the oldest ${{ env.REFRESH_COUNT }} link-cache entries;
+            see the link-cache-refresh workflow header for the model.
+        run: |
+          if [[ "${DEAD_LINKS_FOUND:-false}" == 'true' ]]; then
+            PR_BODY="$PR_BODY"$'\n\n'"The refresh found failing links, recorded with negative statuses in the cache diff: triage before merging."
+          fi
+          prs=$(gh pr list --state open --head "$BRANCH")
+          if [[ -n "$prs" ]]; then
+            echo "PR already exists:"
+            echo "$prs"
+            exit 0
+          fi
+
+          if gh pr create --title 'Refresh link cache' --body "$PR_BODY"; then
+            gh pr view --json url --jq '.url'
+          elif [[ "${DID_PRUNE:-false}" == 'true' ]]; then
+            echo "::error::Pruning ran but produced no PR: an empty refresh" \
+              "after pruning means the workflow is broken."
+            exit 1
+          else
+            echo "No changes to PR."
+          fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,8 @@ jobs:
         run: npm run -s is:clean
 
       # Put lychee on PATH for the link checker (test:full runs on Linux only).
+      # Twin of link-cache-refresh.yaml's checksum-verified install: keep the
+      # pinned versions in step.
       - if: runner.os != 'Windows'
         name: Install lychee
         env:

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -294,9 +294,9 @@ refcache) so checks stay fast and offline-friendly. Each entry records the
 status, its `when` timestamp, and `via` -- the resolver that set it; Lychee's
 own `.lycheecache` is derived from it per run and gitignored. Config lives in
 `docsy.dev/lychee.toml`. CI installs a pinned lychee binary (see
-`.github/workflows/test.yaml`); a plain site build doesn't need it. A daily
-workflow re-verifies the oldest entries on a rolling basis; for the rotation
-model, see the `link-cache-refresh` workflow's header comment.
+`.github/workflows/test.yaml` and `link-cache-refresh.yaml`); a plain site build
+doesn't need it. A daily workflow re-verifies the oldest entries; for the
+rotation model, see the `link-cache-refresh` workflow's header comment.
 
 - **Refresh** after adding or changing external links: `npm run fix:link-cache`
   re-runs the check, adding any missing entries and renormalizing; then commit

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -294,7 +294,9 @@ refcache) so checks stay fast and offline-friendly. Each entry records the
 status, its `when` timestamp, and `via` -- the resolver that set it; Lychee's
 own `.lycheecache` is derived from it per run and gitignored. Config lives in
 `docsy.dev/lychee.toml`. CI installs a pinned lychee binary (see
-`.github/workflows/test.yaml`); a plain site build doesn't need it.
+`.github/workflows/test.yaml`); a plain site build doesn't need it. A daily
+workflow re-verifies the oldest entries on a rolling basis; for the rotation
+model, see the `link-cache-refresh` workflow's header comment.
 
 - **Refresh** after adding or changing external links: `npm run fix:link-cache`
   re-runs the check, adding any missing entries and renormalizing; then commit


### PR DESCRIPTION
- Contributes to the owned-link-cache adoption (#2779): the operational half -- a daily rotation that re-verifies the lychee-verified entries (1069 today) in roughly two weeks of merged daily refreshes.
- **Model**: prune the N (default 75) oldest lychee-verified entries, rebuild + re-check, push to the single reused `bot/link-cache-refresh` branch, open-or-refresh its PR (body carries the oldest-entry marker for prune tuning, and a triage warning when the refresh recorded failing links). Manual seeds are prune-exempt (`link-cache@0.4.1`) and retire via their `expires` dates.
- **Failure semantics**: dead links don't fail the run -- the merge-back records them as negative statuses and the PR diff is the triage surface; preflight failures (exit 2: tool/config broken, zero links verified) fail hard; a prune whose refresh changes nothing fails the run (sanity assertion, independent of PR state).
- **Hardening**: passes the repo's supply-chain audit (credential-free checkout, token-URL pushes, step outputs, SHA256-pinned lychee); PR detection ignores cross-repository branches of the same name; the single-token trade-off is recorded in the workflow header.
- **Simplifications vs the otel.io original** (`refcache-refresh.yml`): plain `GITHUB_TOKEN` instead of a bot app -- regular CI doesn't auto-run on the refresh PR (the link check that matters runs in this workflow, and merges are maintainer-gated); no browser double-check probe; merge-only branch sync.
- **Open items for the first live runs** (dispatch-testable): whether `cla/google` accepts `github-actions[bot]` commits, and prune-count tuning.
