### PR TITLE
link-cache-refresh: weekly cadence, 300-entry prunes, CLA-covered author

### DIFF
--- a/.github/workflows/link-cache-refresh.yaml
+++ b/.github/workflows/link-cache-refresh.yaml
@@ -2,9 +2,9 @@
 # committed link cache (docsy.dev/link-cache.jsonc), maintained by the
 # link-cache npm package. Pruning the N oldest lychee-verified entries and
 # re-running the link checker re-verifies them (or retires URLs no longer in
-# the site), rotating through them over a few weeks (assuming refresh PRs
-# merge roughly daily); manual (seeded) entries are exempt from pruning and
-# retire via their expires dates.
+# the site), rotating through them in about a month of weekly merged
+# refreshes; manual (seeded) entries are exempt from pruning and retire via
+# their expires dates.
 #
 # There is at most one refresh PR at a time (branch bot/link-cache-refresh,
 # PR against main): a scheduled run while the PR is open brings the branch
@@ -25,12 +25,12 @@ name: link-cache-refresh
 
 on:
   schedule:
-    - cron: '17 4 * * *' # daily at 4:17 UTC
+    - cron: '17 4 * * 1' # weekly, Mondays at 4:17 UTC
   workflow_dispatch:
     inputs:
       refresh_count:
         description: Number of (oldest) link-cache entries to refresh.
-        default: &default_refresh_count 75
+        default: &default_refresh_count 300
         type: number
       prune_more:
         description: Prune more entries from the existing PR branch (if any).
@@ -118,8 +118,13 @@ jobs:
 
       - name: Set git identity
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # Author under a CLA-covered identity: cla/google keys on the
+          # commit author's email and github-actions[bot] cannot sign a CLA
+          # (proven on the first live run's PR). The name marks the commits
+          # as machine-made; the pushing credential remains the workflow's
+          # GITHUB_TOKEN either way.
+          git config user.name 'chalin (link-cache bot)'
+          git config user.email 'pchalin@gmail.com'
 
       - name: Merge from main
         id: merge

--- a/.github/workflows/link-cache-refresh.yaml
+++ b/.github/workflows/link-cache-refresh.yaml
@@ -11,15 +11,13 @@
 # current with main and re-runs the check (refreshing the PR body), but
 # prunes further only when dispatched with prune_more set. If the branch
 # exists without an open same-repo PR, it is reset to main and treated as
-# new. Merge conflicts, tolerated exit codes, and push auth are handled
-# per-step; the step comments carry the rationale.
+# new.
 #
-# The PR is created with the workflow's GITHUB_TOKEN, so the repo's regular
-# CI does not auto-run on it (GitHub suppresses workflow-triggered
-# workflows); the link check that matters runs here, and a maintainer review
-# gates the merge. That token (with this job's write permissions) is exposed
-# to lychee for authenticated github.com checks; the alternative (a separate
-# app/bot token) is deliberately out of scope for this repo.
+# The design does not rely on the refresh PR getting its own CI: the link
+# check that matters runs in this workflow, and a maintainer review gates
+# the merge. The workflow's GITHUB_TOKEN (with this job's write permissions)
+# is exposed to lychee for authenticated github.com checks; the alternative
+# (a separate app/bot token) is deliberately out of scope for this repo.
 
 name: link-cache-refresh
 
@@ -118,11 +116,6 @@ jobs:
 
       - name: Set git identity
         run: |
-          # Author under a CLA-covered identity: cla/google keys on the
-          # commit author's email and github-actions[bot] cannot sign a CLA
-          # (proven on the first live run's PR). The name marks the commits
-          # as machine-made; the pushing credential remains the workflow's
-          # GITHUB_TOKEN either way.
           git config user.name 'chalin (link-cache bot)'
           git config user.email 'pchalin@gmail.com'
 
@@ -190,8 +183,8 @@ jobs:
       - name: Refresh the link cache
         id: check
         env:
-          # Authenticated github.com checks (rate limits); see the header's
-          # token notes.
+          # Authenticated github.com checks (rate limits); token trade-off in
+          # the header.
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           # Guard against script drift: if _check:links is renamed, npm run

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -295,7 +295,7 @@ status, its `when` timestamp, and `via` -- the resolver that set it; Lychee's
 own `.lycheecache` is derived from it per run and gitignored. Config lives in
 `docsy.dev/lychee.toml`. CI installs a pinned lychee binary (see
 `.github/workflows/test.yaml` and `link-cache-refresh.yaml`); a plain site build
-doesn't need it. A daily workflow re-verifies the oldest entries; for the
+doesn't need it. A weekly workflow re-verifies the oldest entries; for the
 rotation model, see the `link-cache-refresh` workflow's header comment.
 
 - **Refresh** after adding or changing external links: `npm run fix:link-cache`


### PR DESCRIPTION
- Tunes the link-cache-refresh rotation from its first live run (#2782): the mechanics worked end to end -- prune, re-verify, retire-gone-URLs, PR with telemetry -- but two operational findings need fixes.
- **CLA**: `cla/google` fails `github-actions[bot]`-authored commits (a bot can't sign a CLA; consent-comment flow doesn't apply). Commits now author under a CLA-covered identity, named `chalin (link-cache bot)` so provenance stays legible; the pushing credential remains the workflow's `GITHUB_TOKEN`.
- **Cadence**: rotation speed is merge cadence x prune count (an open PR absorbs later runs as sync-only), so daily x 75 mostly produced no-op runs against a maintainer-gated merge rhythm. Now weekly (Mondays) x 300: full rotation in about a month of merged refreshes, well inside lychee's 375-day `max_cache_age`.
- After this lands, #2782 gets closed and its branch deleted; the next scheduled run recreates the refresh PR under the new identity and count (pruned-then-reverified data regenerates, nothing is lost).
