### PR TITLE
Complete the 0.18 jQuery upgrade guidance; root-check workspace coverage

### DIFF
--- a/docsy.dev/content/en/blog/2026/0.18.0.md
+++ b/docsy.dev/content/en/blog/2026/0.18.0.md
@@ -46,21 +46,21 @@ local resources have one fewer exception to manage.
 
 What this means for your site:
 
-- **No action needed** if your project scripts don't use jQuery -- most don't,
-  since Docsy never documented it as available. To check, search your project's
-  own scripts (`assets/`, `layouts/`, `static/`) for `$(` or `jQuery`.
-- **If you override one of the converted files**, refresh your copy from the
-  theme: an override kept at its 0.17 form still expects the jQuery that Docsy
-  no longer loads. The files that used jQuery were:
+- **No action needed** if your project scripts don't use jQuery. To check,
+  search your project's own scripts (`assets/`, `layouts/`, `static/`) for
+  `$(`, `$.`, or `jQuery`.
+- **If you override a converted file**, [review your override against the new
+  theme version][update-overrides]. The files that changed:
   - `assets/js/base.js`, `search.js`, `offline-search.js`, `markmap.js`, and
-    `plantuml.js`
-  - `layouts/_partials/head.html` (loaded jQuery) and
-    `layouts/_partials/scripts/mermaid.html`
+    `plantuml.js`, plus `layouts/_partials/scripts/mermaid.html`: old copies
+    still expect the jQuery that Docsy no longer loads.
+  - `layouts/_partials/head.html`: an old copy keeps loading jQuery -- and can
+    mask stale copies of the files above from the console check below.
 - **If your own scripts rely on the jQuery that Docsy loaded**, either:
   - Convert them to standard DOM APIs -- for equivalents, see [You might not
     need jQuery][], or
   - Keep jQuery by loading it yourself: add the following script element to a
-    [hooks/head-end.html][] partial in your project:
+    [hooks/head-end.html partial][head-end] in your project:
 
     ```html
     <script
@@ -71,13 +71,13 @@ What this means for your site:
     ```
 
 After upgrading, spot-check your key pages with the browser console open: a
-`$ is not defined` or `jQuery is not defined` error is the signature of a
-script that still expects Docsy's jQuery.
+`$ is not defined` or `jQuery is not defined` error indicates remaining
+jQuery-dependent code.
 
 [#1436]: https://github.com/google/docsy/issues/1436
-[hooks/head-end.html]:
-  https://github.com/google/docsy/blob/main/theme/layouts/_partials/hooks/head-end.html
+[head-end]: /docs/content/lookandfeel/#add-code-to-head-or-before-body-end
 [jQuery]: https://jquery.com/
+[update-overrides]: /docs/update/#update-overrides
 [You might not need jQuery]: https://youmightnotneedjquery.com/
 
 ## What's next

--- a/docsy.dev/content/en/blog/2026/0.18.0.md
+++ b/docsy.dev/content/en/blog/2026/0.18.0.md
@@ -49,23 +49,30 @@ What this means for your site:
 - **No action needed** if your project scripts don't use jQuery -- most don't,
   since Docsy never documented it as available. To check, search your project's
   own scripts (`assets/`, `layouts/`, `static/`) for `$(` or `jQuery`.
+- **If you override one of the converted files**, refresh your copy from the
+  theme: an override kept at its 0.17 form still expects the jQuery that Docsy
+  no longer loads. The files that used jQuery were:
+  - `assets/js/base.js`, `search.js`, `offline-search.js`, `markmap.js`, and
+    `plantuml.js`
+  - `layouts/_partials/head.html` (loaded jQuery) and
+    `layouts/_partials/scripts/mermaid.html`
 - **If your own scripts rely on the jQuery that Docsy loaded**, either:
   - Convert them to standard DOM APIs -- for equivalents, see [You might not
     need jQuery][], or
-  - Keep jQuery by loading it yourself: add the script element below to a
-    [hooks/head-end.html][] partial in your project.
+  - Keep jQuery by loading it yourself: add the following script element to a
+    [hooks/head-end.html][] partial in your project:
+
+    ```html
+    <script
+      src="https://code.jquery.com/jquery-3.7.1.min.js"
+      integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="
+      crossorigin="anonymous"
+    ></script>
+    ```
 
 After upgrading, spot-check your key pages with the browser console open: a
 `$ is not defined` or `jQuery is not defined` error is the signature of a
 script that still expects Docsy's jQuery.
-
-```html
-<script
-  src="https://code.jquery.com/jquery-3.7.1.min.js"
-  integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="
-  crossorigin="anonymous"
-></script>
-```
 
 [#1436]: https://github.com/google/docsy/issues/1436
 [hooks/head-end.html]:

--- a/docsy.dev/content/en/blog/2026/0.18.0.md
+++ b/docsy.dev/content/en/blog/2026/0.18.0.md
@@ -47,8 +47,9 @@ local resources have one fewer exception to manage.
 What this means for your site:
 
 - **No action needed** if your project scripts don't use jQuery. To check,
-  search your project's own scripts (`assets/`, `layouts/`, `static/`) for `$(`,
-  `$.`, or `jQuery`.
+  search your project's own scripts (`assets/`, `layouts/`, `static/`) for `$(`
+  or `jQuery` -- and in JS files, `$.` too (in layouts that token is ordinary
+  Hugo template syntax).
 - **If you override a converted file**, [review your override against the new
   theme version][update-overrides]. The files that changed:
   - `assets/js/base.js`, `search.js`, `offline-search.js`, `markmap.js`, and

--- a/docsy.dev/content/en/blog/2026/0.18.0.md
+++ b/docsy.dev/content/en/blog/2026/0.18.0.md
@@ -49,7 +49,7 @@ What this means for your site:
 - **No action needed** if your project scripts don't use jQuery. To check,
   search your project's own scripts (`assets/`, `layouts/`, `static/`) for `$(`
   or `jQuery` -- and in JS files, `$.` too (in layouts that token is ordinary
-  Hugo template syntax).
+  Hugo template syntax, but do eyeball any inline `<script>` blocks there).
 - **If you override a converted file**, [review your override against the new
   theme version][update-overrides]. The files that changed:
   - `assets/js/base.js`, `search.js`, `offline-search.js`, `markmap.js`, and
@@ -71,9 +71,10 @@ What this means for your site:
     ></script>
     ```
 
-After upgrading, spot-check your key pages with the browser console open: a
-`$ is not defined` or `jQuery is not defined` error indicates remaining
-jQuery-dependent code.
+After upgrading, spot-check your key pages -- including a diagram page, if your
+site has them -- with the browser console open, and exercise interactive
+features such as search: a `$ is not defined` or similar jQuery-is-missing error
+indicates remaining jQuery-dependent code.
 
 [#1436]: https://github.com/google/docsy/issues/1436
 [head-end]: /docs/content/lookandfeel/#add-code-to-head-or-before-body-end

--- a/docsy.dev/content/en/blog/2026/0.18.0.md
+++ b/docsy.dev/content/en/blog/2026/0.18.0.md
@@ -47,12 +47,17 @@ local resources have one fewer exception to manage.
 What this means for your site:
 
 - **No action needed** if your project scripts don't use jQuery -- most don't,
-  since Docsy never documented it as available.
+  since Docsy never documented it as available. To check, search your project's
+  own scripts (`assets/`, `layouts/`, `static/`) for `$(` or `jQuery`.
 - **If your own scripts rely on the jQuery that Docsy loaded**, either:
   - Convert them to standard DOM APIs -- for equivalents, see [You might not
     need jQuery][], or
   - Keep jQuery by loading it yourself: add the script element below to a
     [hooks/head-end.html][] partial in your project.
+
+After upgrading, spot-check your key pages with the browser console open: a
+`$ is not defined` or `jQuery is not defined` error is the signature of a
+script that still expects Docsy's jQuery.
 
 ```html
 <script

--- a/docsy.dev/content/en/blog/2026/0.18.0.md
+++ b/docsy.dev/content/en/blog/2026/0.18.0.md
@@ -47,8 +47,8 @@ local resources have one fewer exception to manage.
 What this means for your site:
 
 - **No action needed** if your project scripts don't use jQuery. To check,
-  search your project's own scripts (`assets/`, `layouts/`, `static/`) for
-  `$(`, `$.`, or `jQuery`.
+  search your project's own scripts (`assets/`, `layouts/`, `static/`) for `$(`,
+  `$.`, or `jQuery`.
 - **If you override a converted file**, [review your override against the new
   theme version][update-overrides]. The files that changed:
   - `assets/js/base.js`, `search.js`, `offline-search.js`, `markmap.js`, and

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -168,7 +168,18 @@ history since 0.17.0][].
 
 - ...
 
+**For maintainers**:
+
+- Grouped Renovate patch/minor dependency updates into per-area batch PRs,
+  after applying the open update wave (devDep pins and bumps, actions v7)
+  ([#2774][], [#2776][]).
+- Switched the docsy.dev committed link cache to an owned JSONC format
+  ([#2779][]).
+
 [#1436]: https://github.com/google/docsy/issues/1436
+[#2774]: https://github.com/google/docsy/pull/2774
+[#2776]: https://github.com/google/docsy/pull/2776
+[#2779]: https://github.com/google/docsy/pull/2779
 [0.18.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.18.0
 [0.18.0-blog-jquery]: /blog/2026/0.18.0/#jquery
 [git history since 0.17.0]:

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -175,8 +175,9 @@ history since 0.17.0][].
   [#2776][]).
 - Switched the docsy.dev committed link cache to an owned JSONC format
   ([#2779][]).
-- Root `npm run check` now also runs the docsy.dev workspace format check,
-  matching what CI enforces (`fix:format` already delegated) ([#2781][]).
+- Extended the root `npm run check` to also run the docsy.dev workspace format
+  check, matching what CI enforces (`fix:format` already delegated)
+  ([#2781][]).
 
 [#1436]: https://github.com/google/docsy/issues/1436
 [#2774]: https://github.com/google/docsy/pull/2774

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -1169,6 +1169,10 @@ For the full list of changes, see the [0.X.Y][] release page.
 
 - ...
 
+**For maintainers**:
+
+- ...
+
 [0.X.Y]: https://github.com/google/docsy/releases/latest?FIXME=v0.X.Y
 ```
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -175,11 +175,14 @@ history since 0.17.0][].
   [#2776][]).
 - Switched the docsy.dev committed link cache to an owned JSONC format
   ([#2779][]).
+- Root `npm run check` now also runs the docsy.dev workspace format check,
+  matching what CI enforces (`fix:format` already delegated) ([#2781][]).
 
 [#1436]: https://github.com/google/docsy/issues/1436
 [#2774]: https://github.com/google/docsy/pull/2774
 [#2776]: https://github.com/google/docsy/pull/2776
 [#2779]: https://github.com/google/docsy/pull/2779
+[#2781]: https://github.com/google/docsy/pull/2781
 [0.18.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.18.0
 [0.18.0-blog-jquery]: /blog/2026/0.18.0/#jquery
 [git history since 0.17.0]:

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -176,8 +176,7 @@ history since 0.17.0][].
 - Switched the docsy.dev committed link cache to an owned JSONC format
   ([#2779][]).
 - Extended the root `npm run check` to also run the docsy.dev workspace format
-  check, matching what CI enforces (`fix:format` already delegated)
-  ([#2781][]).
+  check, matching what CI enforces (`fix:format` already delegated) ([#2781][]).
 
 [#1436]: https://github.com/google/docsy/issues/1436
 [#2774]: https://github.com/google/docsy/pull/2774

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -170,9 +170,9 @@ history since 0.17.0][].
 
 **For maintainers**:
 
-- Grouped Renovate patch/minor dependency updates into per-area batch PRs,
-  after applying the open update wave (devDep pins and bumps, actions v7)
-  ([#2774][], [#2776][]).
+- Grouped Renovate patch/minor dependency updates into per-area batch PRs, after
+  applying the open update wave (devDep pins and bumps, actions v7) ([#2774][],
+  [#2776][]).
 - Switched the docsy.dev committed link cache to an owned JSONC format
   ([#2779][]).
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -170,9 +170,9 @@ history since 0.17.0][].
 
 **For maintainers**:
 
-- Grouped Renovate patch/minor dependency updates into per-area batch PRs, after
-  applying the open update wave (devDep pins and bumps, actions v7) ([#2774][],
-  [#2776][]).
+- Grouped Renovate patch/minor dependency updates into per-update-type batch PRs
+  (one per weekly wave), after applying the open update wave (devDep pins and
+  bumps, actions v7) ([#2774][], [#2776][]).
 - Switched the docsy.dev committed link cache to an owned JSONC format
   ([#2779][]).
 - Extended the root `npm run check` to also run the docsy.dev workspace format

--- a/docsy.dev/link-cache.jsonc
+++ b/docsy.dev/link-cache.jsonc
@@ -2859,6 +2859,11 @@
     "when": "2026-09-01T01:29:59Z",
     "via": "lychee",
   },
+  "https://github.com/google/docsy/pull/2781": {
+    "status": 200,
+    "when": "2026-09-01T03:31:13Z",
+    "via": "lychee",
+  },
   "https://github.com/google/docsy/pull/941": {
     "status": 200,
     "when": "2026-06-26T18:23:45Z",

--- a/docsy.dev/link-cache.jsonc
+++ b/docsy.dev/link-cache.jsonc
@@ -2844,6 +2844,21 @@
     "when": "2026-08-29T16:14:32Z",
     "via": "lychee",
   },
+  "https://github.com/google/docsy/pull/2774": {
+    "status": 200,
+    "when": "2026-09-01T01:29:59Z",
+    "via": "lychee",
+  },
+  "https://github.com/google/docsy/pull/2776": {
+    "status": 200,
+    "when": "2026-09-01T01:29:59Z",
+    "via": "lychee",
+  },
+  "https://github.com/google/docsy/pull/2779": {
+    "status": 200,
+    "when": "2026-09-01T01:29:59Z",
+    "via": "lychee",
+  },
   "https://github.com/google/docsy/pull/941": {
     "status": 200,
     "when": "2026-06-26T18:23:45Z",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "approve:hugo": "npm run _install:safe:pre && npm approve-scripts --allow-scripts-pin hugo-extended && npm run -s _test:supply-chain && npm run _install:safe:post",
     "build": "npm run -C docsy.dev build --",
     "check:afdocs:dev": "npm run -s _check:afdocs -- http://localhost:1313 | awk '/./{if(s)printf \"%s\",b; b=\"\"; print; s=1; next} s{b=b RS}' | tee docsy.dev/content/en/docs/content/agent-support/afdocs-scorecard.txt",
-    "check:format": "npm list prettier && npm run _check:format || (echo '[help] Run: npm run fix:format'; exit 1)",
+    "check:format": "npm list prettier && npm run _check:format && npm run -s -C docsy.dev check:format || (echo '[help] Run: npm run fix:format'; exit 1)",
     "check:links": "npm run -C docsy.dev check:links",
     "check:markdown": "npm run _check:markdown -- '**/*.md'",
     "check": "npm run check:format && npm run check:markdown",


### PR DESCRIPTION
- Contributes to #1436 and the 0.18 release-prep coverage pass
- **Post, jQuery section**: completes the upgrader arc -- detect reliance (own-scripts search; `$.` scoped to JS files), review overrides of the converted files (JS/mermaid copies expect the missing jQuery; an old head.html keeps loading it and can mask them), remediate (convert or self-load), verify (console spot-check). Mechanics route to their docs homes (update procedure, hooks section)
- **Changelog**: 0.18 For-maintainers list covering the landed maintainer stream (Renovate wave + grouping, JSONC link cache, root-check fix below); entry template gains the For-maintainers slot
- **Root `check` covers the docsy.dev workspace**: check:format now delegates as fix:format long has -- a docsy.dev-only format issue used to pass the root check locally and fail only in CI (hit twice on this branch); red-proven
