### PR TITLE
Number the publish-verify gates; make the smoke npm-registry vet honest

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -68,6 +68,7 @@
     "shortcodes",
     "subfolders",
     "submatch",
+    "substep",
     "tabpane",
     "unmarshal",
     "unreviewed",

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -178,8 +178,8 @@ history since 0.17.0][].
 - Extended the root `npm run check` to also run the docsy.dev workspace format
   check, matching what CI enforces (`fix:format` already delegated) ([#2781][]).
 - Restructured the publish-verify release step into numbered gates and hardened
-  the smoke suite's registry vet: exact, registry-resolved versions, with local
-  npm hardening honored (loud failures, never overridden) ([#2786][]).
+  the smoke suite's npm-registry vet: exact, registry-resolved versions, with
+  local npm hardening honored (loud failures, never overridden) ([#2786][]).
 
 [#1436]: https://github.com/google/docsy/issues/1436
 [#2774]: https://github.com/google/docsy/pull/2774

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -179,7 +179,8 @@ history since 0.17.0][].
   check, matching what CI enforces (`fix:format` already delegated) ([#2781][]).
 - Restructured the publish-verify release step into numbered gates and hardened
   the smoke suite's npm-registry vet: exact, registry-resolved versions, with
-  local npm hardening honored (loud failures, never overridden) ([#2786][]).
+  local npm hardening never relaxed except by an explicit per-run knob
+  ([#2786][]).
 
 [#1436]: https://github.com/google/docsy/issues/1436
 [#2774]: https://github.com/google/docsy/pull/2774

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -179,8 +179,8 @@ history since 0.17.0][].
   check, matching what CI enforces (`fix:format` already delegated) ([#2781][]).
 - Restructured the publish-verify release step into numbered gates and hardened
   the smoke suite's registry vet: it installs an exact, registry-resolved
-  version and honors local npm hardening, failing loudly with the deliberate
-  rerun named ([#2786][]).
+  version, and the suite honors local npm hardening, failing loudly and naming
+  the deliberate rerun ([#2786][]).
 
 [#1436]: https://github.com/google/docsy/issues/1436
 [#2774]: https://github.com/google/docsy/pull/2774

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -179,7 +179,7 @@ history since 0.17.0][].
   check, matching what CI enforces (`fix:format` already delegated) ([#2781][]).
 - Restructured the publish-verify release step into numbered gates and hardened
   the smoke suite's npm-registry vet: exact, registry-resolved versions, with
-  local npm hardening never relaxed except by an explicit per-run knob
+  local npm hardening never relaxed except by an explicit per-run override
   ([#2786][]).
 
 [#1436]: https://github.com/google/docsy/issues/1436

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -177,12 +177,17 @@ history since 0.17.0][].
   ([#2779][]).
 - Extended the root `npm run check` to also run the docsy.dev workspace format
   check, matching what CI enforces (`fix:format` already delegated) ([#2781][]).
+- Restructured the publish-verify release step into numbered gates and hardened
+  the smoke suite's registry vet: it installs an exact, registry-resolved
+  version and honors local npm hardening, failing loudly with the deliberate
+  rerun named ([#2786][]).
 
 [#1436]: https://github.com/google/docsy/issues/1436
 [#2774]: https://github.com/google/docsy/pull/2774
 [#2776]: https://github.com/google/docsy/pull/2776
 [#2779]: https://github.com/google/docsy/pull/2779
 [#2781]: https://github.com/google/docsy/pull/2781
+[#2786]: https://github.com/google/docsy/pull/2786
 [0.18.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.18.0
 [0.18.0-blog-jquery]: /blog/2026/0.18.0/#jquery
 [git history since 0.17.0]:

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -178,9 +178,8 @@ history since 0.17.0][].
 - Extended the root `npm run check` to also run the docsy.dev workspace format
   check, matching what CI enforces (`fix:format` already delegated) ([#2781][]).
 - Restructured the publish-verify release step into numbered gates and hardened
-  the smoke suite's registry vet: it installs an exact, registry-resolved
-  version, and the suite honors local npm hardening, failing loudly and naming
-  the deliberate rerun ([#2786][]).
+  the smoke suite's registry vet: exact, registry-resolved versions, with local
+  npm hardening honored (loud failures, never overridden) ([#2786][]).
 
 [#1436]: https://github.com/google/docsy/issues/1436
 [#2774]: https://github.com/google/docsy/pull/2774

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -235,11 +235,11 @@ NPM_CONFIG_MIN_RELEASE_AGE=3 npm run update:hugo -- X.Y.Z
 
 From the repo root:
 
-| Script         | Role                                                                                         |
-| -------------- | -------------------------------------------------------------------------------------------- |
-| `test:repo`    | Fast, offline repo checks. For details, see [`package.json`][package.json]                   |
-| `test:smoke`   | Builds minimal test sites from the theme package and from GitHub; see note below for details |
-| `test:website` | Full docsy.dev checks: format, links, hugo-build, alt-site, md-output, and favicon tests     |
+| Script         | Role                                                                                           |
+| -------------- | ---------------------------------------------------------------------------------------------- |
+| `test:repo`    | Fast, offline repo checks. For details, see [`package.json`][package.json]                     |
+| `test:smoke`   | Builds minimal test sites from the theme package and from GitHub; see [test:smoke](#testsmoke) |
+| `test:website` | Full docsy.dev checks: format, links, hugo-build, alt-site, md-output, and favicon tests       |
 
 Notes:
 
@@ -256,24 +256,25 @@ builds auto-target the current branch's GitHub upstream.
 - Builds a minimal test site from:
   - Theme package: packed tarball, npm registry
   - GitHub: NPM, Hugo module, clone
-  - Hugo: pinned default and minimum Hugo-version builds
+- Builds with the pinned Hugo; the Hugo-module site also with the declared
+  minimum Hugo version
 
 Security:
 
 - The npm-registry install test vets an exact version: the checkout's, when its
-  release tag is in the checkout's history, otherwise `latest`; asserting the
-  installed version against the npm registry's own resolution.
+  release tag is in the checkout's history, otherwise `latest`'s resolution;
+  asserting the installed version against the npm registry's own resolution.
 - `DOCSY_THEME_PKG` overrides the target: exact version or dist-tag; a
   non-`-dev` prerelease checkout (an RC, for example) requires it.
 - The suite never relaxes local npm hardening on its own. When local hardening
   blocks a run:
-  - An npm install-guard shim's block names its own override; follow the shim's
-    instructions to allow the run.
+  - A local install guard's block names its own override; follow it to allow the
+    run.
   - For a release-age gate on a fresh Docsy theme package: set
-    `DOCSY_THEME_MIN_RELEASE_AGE=N` (N no lower than the release age in whole
-    days) to relax the cooldown to N days for the theme-package install commands
-    only -- the theme and the dependencies those installs resolve; nothing else
-    in the run.
+    `DOCSY_THEME_MIN_RELEASE_AGE=N`, N = the release age in whole days (0 on
+    release day; higher still blocks, lower over-relaxes), to relax the cooldown
+    for the theme-package install commands only -- the theme and the
+    dependencies those installs resolve; nothing else in the run.
   - Any other pinned scratch dependency younger than a local age gate fails its
     leg until the pin ages (npm's error names the date cutoff).
   - The make-site scratch sites carry their own baked consumer-simulation
@@ -688,7 +689,8 @@ If not adjust accordingly.
       manual npm commands from within the repo: the root `.npmrc` pins the
       `@docsy` scope registry against local overrides.
 
-      Vet a prerelease publish explicitly (at a prerelease checkout, the
+      Vet a prerelease publish explicitly, before restoring the dev version
+      stamp (while the prerelease version is still in `theme/package.json`, the
       npm-registry install test refuses other targets, a bare run's `latest`
       included), and confirm the run's "expecting" line names the prerelease you
       just published:

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -247,13 +247,15 @@ Notes:
 - To run one `test:repo` suite alone, pass its file(s) to `node --test`, e.g.
   `node --test tests/supply-chain-audit.test.mjs`.
 - `test:smoke`:
-  - Run it manually for `main` or PR-branch validation. Its tests auto-target
-    the current branch's GitHub upstream.
+  - Run it manually for `main` or PR-branch validation. Its GitHub-sourced
+    builds auto-target the current branch's GitHub upstream.
   - Builds a minimal test site from the theme package (packed tarball, registry)
     and from GitHub (NPM, Hugo module, clone, minimum-Hugo).
   - The registry-install test vets an exact version (the checkout's, when its
     release tag is in the checkout's history; otherwise `latest`), asserting the
-    installed version against the registry's own resolution.
+    installed version against the registry's own resolution. `DOCSY_THEME_PKG`
+    overrides the target (exact version or dist-tag); a prerelease checkout
+    requires it.
   - The suite never overrides local npm hardening: an install guard or a
     release-age gate on the theme install fails the run loudly, naming the
     deliberate rerun knob.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -633,11 +633,15 @@ If not adjust accordingly.
        ```
 
     4. **Vet the published artifact** by running the [smoke tests](#test-suites)
-       from `main` at the tag: with `latest` now on the new release, the suite's
-       registry-install test builds a site from the published package:
+       from `main` at the tag: the suite's registry-install test builds a site
+       from the published package. Pin the release explicitly: under npm's
+       `min-release-age`, the suite's default bare `@docsy/theme` install
+       silently resolves to the newest old-enough release, smoke-testing the
+       previous stable (this bit the 0.17.0 run); the exact pin fails visibly
+       instead, so pair it with a one-off age override:
 
        ```sh
-       npm run test:smoke
+       DOCSY_THEME_PKG=@docsy/theme@${REL#v} NPM_CONFIG_MIN_RELEASE_AGE=0 npm run test:smoke
        ```
 
     Exceptions to the CI flow:

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -248,11 +248,11 @@ Notes:
   `node --test tests/supply-chain-audit.test.mjs`.
 - Run `test:smoke` manually for `main` or PR-branch validation. Its tests
   auto-target the current branch's GitHub upstream.
-- The `test:smoke` registry-install test vets an exact version -- the checkout's
-  at a release tag, otherwise `latest` -- asserting the installed version
-  against the registry's own resolution. The suite never overrides local npm
-  hardening: an install guard or a release-age gate on the theme install fails
-  the run loudly, naming the deliberate rerun knob.
+- The `test:smoke` registry-install test vets an exact version (the checkout's,
+  when it sits at a release tag; otherwise `latest`), asserting the installed
+  version against the registry's own resolution. The suite never overrides local
+  npm hardening: an install guard or a release-age gate on the theme install
+  fails the run loudly, naming the deliberate rerun knob.
 
 ### Structural guards: one concern per file
 
@@ -664,7 +664,9 @@ If not adjust accordingly.
       `@docsy` scope registry against local overrides.
 
       Vet a prerelease publish explicitly -- at a prerelease checkout, a bare
-      smoke run vets `latest` (the previous stable), not the prerelease:
+      smoke run vets `latest` (the previous stable), not the prerelease -- and
+      confirm the run's "expecting" line names the prerelease you just
+      published:
 
       ```sh
       DOCSY_THEME_PKG=@docsy/theme@next npm run test:smoke

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -251,8 +251,8 @@ Notes:
 - The `test:smoke` registry-install test vets an exact version -- the checkout's
   at a release tag, otherwise `latest` -- asserting the installed version
   against the registry's own resolution. The suite never overrides local npm
-  hardening: an install guard or release-age gate fails the run loudly, naming
-  the deliberate rerun knob.
+  hardening: an install guard or a release-age gate on the theme install fails
+  the run loudly, naming the deliberate rerun knob.
 
 ### Structural guards: one concern per file
 
@@ -639,7 +639,8 @@ If not adjust accordingly.
 
     4. **Vet the published artifact**: run the [smoke tests](#test-suites) from
        `$BASE`; the registry-install test vets exactly the just-published
-       version:
+       version. (On a machine with local npm hardening, the first run fails by
+       design; rerun as the failure directs.)
 
        ```sh
        npm run test:smoke
@@ -661,6 +662,13 @@ If not adjust accordingly.
       materializes the LICENSE), even under a script-disabling npm config. Run
       manual npm commands from within the repo: the root `.npmrc` pins the
       `@docsy` scope registry against local overrides.
+
+      Vet a prerelease publish explicitly -- at a prerelease checkout, a bare
+      smoke run vets `latest` (the previous stable), not the prerelease:
+
+      ```sh
+      DOCSY_THEME_PKG=@docsy/theme@next npm run test:smoke
+      ```
 
     - **If the CI publish is broken for a stable**, prefer fixing CI over a
       laptop publish: a manual publish carries no provenance attestation. As a

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -246,7 +246,7 @@ Notes:
 - All but `test:smoke` run in CI.
 - To run one `test:repo` suite alone, pass its file(s) to `node --test`, e.g.
   `node --test tests/supply-chain-audit.test.mjs`.
-- `test:smoke`:
+- `test:smoke` (slow, network-bound):
   - Run it manually for `main` or PR-branch validation. Its GitHub-sourced
     builds auto-target the current branch's GitHub upstream.
   - Builds a minimal test site from the theme package (packed tarball, npm
@@ -256,9 +256,13 @@ Notes:
     the installed version against the npm registry's own resolution.
     `DOCSY_THEME_PKG` overrides the target (exact version or dist-tag); a
     prerelease checkout requires it.
-  - The suite never overrides local npm hardening: an install guard or a
-    release-age gate on the theme install fails the run loudly, naming the
-    deliberate rerun knob (which the suite applies to the theme install only).
+  - The suite never overrides local npm hardening, and its installs run under
+    your ambient npm config: an install guard's block fails the run with the
+    guard's own remedy, and a release-age gate on the fresh theme package fails
+    it naming `DOCSY_THEME_MIN_RELEASE_AGE=N`, a suite knob applied to the
+    theme-package installs only. Any other pinned scratch dependency younger
+    than a local age gate fails its leg until the pin ages (npm's error names
+    the date cutoff).
 
 ### Structural guards: one concern per file
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -633,12 +633,11 @@ If not adjust accordingly.
        ```
 
     4. **Vet the published artifact**: run the [smoke tests](#test-suites) from
-       `$BASE`, pinning the release -- a bare install
-       [resolves past a too-young release](/docs/update/npm-package/) and would
-       silently smoke-test the previous stable:
+       `$BASE`; the registry-install test derives the just-published version
+       from the checkout and fails unless the registry serves exactly it:
 
        ```sh
-       DOCSY_THEME_PKG=@docsy/theme@${REL#v} NPM_CONFIG_MIN_RELEASE_AGE=0 npm run test:smoke
+       npm run test:smoke
        ```
 
     Exceptions to the CI flow:

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -249,10 +249,11 @@ Notes:
 - Run `test:smoke` manually for `main` or PR-branch validation. Its tests
   auto-target the current branch's GitHub upstream.
 - The `test:smoke` registry-install test vets an exact version (the checkout's,
-  when it sits at a release tag; otherwise `latest`), asserting the installed
-  version against the registry's own resolution. The suite never overrides local
-  npm hardening: an install guard or a release-age gate on the theme install
-  fails the run loudly, naming the deliberate rerun knob.
+  when its release tag is in the checkout's history; otherwise `latest`),
+  asserting the installed version against the registry's own resolution. The
+  suite never overrides local npm hardening: an install guard or a release-age
+  gate on the theme install fails the run loudly, naming the deliberate rerun
+  knob.
 
 ### Structural guards: one concern per file
 
@@ -663,10 +664,10 @@ If not adjust accordingly.
       manual npm commands from within the repo: the root `.npmrc` pins the
       `@docsy` scope registry against local overrides.
 
-      Vet a prerelease publish explicitly -- at a prerelease checkout, a bare
-      smoke run vets `latest` (the previous stable), not the prerelease -- and
-      confirm the run's "expecting" line names the prerelease you just
-      published:
+      Vet a prerelease publish explicitly (at a prerelease checkout, the
+      registry-install test refuses other targets, a bare run's `latest`
+      included), and confirm the run's "expecting" line names the prerelease you
+      just published:
 
       ```sh
       DOCSY_THEME_PKG=@docsy/theme@next npm run test:smoke

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -246,25 +246,36 @@ Notes:
 - All but `test:smoke` run in CI.
 - To run one `test:repo` suite alone, pass its file(s) to `node --test`, e.g.
   `node --test tests/supply-chain-audit.test.mjs`.
-- `test:smoke` (slow, network-bound):
-  - Run it manually for `main` or PR-branch validation. Its GitHub-sourced
-    builds auto-target the current branch's GitHub upstream.
-  - Builds a minimal test site from the theme package (packed tarball, npm
-    registry) and from GitHub (NPM, Hugo module, clone, minimum-Hugo).
-  - The npm-registry install test vets an exact version (the checkout's, when
-    its release tag is in the checkout's history; otherwise `latest`), asserting
-    the installed version against the npm registry's own resolution.
-    `DOCSY_THEME_PKG` overrides the target (exact version or dist-tag); a
-    non-`-dev` prerelease checkout (an RC, for example) requires it.
-  - The suite never relaxes local npm hardening on its own -- the one relaxation
-    is the knob you pass: an install guard's block fails the run with the
-    guard's own remedy, and a release-age gate on the fresh theme package fails
-    it naming `DOCSY_THEME_MIN_RELEASE_AGE=N`, a suite knob applied to the
-    theme-package installs only. Any other pinned scratch dependency younger
-    than a local age gate fails its leg until the pin ages (npm's error names
-    the date cutoff). The make-site scratch sites carry their own baked
-    consumer-simulation `.npmrc` (7-day gate), which can differ from your
-    machine's settings.
+
+### test:smoke
+
+Run `test:smoke` locally for `main` or PR-branch validation. Its GitHub-sourced
+builds auto-target the current branch's GitHub upstream.
+
+- Slow, network-bound
+- Builds a minimal test site from:
+  - Theme package: packed tarball, npm registry
+  - GitHub: NPM, Hugo module, clone
+  - Hugo: pinned default and minimum Hugo-version builds
+
+Security:
+
+- The npm-registry install test vets an exact version: the checkout's, when its
+  release tag is in the checkout's history, otherwise `latest`; asserting the
+  installed version against the npm registry's own resolution.
+- `DOCSY_THEME_PKG` overrides the target: exact version or dist-tag; a
+  non-`-dev` prerelease checkout (an RC, for example) requires it.
+- The suite never relaxes local npm hardening on its own. When local hardening
+  blocks a run:
+  - An npm install-guard shim's block names its own override; follow the shim's
+    instructions to allow the run.
+  - For a release-age gate on a fresh Docsy theme package: set
+    `DOCSY_THEME_MIN_RELEASE_AGE=N` (N no lower than the release age in whole
+    days) to relax the cooldown to N days for the theme-package installs only.
+  - Any other pinned scratch dependency younger than a local age gate fails its
+    leg until the pin ages (npm's error names the date cutoff).
+  - The make-site scratch sites carry their own baked consumer-simulation
+    `.npmrc` (7-day gate), which can differ from your machine's settings.
 
 ### Structural guards: one concern per file
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -255,14 +255,16 @@ Notes:
     its release tag is in the checkout's history; otherwise `latest`), asserting
     the installed version against the npm registry's own resolution.
     `DOCSY_THEME_PKG` overrides the target (exact version or dist-tag); a
-    prerelease checkout requires it.
-  - The suite never overrides local npm hardening, and its installs run under
-    your ambient npm config: an install guard's block fails the run with the
+    non-`-dev` prerelease checkout (an RC, for example) requires it.
+  - The suite never relaxes local npm hardening on its own -- the one relaxation
+    is the knob you pass: an install guard's block fails the run with the
     guard's own remedy, and a release-age gate on the fresh theme package fails
     it naming `DOCSY_THEME_MIN_RELEASE_AGE=N`, a suite knob applied to the
     theme-package installs only. Any other pinned scratch dependency younger
     than a local age gate fails its leg until the pin ages (npm's error names
-    the date cutoff).
+    the date cutoff). The make-site scratch sites carry their own baked
+    consumer-simulation `.npmrc` (7-day gate), which can differ from your
+    machine's settings.
 
 ### Structural guards: one concern per file
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -249,13 +249,13 @@ Notes:
 - `test:smoke`:
   - Run it manually for `main` or PR-branch validation. Its GitHub-sourced
     builds auto-target the current branch's GitHub upstream.
-  - Builds a minimal test site from the theme package (packed tarball, registry)
-    and from GitHub (NPM, Hugo module, clone, minimum-Hugo).
-  - The registry-install test vets an exact version (the checkout's, when its
-    release tag is in the checkout's history; otherwise `latest`), asserting the
-    installed version against the registry's own resolution. `DOCSY_THEME_PKG`
-    overrides the target (exact version or dist-tag); a prerelease checkout
-    requires it.
+  - Builds a minimal test site from the theme package (packed tarball, npm
+    registry) and from GitHub (NPM, Hugo module, clone, minimum-Hugo).
+  - The npm-registry install test vets an exact version (the checkout's, when
+    its release tag is in the checkout's history; otherwise `latest`), asserting
+    the installed version against the npm registry's own resolution.
+    `DOCSY_THEME_PKG` overrides the target (exact version or dist-tag); a
+    prerelease checkout requires it.
   - The suite never overrides local npm hardening: an install guard or a
     release-age gate on the theme install fails the run loudly, naming the
     deliberate rerun knob.
@@ -615,20 +615,20 @@ If not adjust accordingly.
     its own checkbox.
 
     1. **Approve** the waiting `npm-publish` deployment. The guards re-verify
-       content and registry order mechanically (an out-of-order or inconsistent
-       run fails instead of publishing), and the approval prompt only appears
-       after the pack job succeeded, so approval owns **intent**. Note that on
-       tag pushes the workflow definition itself comes from the tagged commit,
-       so for an unexpected tag don't trust the run's green checks; the two
-       checks below are the real barrier:
+       content and npm-registry order mechanically (an out-of-order or
+       inconsistent run fails instead of publishing), and the approval prompt
+       only appears after the pack job succeeded, so approval owns **intent**.
+       Note that on tag pushes the workflow definition itself comes from the
+       tagged commit, so for an unexpected tag don't trust the run's green
+       checks; the two checks below are the real barrier:
        - the run's commit is the release commit you drove (the tip of `$BASE` at
          tag time; an unrelated merge landing since is fine), and the tag actor
          is the release driver you expect; anything else: reject and ask;
        - the run is `publish.yaml` on `google/docsy` (another workflow could
          reference the same environment).
 
-    2. **Check** that the workflow run succeeded and that the registry version
-       matches the tag:
+    2. **Check** that the workflow run succeeded and that the npm-registry
+       version matches the tag:
 
        ```sh
        npm view @docsy/theme version dist-tags
@@ -644,7 +644,7 @@ If not adjust accordingly.
        ```
 
     4. **Vet the published artifact**: run the [smoke tests](#test-suites) from
-       `$BASE`; the registry-install test vets exactly the just-published
+       `$BASE`; the npm-registry install test vets exactly the just-published
        version. (On a machine with local npm hardening, the first run fails by
        design; rerun as the failure directs.)
 
@@ -670,7 +670,7 @@ If not adjust accordingly.
       `@docsy` scope registry against local overrides.
 
       Vet a prerelease publish explicitly (at a prerelease checkout, the
-      registry-install test refuses other targets, a bare run's `latest`
+      npm-registry install test refuses other targets, a bare run's `latest`
       included), and confirm the run's "expecting" line names the prerelease you
       just published:
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -235,11 +235,11 @@ NPM_CONFIG_MIN_RELEASE_AGE=3 npm run update:hugo -- X.Y.Z
 
 From the repo root:
 
-| Script         | Role                                                                                                |
-| -------------- | --------------------------------------------------------------------------------------------------- |
-| `test:repo`    | Fast, offline repo checks. For details, see [`package.json`][package.json]                          |
-| `test:smoke`   | Slow, network-bound; builds a site from GitHub several ways (NPM, Hugo module, clone, minimum-Hugo) |
-| `test:website` | Full docsy.dev checks: format, links, hugo-build, alt-site, md-output, and favicon tests            |
+| Script         | Role                                                                                                                                                 |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `test:repo`    | Fast, offline repo checks. For details, see [`package.json`][package.json]                                                                           |
+| `test:smoke`   | Slow, network-bound; builds consumer sites from GitHub (NPM, Hugo module, clone, minimum-Hugo) and from the theme package (packed tarball, registry) |
+| `test:website` | Full docsy.dev checks: format, links, hugo-build, alt-site, md-output, and favicon tests                                                             |
 
 Notes:
 
@@ -248,6 +248,11 @@ Notes:
   `node --test tests/supply-chain-audit.test.mjs`.
 - Run `test:smoke` manually for `main` or PR-branch validation. Its tests
   auto-target the current branch's GitHub upstream.
+- The `test:smoke` registry-install test vets an exact version -- the checkout's
+  at a release tag, otherwise `latest` -- asserting the installed version
+  against the registry's own resolution. The suite never overrides local npm
+  hardening: an install guard or release-age gate fails the run loudly, naming
+  the deliberate rerun knob.
 
 ### Structural guards: one concern per file
 
@@ -633,11 +638,8 @@ If not adjust accordingly.
        ```
 
     4. **Vet the published artifact**: run the [smoke tests](#test-suites) from
-       `$BASE`; the registry-install test derives the just-published version
-       from the checkout and fails unless the registry serves exactly it. The
-       suite never overrides local npm hardening (install guards, a
-       `min-release-age` gate): those surface as loud failures naming the
-       deliberate rerun.
+       `$BASE`; the registry-install test vets exactly the just-published
+       version:
 
        ```sh
        npm run test:smoke

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -600,8 +600,8 @@ If not adjust accordingly.
     `release` branch needs the workflow's ancestry check deliberately widened
     first.
 
-    Each numbered substep below is a distinct gate; in a release-run tracker,
-    give each its own checkbox rather than one for the step.
+    When copying this procedure into a release-run tracker, give each substep
+    its own checkbox.
 
     1. **Approve** the waiting `npm-publish` deployment. The guards re-verify
        content and registry order mechanically (an out-of-order or inconsistent
@@ -632,13 +632,10 @@ If not adjust accordingly.
        npm dist-tag add @docsy/theme@${REL#v} next
        ```
 
-    4. **Vet the published artifact** by running the [smoke tests](#test-suites)
-       from `main` at the tag: the suite's registry-install test builds a site
-       from the published package. Pin the release explicitly: under npm's
-       `min-release-age`, the suite's default bare `@docsy/theme` install
-       silently resolves to the newest old-enough release, smoke-testing the
-       previous stable (this bit the 0.17.0 run); the exact pin fails visibly
-       instead, so pair it with a one-off age override:
+    4. **Vet the published artifact**: run the [smoke tests](#test-suites) from
+       `$BASE`, pinning the release -- a bare install
+       [resolves past a too-young release](/docs/update/npm-package/) and would
+       silently smoke-test the previous stable:
 
        ```sh
        DOCSY_THEME_PKG=@docsy/theme@${REL#v} NPM_CONFIG_MIN_RELEASE_AGE=0 npm run test:smoke

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -235,25 +235,28 @@ NPM_CONFIG_MIN_RELEASE_AGE=3 npm run update:hugo -- X.Y.Z
 
 From the repo root:
 
-| Script         | Role                                                                                                                                                 |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `test:repo`    | Fast, offline repo checks. For details, see [`package.json`][package.json]                                                                           |
-| `test:smoke`   | Slow, network-bound; builds consumer sites from GitHub (NPM, Hugo module, clone, minimum-Hugo) and from the theme package (packed tarball, registry) |
-| `test:website` | Full docsy.dev checks: format, links, hugo-build, alt-site, md-output, and favicon tests                                                             |
+| Script         | Role                                                                                         |
+| -------------- | -------------------------------------------------------------------------------------------- |
+| `test:repo`    | Fast, offline repo checks. For details, see [`package.json`][package.json]                   |
+| `test:smoke`   | Builds minimal test sites from the theme package and from GitHub; see note below for details |
+| `test:website` | Full docsy.dev checks: format, links, hugo-build, alt-site, md-output, and favicon tests     |
 
 Notes:
 
 - All but `test:smoke` run in CI.
 - To run one `test:repo` suite alone, pass its file(s) to `node --test`, e.g.
   `node --test tests/supply-chain-audit.test.mjs`.
-- Run `test:smoke` manually for `main` or PR-branch validation. Its tests
-  auto-target the current branch's GitHub upstream.
-- The `test:smoke` registry-install test vets an exact version (the checkout's,
-  when its release tag is in the checkout's history; otherwise `latest`),
-  asserting the installed version against the registry's own resolution. The
-  suite never overrides local npm hardening: an install guard or a release-age
-  gate on the theme install fails the run loudly, naming the deliberate rerun
-  knob.
+- `test:smoke`:
+  - Run it manually for `main` or PR-branch validation. Its tests auto-target
+    the current branch's GitHub upstream.
+  - Builds a minimal test site from the theme package (packed tarball, registry)
+    and from GitHub (NPM, Hugo module, clone, minimum-Hugo).
+  - The registry-install test vets an exact version (the checkout's, when its
+    release tag is in the checkout's history; otherwise `latest`), asserting the
+    installed version against the registry's own resolution.
+  - The suite never overrides local npm hardening: an install guard or a
+    release-age gate on the theme install fails the run loudly, naming the
+    deliberate rerun knob.
 
 ### Structural guards: one concern per file
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -258,7 +258,7 @@ Notes:
     prerelease checkout requires it.
   - The suite never overrides local npm hardening: an install guard or a
     release-age gate on the theme install fails the run loudly, naming the
-    deliberate rerun knob.
+    deliberate rerun knob (which the suite applies to the theme install only).
 
 ### Structural guards: one concern per file
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -634,7 +634,10 @@ If not adjust accordingly.
 
     4. **Vet the published artifact**: run the [smoke tests](#test-suites) from
        `$BASE`; the registry-install test derives the just-published version
-       from the checkout and fails unless the registry serves exactly it:
+       from the checkout and fails unless the registry serves exactly it. The
+       suite never overrides local npm hardening (install guards, a
+       `min-release-age` gate): those surface as loud failures naming the
+       deliberate rerun.
 
        ```sh
        npm run test:smoke

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -599,33 +599,48 @@ If not adjust accordingly.
     only publishes tags on `main`'s history: a patch release tagged on the
     `release` branch needs the workflow's ancestry check deliberately widened
     first.
-    - **Before approving** the waiting `npm-publish` deployment. The guards
-      re-verify content and registry order mechanically (an out-of-order or
-      inconsistent run fails instead of publishing), and the approval prompt
-      only appears after the pack job succeeded, so approval owns **intent**.
-      Note that on tag pushes the workflow definition itself comes from the
-      tagged commit, so for an unexpected tag don't trust the run's green
-      checks; the two checks below are the real barrier:
-      - the run's commit is the release commit you drove (the tip of `$BASE` at
-        tag time; an unrelated merge landing since is fine), and the tag actor
-        is the release driver you expect; anything else: reject and ask;
-      - the run is `publish.yaml` on `google/docsy` (another workflow could
-        reference the same environment).
-    - Check that the workflow run succeeded and that the registry version
-      matches the tag:
 
-      ```sh
-      npm view @docsy/theme version dist-tags
-      ```
+    Each numbered substep below is a distinct gate; in a release-run tracker,
+    give each its own checkbox rather than one for the step.
 
-    - Re-point the `next` dist-tag at the new stable (dist-tags never move on
-      their own, and `next` must stay `>= latest`). OIDC covers only the publish
-      itself, so run this inside a narrow auth window (login/logout, next
-      bullet), then re-verify the dist-tags:
+    1. **Approve** the waiting `npm-publish` deployment. The guards re-verify
+       content and registry order mechanically (an out-of-order or inconsistent
+       run fails instead of publishing), and the approval prompt only appears
+       after the pack job succeeded, so approval owns **intent**. Note that on
+       tag pushes the workflow definition itself comes from the tagged commit,
+       so for an unexpected tag don't trust the run's green checks; the two
+       checks below are the real barrier:
+       - the run's commit is the release commit you drove (the tip of `$BASE` at
+         tag time; an unrelated merge landing since is fine), and the tag actor
+         is the release driver you expect; anything else: reject and ask;
+       - the run is `publish.yaml` on `google/docsy` (another workflow could
+         reference the same environment).
 
-      ```sh
-      npm dist-tag add @docsy/theme@${REL#v} next
-      ```
+    2. **Check** that the workflow run succeeded and that the registry version
+       matches the tag:
+
+       ```sh
+       npm view @docsy/theme version dist-tags
+       ```
+
+    3. **Re-point the `next` dist-tag** at the new stable (dist-tags never move
+       on their own, and `next` must stay `>= latest`). OIDC covers only the
+       publish itself, so run this inside a narrow auth window (login/logout,
+       manual-publish note below), then re-verify the dist-tags:
+
+       ```sh
+       npm dist-tag add @docsy/theme@${REL#v} next
+       ```
+
+    4. **Vet the published artifact** by running the [smoke tests](#test-suites)
+       from `main` at the tag: with `latest` now on the new release, the suite's
+       registry-install test builds a site from the published package:
+
+       ```sh
+       npm run test:smoke
+       ```
+
+    Exceptions to the CI flow:
 
     - **Manual publishes** (prereleases only): the workflow triggers only on
       stable `vX.Y.Z` tags, so prereleases always publish manually. Publish from

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -273,8 +273,8 @@ Security:
   - For a release-age gate on a fresh Docsy theme package: set
     `DOCSY_THEME_MIN_RELEASE_AGE=N`, N = the release age in whole days (0 on
     release day; higher still blocks, lower over-relaxes), to relax the cooldown
-    for the theme-package install commands only -- the theme and the
-    dependencies those installs resolve; nothing else in the run.
+    for the theme-package install commands only: the theme and the dependencies
+    those installs resolve; nothing else in the run.
   - Any other pinned scratch dependency younger than a local age gate fails its
     leg until the pin ages (npm's error names the date cutoff).
   - The make-site scratch sites carry their own baked consumer-simulation

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -271,7 +271,9 @@ Security:
     instructions to allow the run.
   - For a release-age gate on a fresh Docsy theme package: set
     `DOCSY_THEME_MIN_RELEASE_AGE=N` (N no lower than the release age in whole
-    days) to relax the cooldown to N days for the theme-package installs only.
+    days) to relax the cooldown to N days for the theme-package install commands
+    only -- the theme and the dependencies those installs resolve; nothing else
+    in the run.
   - Any other pinned scratch dependency younger than a local age gate fails its
     leg until the pin ages (npm's error names the date cutoff).
   - The make-site scratch sites carry their own baked consumer-simulation

--- a/docsy.dev/link-cache.jsonc
+++ b/docsy.dev/link-cache.jsonc
@@ -2899,6 +2899,11 @@
     "when": "2026-09-01T03:31:13Z",
     "via": "lychee",
   },
+  "https://github.com/google/docsy/pull/2786": {
+    "status": 200,
+    "when": "2026-09-03T01:13:43Z",
+    "via": "lychee",
+  },
   "https://github.com/google/docsy/pull/941": {
     "status": 200,
     "when": "2026-09-02T08:07:06Z",

--- a/scripts/make-site.sh
+++ b/scripts/make-site.sh
@@ -141,8 +141,10 @@ function _npm_install() {
   # The theme's dartsass transpiler needs the sass CLI on Hugo's PATH; the
   # site provides it, mirroring the documented consumer setup for every
   # Docsy source. Runs after the --omit=dev install above, which would
-  # prune it.
-  npm install --ignore-scripts --no-audit --no-fund --save-dev sass-embedded
+  # prune it. Pinned to the repo's tested version, read from its manifest
+  # (the pin's one home).
+  npm install --ignore-scripts --no-audit --no-fund --save-dev \
+    "sass-embedded@$(node -p 'require(process.argv[1]).devDependencies["sass-embedded"]' "$SCRIPT_DIR/../package.json")"
   # The documented hugo passthrough script, with one harness twist: hugo is
   # the borrowed repo binary ($HUGO, expanded by the script shell at run
   # time), not a bare name. A name lookup would need the repo's bin dir on

--- a/scripts/make-site.sh
+++ b/scripts/make-site.sh
@@ -145,7 +145,7 @@ function _npm_install() {
   # (the pin's one home); an empty read would silently install latest
   # (set -e can't see a failure inside an argument), so guard it.
   sass_version=$(node -p 'require(process.argv[1]).devDependencies["sass-embedded"]' "$SCRIPT_DIR/../package.json")
-  [[ "$sass_version" =~ ^[0-9] ]] || { echo "ERROR: sass-embedded pin not found in the repo manifest (got: '$sass_version')" >&2; exit 1; }
+  [[ "$sass_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.+-]*$ ]] || { echo "ERROR: exact sass-embedded pin not found in the repo manifest (got: '$sass_version')" >&2; exit 1; }
   npm install --ignore-scripts --no-audit --no-fund --save-dev "sass-embedded@$sass_version"
   # The documented hugo passthrough script, with one harness twist: hugo is
   # the borrowed repo binary ($HUGO, expanded by the script shell at run

--- a/scripts/make-site.sh
+++ b/scripts/make-site.sh
@@ -142,9 +142,11 @@ function _npm_install() {
   # site provides it, mirroring the documented consumer setup for every
   # Docsy source. Runs after the --omit=dev install above, which would
   # prune it. Pinned to the repo's tested version, read from its manifest
-  # (the pin's one home).
-  npm install --ignore-scripts --no-audit --no-fund --save-dev \
-    "sass-embedded@$(node -p 'require(process.argv[1]).devDependencies["sass-embedded"]' "$SCRIPT_DIR/../package.json")"
+  # (the pin's one home); an empty read would silently install latest
+  # (set -e can't see a failure inside an argument), so guard it.
+  sass_version=$(node -p 'require(process.argv[1]).devDependencies["sass-embedded"]' "$SCRIPT_DIR/../package.json")
+  [[ -n "$sass_version" ]] || { echo "ERROR: sass-embedded pin not found in the repo manifest" >&2; exit 1; }
+  npm install --ignore-scripts --no-audit --no-fund --save-dev "sass-embedded@$sass_version"
   # The documented hugo passthrough script, with one harness twist: hugo is
   # the borrowed repo binary ($HUGO, expanded by the script shell at run
   # time), not a bare name. A name lookup would need the repo's bin dir on

--- a/scripts/make-site.sh
+++ b/scripts/make-site.sh
@@ -145,7 +145,7 @@ function _npm_install() {
   # (the pin's one home); an empty read would silently install latest
   # (set -e can't see a failure inside an argument), so guard it.
   sass_version=$(node -p 'require(process.argv[1]).devDependencies["sass-embedded"]' "$SCRIPT_DIR/../package.json")
-  [[ -n "$sass_version" ]] || { echo "ERROR: sass-embedded pin not found in the repo manifest" >&2; exit 1; }
+  [[ "$sass_version" =~ ^[0-9] ]] || { echo "ERROR: sass-embedded pin not found in the repo manifest (got: '$sass_version')" >&2; exit 1; }
   npm install --ignore-scripts --no-audit --no-fund --save-dev "sass-embedded@$sass_version"
   # The documented hugo passthrough script, with one harness twist: hugo is
   # the borrowed repo binary ($HUGO, expanded by the script shell at run

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -45,6 +45,9 @@ const MAKE_SITE = path.join(repoRoot, 'scripts', 'make-site.sh');
 // resolve the repo's own node_modules and mask a packaging gap. Only Hugo (the
 // build tool, not a dependency under test) is borrowed from the repo install.
 const HUGO_BIN = path.join(repoRoot, 'node_modules', '.bin', 'hugo');
+const THEME_VERSION = JSON.parse(
+  readFileSync(path.join(repoRoot, 'theme', 'package.json'), 'utf8'),
+).version;
 
 // PATH for consumer-site Hugo builds: the site's own bin dir first, and this
 // checkout's directories removed, so a consumer site missing its own sass
@@ -130,6 +133,12 @@ const winShell = process.platform === 'win32';
 // All sites built here are scratch sites; an inherited HUGO_THEME (worktree
 // checkouts) would override their pinned themes.
 delete process.env.HUGO_THEME;
+
+// The suite's installs are deliberate: pinned specs into throwaway sites.
+// Pre-authorize them under the npm-guard wrapper of the supply-chain setup
+// (rationale link in the root .npmrc); a no-op where the wrapper isn't
+// installed.
+process.env.NPM_GUARD_ALLOW_BARE_INSTALL = '1';
 
 // Run a command; surface its output only on failure.
 function run(cmd, args, opts = {}) {
@@ -262,12 +271,30 @@ function buildThemeConsumerSite(name, pkgSpec) {
   assert.equal(
     run(
       'npm',
-      ['install', '--ignore-scripts', '--no-audit', '--no-fund', pkgSpec],
+      [
+        'install',
+        '--ignore-scripts',
+        '--no-audit',
+        '--no-fund',
+        // The spec is exact (tarball path or pinned version), so a release-age
+        // cooldown adds nothing here; without the override, a gated npm config
+        // ETARGETs a fresh release instead of installing it. A flag, not
+        // NPM_CONFIG_* env: npm ignores the env form in direct spawns.
+        '--min-release-age=0',
+        pkgSpec,
+      ],
       npmOpts,
     ).status,
     0,
     `${pkgSpec} installs`,
   );
+  const installed = JSON.parse(
+    readFileSync(
+      path.join(site, 'node_modules', '@docsy', 'theme', 'package.json'),
+      'utf8',
+    ),
+  ).version;
+  progress(`${name}: installed @docsy/theme@${installed}`);
   installSiteSass(name, npmOpts);
 
   // The one-line consumer config change (@ must be quoted in YAML).
@@ -284,6 +311,7 @@ function buildThemeConsumerSite(name, pkgSpec) {
   assertBuilt(name);
   assertGenFaviconsBin(site);
   progress(`${name}: ok`);
+  return installed;
 }
 
 test('tarball install of @docsy/theme packed from this checkout', () => {
@@ -312,16 +340,45 @@ test('tarball install of @docsy/theme packed from this checkout', () => {
   assert.equal(pack.status, 0, 'npm pack exits 0');
   const tgz = readdirSync(packDest).find((f) => f.endsWith('.tgz'));
   assert.ok(tgz, 'npm pack produced a tarball');
-  buildThemeConsumerSite('smoke-tarball', path.join(packDest, tgz));
+  const installed = buildThemeConsumerSite(
+    'smoke-tarball',
+    path.join(packDest, tgz),
+  );
+  // Dev versions pack with a build-ID stamp appended (scripts/pack-stamp.mjs);
+  // releases and RCs pack unchanged.
+  assert.ok(
+    installed === THEME_VERSION || installed.startsWith(`${THEME_VERSION}+`),
+    `packed theme version (${installed}) matches the checkout (${THEME_VERSION})`,
+  );
 });
 
-// DOCSY_THEME_PKG overrides the registry spec: e.g. @docsy/theme@next to vet
-// an RC, or @docsy/theme@0.16.0 to pin a version. The default, the bare name,
-// resolves to the `latest` dist-tag: whatever the registry currently serves
-// plain `npm install @docsy/theme` users.
-const REGISTRY_PKG = process.env.DOCSY_THEME_PKG ?? '@docsy/theme';
+// Registry spec: always an exact pin, derived -- a bare @docsy/theme resolves
+// through the local npm config, where a min-release-age gate silently
+// redirects it to the previous old-enough stable (the 0.17.0 release vet
+// installed 0.16.0). At a release tag the checkout's theme version is the
+// just-published stable: vet exactly it. Between releases (dev-stamped theme)
+// vet what consumers get: the registry's actual `latest`, resolved
+// explicitly. DOCSY_THEME_PKG overrides both: e.g. @docsy/theme@next to vet
+// an RC.
+function registrySpec() {
+  if (process.env.DOCSY_THEME_PKG) return process.env.DOCSY_THEME_PKG;
+  if (/^\d+\.\d+\.\d+$/.test(THEME_VERSION))
+    return `@docsy/theme@${THEME_VERSION}`;
+  const view = run('npm', ['view', '@docsy/theme', 'dist-tags.latest'], {
+    cwd: repoRoot,
+    shell: winShell,
+  });
+  if (view.status !== 0 || !view.stdout.trim())
+    throw new Error('npm view failed to resolve @docsy/theme dist-tags.latest');
+  return `@docsy/theme@${view.stdout.trim()}`;
+}
+const REGISTRY_PKG = registrySpec();
 test(`registry install of ${REGISTRY_PKG}`, () => {
-  buildThemeConsumerSite('smoke-registry', REGISTRY_PKG);
+  const installed = buildThemeConsumerSite('smoke-registry', REGISTRY_PKG);
+  // Exact except under a dist-tag override (e.g. @next).
+  const pinned = REGISTRY_PKG.match(/@(\d+\.\d+\.\d+[^@]*)$/)?.[1];
+  if (pinned)
+    assert.equal(installed, pinned, 'installed theme version matches the pin');
 });
 
 // --- declared minimum Hugo version actually builds --------------------------

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -54,7 +54,7 @@ const SASS_VERSION = JSON.parse(
 ).devDependencies['sass-embedded'];
 assert.match(
   SASS_VERSION ?? '',
-  /^\d/,
+  /^\d+\.\d+\.\d+[\w.+-]*$/,
   'the repo manifest carries an exact sass-embedded pin',
 );
 
@@ -386,33 +386,67 @@ test('tarball install of @docsy/theme packed from this checkout', () => {
   );
 });
 
-// Registry spec: an exact pin when the checkout is at a release (stable
-// manifest version and its git tag exists: notes step 15.4) -- a
-// stable-stamped but untagged checkout is release prep pre-publish (notes
-// step 8), where the version isn't on the registry yet -- else `latest`. The
+// Registry spec: an exact pin when the checkout is at a published release
+// (stable manifest version whose git tag is an ancestor of HEAD: notes step
+// 15.4, tolerating unrelated merges landing after the tag); a stable-stamped
+// but untagged checkout is release prep pre-publish (notes step 8), where the
+// version isn't on the registry yet, so `latest` gets vetted instead. The
 // test resolves the spec's expected version registry-side (npm view, ungated
 // by min-release-age) and asserts the installed version matches, so a local
 // age gate can't silently redirect any spec form to an older stable (the
 // 0.17.0 release vet installed 0.16.0). DOCSY_THEME_PKG overrides the spec:
 // e.g. @docsy/theme@next to vet an RC. `||`: an empty override means unset.
 const REGISTRY_PKG = process.env.DOCSY_THEME_PKG || derivedRegistrySpec();
+let derivationError;
 function derivedRegistrySpec() {
   if (/^\d+\.\d+\.\d+$/.test(THEME_VERSION)) {
-    const tag = run('git', ['-C', repoRoot, 'tag', '-l', `v${THEME_VERSION}`]);
-    if ((tag.stdout ?? '').trim()) return `@docsy/theme@${THEME_VERSION}`;
+    const gitArgs = ['-C', repoRoot];
+    const tag = run('git', [
+      ...gitArgs,
+      'rev-parse',
+      '-q',
+      '--verify',
+      `refs/tags/v${THEME_VERSION}`,
+    ]);
+    // Exit 1 (silent) is "no such tag"; anything else is a checkout without
+    // usable git identity (shallow/tagless clone, source archive), where a
+    // guessed target could vet the wrong artifact. Recorded, not thrown: a
+    // load-time throw would abort the file's five other tests.
+    if (tag.status !== 0 && tag.status !== 1) {
+      derivationError =
+        'the release state of this checkout is determinable (git identity unavailable; name the target by adding DOCSY_THEME_PKG=@docsy/theme@VERSION to your command)';
+      return '@docsy/theme@latest';
+    }
+    if (
+      tag.status === 0 &&
+      run('git', [
+        ...gitArgs,
+        'merge-base',
+        '--is-ancestor',
+        tag.stdout.trim(),
+        'HEAD',
+      ]).status === 0
+    ) {
+      return `@docsy/theme@${THEME_VERSION}`;
+    }
     progress(
-      `registry: ${THEME_VERSION} is stamped but untagged (pre-publish); vetting latest`,
+      `registry: ${THEME_VERSION} is stamped but its tag is ${
+        tag.status === 0 ? 'not in this history' : 'not created yet'
+      } (pre-publish); vetting latest`,
     );
   }
   return '@docsy/theme@latest';
 }
 test(`registry install of ${REGISTRY_PKG}`, () => {
-  // The vet targets the registry package; a path or foreign-package override
-  // would test something else while reporting a registry vet.
+  if (derivationError) assert.fail(derivationError);
+  // The vet targets the registry package, by exact version or dist-tag only:
+  // a path or foreign-package override would test something else while
+  // reporting a registry vet, and on Windows the spec reaches npm through a
+  // shell (winShell), so metacharacters and ranges stay out.
   assert.match(
     REGISTRY_PKG,
-    /^@docsy\/theme(@|$)/,
-    `DOCSY_THEME_PKG (${REGISTRY_PKG}) targets the @docsy/theme registry package`,
+    /^@docsy\/theme(@[\w.+~-]+)?$/,
+    `DOCSY_THEME_PKG (${REGISTRY_PKG}) is an exact-version or dist-tag form of the @docsy/theme registry package`,
   );
   const view = run('npm', ['view', REGISTRY_PKG, 'version'], {
     cwd: repoRoot,
@@ -432,14 +466,15 @@ test(`registry install of ${REGISTRY_PKG}`, () => {
     `${REGISTRY_PKG} resolves to a single version (got: ${expected})`,
   );
   // A prerelease checkout names the artifact just published (manual RC flow);
-  // a stale dist-tag resolving elsewhere would vet the wrong artifact. A
-  // -dev checkout can't anchor this (the RC stamp is uncommitted and restored
-  // post-publish); the notes have the driver eyeball the expecting line.
+  // any other resolution, a bare run's `latest` included, would vet the wrong
+  // artifact. A -dev checkout can't anchor this (the RC stamp is uncommitted
+  // and restored post-publish); the notes have the driver eyeball the
+  // expecting line.
   if (/^\d+\.\d+\.\d+-/.test(THEME_VERSION) && !THEME_VERSION.endsWith('-dev'))
     assert.equal(
       expected,
       THEME_VERSION,
-      `${REGISTRY_PKG} resolves to this prerelease checkout's version (a stale dist-tag vets the wrong artifact)`,
+      `${REGISTRY_PKG} resolves to this prerelease checkout's version (vet the prerelease explicitly by adding DOCSY_THEME_PKG=@docsy/theme@next to your command; a stale dist-tag vets the wrong artifact)`,
     );
   progress(`smoke-registry: expecting @docsy/theme@${expected}`);
   buildThemeConsumerSite('smoke-registry', REGISTRY_PKG, expected);

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -216,10 +216,11 @@ before(() => {
       shell: winShell,
     },
   );
-  assert.ok(
-    !(probe.status !== 0 && /npm-guard/.test(probe.stderr ?? '')),
-    'npm installs are unblocked (a PATH guard blocks the suite; its installs are pinned specs into throwaway scratch sites, so rerun deliberately: NPM_GUARD_ALLOW_BARE_INSTALL=1 npm run test:smoke)',
-  );
+  if (probe.status !== 0 && /npm-guard/.test(probe.stderr ?? '')) {
+    assert.fail(
+      'npm installs are blocked by a PATH guard; the suite installs pinned specs into throwaway scratch sites, so rerun deliberately: NPM_GUARD_ALLOW_BARE_INSTALL=1 npm run test:smoke',
+    );
+  }
 });
 
 // An npm install of @docsy/theme wires the package bins into
@@ -288,9 +289,8 @@ function buildThemeConsumerSite(name, pkgSpec) {
     ['install', '--ignore-scripts', '--no-audit', '--no-fund', pkgSpec],
     npmOpts,
   );
-  // A fresh release is younger than a local min-release-age gate; the suite
-  // honors the gate (never overrides it) and instead maps the failure to the
-  // deliberate rerun.
+  // A fresh release is younger than a local min-release-age gate (which the
+  // suite honors); map the failure to the deliberate rerun.
   if (install.status !== 0 && /ETARGET/.test(install.stderr ?? '')) {
     assert.fail(
       `${pkgSpec} is blocked by your npm min-release-age setting; it is the artifact under test, so vet it deliberately: NPM_CONFIG_MIN_RELEASE_AGE=0 npm run test:smoke`,
@@ -361,33 +361,36 @@ test('tarball install of @docsy/theme packed from this checkout', () => {
   );
 });
 
-// Registry spec: always an exact pin, derived -- a bare @docsy/theme resolves
-// through the local npm config, where a min-release-age gate silently
-// redirects it to the previous old-enough stable (the 0.17.0 release vet
-// installed 0.16.0). At a release tag the checkout's theme version is the
-// just-published stable: vet exactly it. Between releases (dev-stamped theme)
-// vet what consumers get: the registry's actual `latest`, resolved
-// explicitly. DOCSY_THEME_PKG overrides both: e.g. @docsy/theme@next to vet
-// an RC.
-function registrySpec() {
-  if (process.env.DOCSY_THEME_PKG) return process.env.DOCSY_THEME_PKG;
-  if (/^\d+\.\d+\.\d+$/.test(THEME_VERSION))
-    return `@docsy/theme@${THEME_VERSION}`;
-  const view = run('npm', ['view', '@docsy/theme', 'dist-tags.latest'], {
+// Registry spec: an exact pin when the checkout names one -- at a release tag
+// the theme version is the just-published stable, so vet exactly it -- else
+// `latest`. The test resolves the spec's expected version registry-side
+// (npm view, ungated by min-release-age) and asserts the installed version
+// matches, so a local age gate can't silently redirect any spec form to an
+// older stable (the 0.17.0 release vet installed 0.16.0). DOCSY_THEME_PKG
+// overrides the spec: e.g. @docsy/theme@next to vet an RC.
+const REGISTRY_PKG =
+  process.env.DOCSY_THEME_PKG ??
+  (/^\d+\.\d+\.\d+$/.test(THEME_VERSION)
+    ? `@docsy/theme@${THEME_VERSION}`
+    : '@docsy/theme@latest');
+test(`registry install of ${REGISTRY_PKG}`, () => {
+  const view = run('npm', ['view', REGISTRY_PKG, 'version'], {
     cwd: repoRoot,
     shell: winShell,
   });
-  if (view.status !== 0 || !view.stdout.trim())
-    throw new Error('npm view failed to resolve @docsy/theme dist-tags.latest');
-  return `@docsy/theme@${view.stdout.trim()}`;
-}
-const REGISTRY_PKG = registrySpec();
-test(`registry install of ${REGISTRY_PKG}`, () => {
+  const expected = (view.stdout ?? '').trim();
+  if (view.status !== 0 || !expected) {
+    assert.fail(
+      `${REGISTRY_PKG} resolves on the registry (view failed; for a fresh release, check that the npm publish landed: maintainer notes step 15)`,
+    );
+  }
+  progress(`smoke-registry: expecting @docsy/theme@${expected}`);
   const installed = buildThemeConsumerSite('smoke-registry', REGISTRY_PKG);
-  // Exact except under a dist-tag override (e.g. @next).
-  const pinned = REGISTRY_PKG.match(/@(\d+\.\d+\.\d+[^@]*)$/)?.[1];
-  if (pinned)
-    assert.equal(installed, pinned, 'installed theme version matches the pin');
+  assert.equal(
+    installed,
+    expected,
+    `installed version matches the registry's resolution of ${REGISTRY_PKG} (a mismatch usually means a local min-release-age gate redirected the install; vet deliberately: NPM_CONFIG_MIN_RELEASE_AGE=0 npm run test:smoke)`,
+  );
 });
 
 // --- declared minimum Hugo version actually builds --------------------------

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -58,11 +58,21 @@ assert.match(
   'the repo manifest carries an exact sass-embedded pin',
 );
 
-// One home for the age-gate remedy. The override spans the whole run's
-// installs (env config outranks even a project .npmrc gate), which is
-// acceptable because every npm-registry install here is an exact reviewed pin.
+// One home for the age-gate remedy. The suite scopes the granted override to
+// the theme install (the exact, asserted artifact under test): scratch sites
+// have no lockfile, so a run-wide relaxation would also admit fresh
+// transitive releases under the other pinned top-level installs. The knob is
+// captured here, stripped from the environment the child installs inherit,
+// and re-applied as a flag on the one install it targets.
 const AGE_GATE_REMEDY =
   'add NPM_CONFIG_MIN_RELEASE_AGE=N to your command, N no lower than the release age in whole days (0 on release day)';
+let ageGateOverride;
+for (const key of Object.keys(process.env)) {
+  if (/^npm_config_min[-_]release[-_]age$/i.test(key)) {
+    ageGateOverride ??= process.env[key];
+    delete process.env[key];
+  }
+}
 
 // PATH for consumer-site Hugo builds: the site's own bin dir first, and this
 // checkout's directories removed, so a consumer site missing its own sass
@@ -289,7 +299,18 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
   );
   const install = run(
     'npm',
-    ['install', '--ignore-scripts', '--no-audit', '--no-fund', pkgSpec],
+    [
+      'install',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      // The captured age-gate override applies here only (rationale at
+      // AGE_GATE_REMEDY); harmless for the tarball leg's path spec.
+      ...(ageGateOverride !== undefined
+        ? [`--min-release-age=${ageGateOverride}`]
+        : []),
+      pkgSpec,
+    ],
     npmOpts,
   );
   // A fresh release is younger than a local min-release-age gate (which the
@@ -385,9 +406,9 @@ test('tarball install of @docsy/theme packed from this checkout', () => {
 // age gate can't silently redirect any spec form to an older stable (the
 // 0.17.0 release vet installed 0.16.0). DOCSY_THEME_PKG overrides the spec:
 // e.g. @docsy/theme@next to vet an RC. `||`: an empty override means unset.
+let derivationError;
 const NPM_REGISTRY_PKG =
   process.env.DOCSY_THEME_PKG || derivedNpmRegistrySpec();
-let derivationError;
 function derivedNpmRegistrySpec() {
   if (/^\d+\.\d+\.\d+$/.test(THEME_VERSION)) {
     const gitArgs = ['-C', repoRoot];
@@ -421,21 +442,23 @@ function derivedNpmRegistrySpec() {
     }
     progress(
       `npm registry: ${THEME_VERSION} is stamped but its tag is ${
-        tag.status === 0 ? 'not in this history' : 'not created yet'
-      } (pre-publish); vetting latest`,
+        tag.status === 0
+          ? 'not in this history'
+          : `not in this clone (pre-publish, or tags unfetched; if ${THEME_VERSION} is published, fetch tags or set DOCSY_THEME_PKG)`
+      }; vetting latest`,
     );
   }
   return '@docsy/theme@latest';
 }
 test(`npm-registry install of ${NPM_REGISTRY_PKG}`, () => {
   if (derivationError) assert.fail(derivationError);
-  // The vet targets the npm-registry package, by exact version or dist-tag only:
-  // a path or foreign-package override would test something else while
-  // reporting an npm-registry vet, and on Windows the spec reaches npm through a
-  // shell (winShell), so metacharacters and ranges stay out.
+  // The vet targets the npm-registry package, by exact version or dist-tag
+  // only: a path, foreign-package, or range override would test something
+  // other than what it reports, and on Windows the spec reaches npm through
+  // a shell (winShell), so metacharacters stay out.
   assert.match(
     NPM_REGISTRY_PKG,
-    /^@docsy\/theme(@[\w.+~-]+)?$/,
+    /^@docsy\/theme(@(\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?|[A-Za-z][\w-]*))?$/,
     `DOCSY_THEME_PKG (${NPM_REGISTRY_PKG}) is an exact-version or dist-tag form of the @docsy/theme npm-registry package`,
   );
   const view = run('npm', ['view', NPM_REGISTRY_PKG, 'version'], {

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -210,23 +210,6 @@ before(() => {
     /extended/,
     'extended Hugo is installed (missing? run `npm run install:safe` at the repo root)',
   );
-  // The suite never overrides local npm security settings; it fails loud and
-  // names the rerun instead. An install-blocking PATH guard (e.g. the
-  // npm-guard shim) would fail every consumer test the same way, so probe
-  // once here: a dry-run install resolves nothing and changes nothing.
-  const probe = run(
-    'npm',
-    ['install', '--dry-run', '--no-audit', '--no-fund'],
-    {
-      cwd: TMP,
-      shell: winShell,
-    },
-  );
-  if (probe.status !== 0 && /npm-guard/.test(probe.stderr ?? '')) {
-    assert.fail(
-      'npm installs are runnable (a PATH guard blocked the probe; the suite installs pinned specs into throwaway scratch sites, so rerun deliberately with NPM_GUARD_ALLOW_BARE_INSTALL=1 added to your command)',
-    );
-  }
 });
 
 // An npm install of @docsy/theme wires the package bins into

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -58,21 +58,21 @@ assert.match(
   'the repo manifest carries an exact sass-embedded pin',
 );
 
-// One home for the age-gate remedy. The suite scopes the granted override to
-// the theme install (the exact, asserted artifact under test): scratch sites
-// have no lockfile, so a run-wide relaxation would also admit fresh
-// transitive releases under the other pinned top-level installs. The knob is
-// captured here, stripped from the environment the child installs inherit,
-// and re-applied as a flag on the one install it targets.
+// One home for the age-gate remedy: a suite-owned knob, applied as a flag on
+// the theme-package installs only (the exact, asserted artifact under test,
+// plus its fresh dep pins). The generic npm knob is deliberately not used:
+// scratch sites have no lockfile, so a run-wide relaxation would admit fresh
+// transitive releases under the other pinned installs -- those stay under the
+// operator's ambient npm config, untouched in either direction.
 const AGE_GATE_REMEDY =
-  'add NPM_CONFIG_MIN_RELEASE_AGE=N to your command, N no lower than the release age in whole days (0 on release day)';
-let ageGateOverride;
-for (const key of Object.keys(process.env)) {
-  if (/^npm_config_min[-_]release[-_]age$/i.test(key)) {
-    ageGateOverride ??= process.env[key];
-    delete process.env[key];
-  }
-}
+  'add DOCSY_THEME_MIN_RELEASE_AGE=N to your command, N no lower than the release age in whole days (0 on release day); the suite applies it to the theme-package installs only';
+const ageGateOverride = process.env.DOCSY_THEME_MIN_RELEASE_AGE || undefined;
+if (ageGateOverride !== undefined)
+  assert.match(
+    ageGateOverride,
+    /^\d+$/,
+    `DOCSY_THEME_MIN_RELEASE_AGE (${ageGateOverride}) is a whole number of days`,
+  );
 
 // PATH for consumer-site Hugo builds: the site's own bin dir first, and this
 // checkout's directories removed, so a consumer site missing its own sass
@@ -304,8 +304,10 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
       '--ignore-scripts',
       '--no-audit',
       '--no-fund',
-      // The captured age-gate override applies here only (rationale at
-      // AGE_GATE_REMEDY); harmless for the tarball leg's path spec.
+      // The granted override applies here only (rationale at AGE_GATE_REMEDY);
+      // as a flag it outranks env-borne config. Load-bearing for both legs:
+      // the tarball's path spec is ungated, but its fresh theme dep pins
+      // resolve from the npm registry too.
       ...(ageGateOverride !== undefined
         ? [`--min-release-age=${ageGateOverride}`]
         : []),
@@ -412,17 +414,24 @@ const NPM_REGISTRY_PKG =
 function derivedNpmRegistrySpec() {
   if (/^\d+\.\d+\.\d+$/.test(THEME_VERSION)) {
     const gitArgs = ['-C', repoRoot];
-    const tag = run('git', [
-      ...gitArgs,
-      'rev-parse',
-      '-q',
-      '--verify',
-      `refs/tags/v${THEME_VERSION}`,
-    ]);
-    // Exit 1 (silent) is "no such tag"; anything else is a checkout without
-    // usable git identity (shallow/tagless clone, source archive), where a
-    // guessed target could vet the wrong artifact. Recorded, not thrown: a
-    // load-time throw would abort the file's five other tests.
+    // spawnSync, not run(): a nonzero exit is an expected answer for both
+    // probes, not a failure to dump.
+    const tag = spawnSync(
+      'git',
+      [
+        ...gitArgs,
+        'rev-parse',
+        '-q',
+        '--verify',
+        `refs/tags/v${THEME_VERSION}`,
+      ],
+      { encoding: 'utf8' },
+    );
+    // Exit 1 (silent) is "no such tag" (pre-publish, or a clone without the
+    // tag fetched); anything else is a checkout without usable git identity
+    // (source archive, broken git), where a guessed target could vet the
+    // wrong artifact. Recorded, not thrown: a load-time throw would abort the
+    // file's five other tests.
     if (tag.status !== 0 && tag.status !== 1) {
       derivationError =
         'the release state of this checkout is determinable (git identity unavailable; name the target by adding DOCSY_THEME_PKG=@docsy/theme@VERSION to your command)';
@@ -430,13 +439,11 @@ function derivedNpmRegistrySpec() {
     }
     if (
       tag.status === 0 &&
-      run('git', [
-        ...gitArgs,
-        'merge-base',
-        '--is-ancestor',
-        tag.stdout.trim(),
-        'HEAD',
-      ]).status === 0
+      spawnSync(
+        'git',
+        [...gitArgs, 'merge-base', '--is-ancestor', tag.stdout.trim(), 'HEAD'],
+        { encoding: 'utf8' },
+      ).status === 0
     ) {
       return `@docsy/theme@${THEME_VERSION}`;
     }
@@ -458,7 +465,7 @@ test(`npm-registry install of ${NPM_REGISTRY_PKG}`, () => {
   // a shell (winShell), so metacharacters stay out.
   assert.match(
     NPM_REGISTRY_PKG,
-    /^@docsy\/theme(@(\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?|[A-Za-z][\w-]*))?$/,
+    /^@docsy\/theme(@(\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?|[A-Za-z][\w.-]*))?$/,
     `DOCSY_THEME_PKG (${NPM_REGISTRY_PKG}) is an exact-version or dist-tag form of the @docsy/theme npm-registry package`,
   );
   const view = run('npm', ['view', NPM_REGISTRY_PKG, 'version'], {

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -29,6 +29,7 @@ import {
   readdirSync,
   rmSync,
   statSync,
+  writeFileSync,
   writeSync,
 } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -51,6 +52,11 @@ const THEME_VERSION = JSON.parse(
 const SASS_VERSION = JSON.parse(
   readFileSync(path.join(repoRoot, 'package.json'), 'utf8'),
 ).devDependencies['sass-embedded'];
+assert.match(
+  SASS_VERSION ?? '',
+  /^\d/,
+  'the repo manifest carries an exact sass-embedded pin',
+);
 
 // PATH for consumer-site Hugo builds: the site's own bin dir first, and this
 // checkout's directories removed, so a consumer site missing its own sass
@@ -218,7 +224,7 @@ before(() => {
   );
   if (probe.status !== 0 && /npm-guard/.test(probe.stderr ?? '')) {
     assert.fail(
-      'npm installs are runnable (a PATH guard blocked the probe; the suite installs pinned specs into throwaway scratch sites, so rerun deliberately: NPM_GUARD_ALLOW_BARE_INSTALL=1 npm run test:smoke)',
+      'npm installs are runnable (a PATH guard blocked the probe; the suite installs pinned specs into throwaway scratch sites, so rerun deliberately with NPM_GUARD_ALLOW_BARE_INSTALL=1 added to your command)',
     );
   }
 });
@@ -284,6 +290,14 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
   progress(`${name}: npm install ${pkgSpec}…`);
   const npmOpts = { cwd: site, shell: winShell };
   assert.equal(run('npm', ['init', '-y'], npmOpts).status, 0, 'npm init');
+  // Pin which registry serves the scoped package, mirroring the root .npmrc
+  // (its rationale comment): the expected version was resolved against npmjs,
+  // so the install must not route through a user-configured mirror whose
+  // same-version artifact could differ.
+  writeFileSync(
+    path.join(site, '.npmrc'),
+    '@docsy:registry=https://registry.npmjs.org/\n',
+  );
   const install = run(
     'npm',
     ['install', '--ignore-scripts', '--no-audit', '--no-fund', pkgSpec],
@@ -293,7 +307,7 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
   // suite honors); map the failure to the deliberate rerun.
   if (install.status !== 0 && /ETARGET/.test(install.stderr ?? '')) {
     assert.fail(
-      `${pkgSpec} is installable (blocked by your npm min-release-age setting; it is the artifact under test, so vet it deliberately: NPM_CONFIG_MIN_RELEASE_AGE=0 npm run test:smoke)`,
+      `${pkgSpec} is installable (blocked by your npm min-release-age setting; it is the artifact under test, so vet it deliberately by adding NPM_CONFIG_MIN_RELEASE_AGE=0 to your command)`,
     );
   }
   assert.equal(install.status, 0, `${pkgSpec} installs`);
@@ -310,7 +324,7 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
     assert.equal(
       installed,
       expected,
-      `installed version matches the registry's resolution of ${pkgSpec} (a mismatch usually means a local min-release-age gate redirected the install; vet deliberately: NPM_CONFIG_MIN_RELEASE_AGE=0 npm run test:smoke)`,
+      `installed version matches the registry's resolution of ${pkgSpec} (a mismatch usually means a local min-release-age gate redirected the install; vet deliberately by adding NPM_CONFIG_MIN_RELEASE_AGE=0 to your command)`,
     );
   }
   installSiteSass(name, npmOpts);
@@ -372,19 +386,34 @@ test('tarball install of @docsy/theme packed from this checkout', () => {
   );
 });
 
-// Registry spec: an exact pin when the checkout names one -- at a release tag
-// the theme version is the just-published stable, so vet exactly it -- else
-// `latest`. The test resolves the spec's expected version registry-side
-// (npm view, ungated by min-release-age) and asserts the installed version
-// matches, so a local age gate can't silently redirect any spec form to an
-// older stable (the 0.17.0 release vet installed 0.16.0). DOCSY_THEME_PKG
-// overrides the spec: e.g. @docsy/theme@next to vet an RC.
-const REGISTRY_PKG =
-  process.env.DOCSY_THEME_PKG ??
-  (/^\d+\.\d+\.\d+$/.test(THEME_VERSION)
-    ? `@docsy/theme@${THEME_VERSION}`
-    : '@docsy/theme@latest');
+// Registry spec: an exact pin when the checkout is at a release (stable
+// manifest version and its git tag exists: notes step 15.4) -- a
+// stable-stamped but untagged checkout is release prep pre-publish (notes
+// step 8), where the version isn't on the registry yet -- else `latest`. The
+// test resolves the spec's expected version registry-side (npm view, ungated
+// by min-release-age) and asserts the installed version matches, so a local
+// age gate can't silently redirect any spec form to an older stable (the
+// 0.17.0 release vet installed 0.16.0). DOCSY_THEME_PKG overrides the spec:
+// e.g. @docsy/theme@next to vet an RC. `||`: an empty override means unset.
+const REGISTRY_PKG = process.env.DOCSY_THEME_PKG || derivedRegistrySpec();
+function derivedRegistrySpec() {
+  if (/^\d+\.\d+\.\d+$/.test(THEME_VERSION)) {
+    const tag = run('git', ['-C', repoRoot, 'tag', '-l', `v${THEME_VERSION}`]);
+    if ((tag.stdout ?? '').trim()) return `@docsy/theme@${THEME_VERSION}`;
+    progress(
+      `registry: ${THEME_VERSION} is stamped but untagged (pre-publish); vetting latest`,
+    );
+  }
+  return '@docsy/theme@latest';
+}
 test(`registry install of ${REGISTRY_PKG}`, () => {
+  // The vet targets the registry package; a path or foreign-package override
+  // would test something else while reporting a registry vet.
+  assert.match(
+    REGISTRY_PKG,
+    /^@docsy\/theme(@|$)/,
+    `DOCSY_THEME_PKG (${REGISTRY_PKG}) targets the @docsy/theme registry package`,
+  );
   const view = run('npm', ['view', REGISTRY_PKG, 'version'], {
     cwd: repoRoot,
     shell: winShell,
@@ -402,6 +431,16 @@ test(`registry install of ${REGISTRY_PKG}`, () => {
     /^\d+\.\d+\.\d+\S*$/,
     `${REGISTRY_PKG} resolves to a single version (got: ${expected})`,
   );
+  // A prerelease checkout names the artifact just published (manual RC flow);
+  // a stale dist-tag resolving elsewhere would vet the wrong artifact. A
+  // -dev checkout can't anchor this (the RC stamp is uncommitted and restored
+  // post-publish); the notes have the driver eyeball the expecting line.
+  if (/^\d+\.\d+\.\d+-/.test(THEME_VERSION) && !THEME_VERSION.endsWith('-dev'))
+    assert.equal(
+      expected,
+      THEME_VERSION,
+      `${REGISTRY_PKG} resolves to this prerelease checkout's version (a stale dist-tag vets the wrong artifact)`,
+    );
   progress(`smoke-registry: expecting @docsy/theme@${expected}`);
   buildThemeConsumerSite('smoke-registry', REGISTRY_PKG, expected);
 });

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -476,13 +476,20 @@ test(`npm-registry install of ${NPM_REGISTRY_PKG}`, () => {
   // reaches npm through a shell (winShell), so metacharacters stay out.
   assert.match(
     NPM_REGISTRY_PKG,
-    /^@docsy\/theme(@(\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?|[A-Za-z][\w.-]*))?$/,
+    /^@docsy\/theme(@(\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?|[A-Za-z][\w.-]*))?$/,
     `DOCSY_THEME_PKG (${NPM_REGISTRY_PKG}) is the @docsy/theme npm-registry package, with an optional exact-version or dist-tag pin`,
   );
-  const view = run('npm', ['view', NPM_REGISTRY_PKG, 'version'], {
-    cwd: repoRoot,
-    shell: winShell,
-  });
+  // --prefer-online: the expectation must come from the npm registry itself;
+  // under an offline/prefer-offline npm config, view and install would agree
+  // on a stale cached resolution and the equality below couldn't catch it.
+  const view = run(
+    'npm',
+    ['view', '--prefer-online', NPM_REGISTRY_PKG, 'version'],
+    {
+      cwd: repoRoot,
+      shell: winShell,
+    },
+  );
   const expected = (view.stdout ?? '').trim();
   if (view.status !== 0 || !expected) {
     assert.fail(

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -274,7 +274,7 @@ for (const src of ['NPM', 'HUGO_MODULE']) {
 // check that covers the code under review. The npm-registry test installs a
 // published spec: the post-publish check.
 
-function buildThemeConsumerSite(name, pkgSpec, expected) {
+function buildThemeConsumerSite(name, themePkgSpec, expected) {
   const site = path.join(TMP, name);
   rmSync(site, { recursive: true, force: true });
 
@@ -286,7 +286,7 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
     'hugo new site',
   );
 
-  progress(`${name}: npm install ${pkgSpec}…`);
+  progress(`${name}: npm install ${themePkgSpec}…`);
   const npmOpts = { cwd: site, shell: winShell };
   assert.equal(run('npm', ['init', '-y'], npmOpts).status, 0, 'npm init');
   // Pin which npm registry serves the scoped package, mirroring the root .npmrc
@@ -311,7 +311,7 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
       ...(ageGateOverride !== undefined
         ? [`--min-release-age=${ageGateOverride}`]
         : []),
-      pkgSpec,
+      themePkgSpec,
     ],
     npmOpts,
   );
@@ -325,10 +325,10 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
     /with a date before/.test(install.stderr ?? '')
   ) {
     assert.fail(
-      `${pkgSpec} is installable (blocked by your npm min-release-age setting; it is the artifact under test, so vet it deliberately: ${AGE_GATE_REMEDY})`,
+      `${themePkgSpec} is installable (blocked by your npm min-release-age setting; it is the artifact under test, so vet it deliberately: ${AGE_GATE_REMEDY})`,
     );
   }
-  assert.equal(install.status, 0, `${pkgSpec} installs`);
+  assert.equal(install.status, 0, `${themePkgSpec} installs`);
   const installed = JSON.parse(
     readFileSync(
       path.join(site, 'node_modules', '@docsy', 'theme', 'package.json'),
@@ -342,7 +342,7 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
     assert.equal(
       installed,
       expected,
-      `installed version matches the npm registry's resolution of ${pkgSpec} (a mismatch usually means a local min-release-age gate redirected the install; ${AGE_GATE_REMEDY})`,
+      `installed version matches the npm registry's resolution of ${themePkgSpec} (a mismatch usually means a local min-release-age gate redirected the install; ${AGE_GATE_REMEDY})`,
     );
   }
   installSiteSass(name, npmOpts);

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -70,8 +70,8 @@ const ageGateOverride = process.env.DOCSY_THEME_MIN_RELEASE_AGE || undefined;
 if (ageGateOverride !== undefined)
   assert.match(
     ageGateOverride,
-    /^\d+$/,
-    `DOCSY_THEME_MIN_RELEASE_AGE (${ageGateOverride}) is a whole number of days`,
+    /^\d{1,4}$/,
+    `DOCSY_THEME_MIN_RELEASE_AGE (${ageGateOverride}) is a whole number of days (at most 4 digits)`,
   );
 
 // PATH for consumer-site Hugo builds: the site's own bin dir first, and this
@@ -316,8 +316,14 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
     npmOpts,
   );
   // A fresh release is younger than a local min-release-age gate (which the
-  // suite honors); map the failure to the deliberate rerun.
-  if (install.status !== 0 && /ETARGET/.test(install.stderr ?? '')) {
+  // suite honors); map that failure -- identified by npm's date-cutoff
+  // diagnostic, so other ETARGETs (broken pins) keep npm's own message -- to
+  // the deliberate rerun.
+  if (
+    install.status !== 0 &&
+    /ETARGET/.test(install.stderr ?? '') &&
+    /with a date before/.test(install.stderr ?? '')
+  ) {
     assert.fail(
       `${pkgSpec} is installable (blocked by your npm min-release-age setting; it is the artifact under test, so vet it deliberately: ${AGE_GATE_REMEDY})`,
     );
@@ -437,15 +443,20 @@ function derivedNpmRegistrySpec() {
         'the release state of this checkout is determinable (git identity unavailable; name the target by adding DOCSY_THEME_PKG=@docsy/theme@VERSION to your command)';
       return '@docsy/theme@latest';
     }
-    if (
-      tag.status === 0 &&
-      spawnSync(
+    if (tag.status === 0) {
+      const ancestor = spawnSync(
         'git',
         [...gitArgs, 'merge-base', '--is-ancestor', tag.stdout.trim(), 'HEAD'],
         { encoding: 'utf8' },
-      ).status === 0
-    ) {
-      return `@docsy/theme@${THEME_VERSION}`;
+      );
+      if (ancestor.status === 0) return `@docsy/theme@${THEME_VERSION}`;
+      // Same status routing as the tag probe: only "not an ancestor" (1)
+      // falls back; a fatal error must not silently redirect the vet.
+      if (ancestor.status !== 1) {
+        derivationError =
+          'the release state of this checkout is determinable (git ancestry check failed; name the target by adding DOCSY_THEME_PKG=@docsy/theme@VERSION to your command)';
+        return '@docsy/theme@latest';
+      }
     }
     progress(
       `npm registry: ${THEME_VERSION} is stamped but its tag is ${
@@ -459,14 +470,14 @@ function derivedNpmRegistrySpec() {
 }
 test(`npm-registry install of ${NPM_REGISTRY_PKG}`, () => {
   if (derivationError) assert.fail(derivationError);
-  // The vet targets the npm-registry package, by exact version or dist-tag
-  // only: a path, foreign-package, or range override would test something
-  // other than what it reports, and on Windows the spec reaches npm through
-  // a shell (winShell), so metacharacters stay out.
+  // The vet targets the npm-registry package, optionally pinned by exact
+  // version or dist-tag: a path, foreign-package, or range override would
+  // test something other than what it reports, and on Windows the spec
+  // reaches npm through a shell (winShell), so metacharacters stay out.
   assert.match(
     NPM_REGISTRY_PKG,
     /^@docsy\/theme(@(\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?|[A-Za-z][\w.-]*))?$/,
-    `DOCSY_THEME_PKG (${NPM_REGISTRY_PKG}) is an exact-version or dist-tag form of the @docsy/theme npm-registry package`,
+    `DOCSY_THEME_PKG (${NPM_REGISTRY_PKG}) is the @docsy/theme npm-registry package, with an optional exact-version or dist-tag pin`,
   );
   const view = run('npm', ['view', NPM_REGISTRY_PKG, 'version'], {
     cwd: repoRoot,

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -58,6 +58,12 @@ assert.match(
   'the repo manifest carries an exact sass-embedded pin',
 );
 
+// One home for the age-gate remedy. The override spans the whole run's
+// installs (env config outranks even a project .npmrc gate), which is
+// acceptable because every registry install here is an exact reviewed pin.
+const AGE_GATE_REMEDY =
+  'add NPM_CONFIG_MIN_RELEASE_AGE=N to your command, N no lower than the release age in whole days (0 on release day)';
+
 // PATH for consumer-site Hugo builds: the site's own bin dir first, and this
 // checkout's directories removed, so a consumer site missing its own sass
 // compiler fails loud instead of silently borrowing the maintainer repo's
@@ -290,7 +296,7 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
   // suite honors); map the failure to the deliberate rerun.
   if (install.status !== 0 && /ETARGET/.test(install.stderr ?? '')) {
     assert.fail(
-      `${pkgSpec} is installable (blocked by your npm min-release-age setting; it is the artifact under test, so vet it deliberately by adding NPM_CONFIG_MIN_RELEASE_AGE=0 to your command)`,
+      `${pkgSpec} is installable (blocked by your npm min-release-age setting; it is the artifact under test, so vet it deliberately: ${AGE_GATE_REMEDY})`,
     );
   }
   assert.equal(install.status, 0, `${pkgSpec} installs`);
@@ -307,7 +313,7 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
     assert.equal(
       installed,
       expected,
-      `installed version matches the registry's resolution of ${pkgSpec} (a mismatch usually means a local min-release-age gate redirected the install; vet deliberately by adding NPM_CONFIG_MIN_RELEASE_AGE=0 to your command)`,
+      `installed version matches the registry's resolution of ${pkgSpec} (a mismatch usually means a local min-release-age gate redirected the install; ${AGE_GATE_REMEDY})`,
     );
   }
   installSiteSass(name, npmOpts);

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -60,7 +60,7 @@ assert.match(
 
 // One home for the age-gate remedy. The override spans the whole run's
 // installs (env config outranks even a project .npmrc gate), which is
-// acceptable because every registry install here is an exact reviewed pin.
+// acceptable because every npm-registry install here is an exact reviewed pin.
 const AGE_GATE_REMEDY =
   'add NPM_CONFIG_MIN_RELEASE_AGE=N to your command, N no lower than the release age in whole days (0 on release day)';
 
@@ -261,7 +261,7 @@ for (const src of ['NPM', 'HUGO_MODULE']) {
 // Install the theme-only package into a scratch site outside the repo and
 // exercise the consumer contract: a styled build plus the wired gen-favicons
 // bin. The tarball test packs theme/ from this checkout: the pre-publish
-// check that covers the code under review. The registry test installs a
+// check that covers the code under review. The npm-registry test installs a
 // published spec: the post-publish check.
 
 function buildThemeConsumerSite(name, pkgSpec, expected) {
@@ -279,7 +279,7 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
   progress(`${name}: npm install ${pkgSpec}…`);
   const npmOpts = { cwd: site, shell: winShell };
   assert.equal(run('npm', ['init', '-y'], npmOpts).status, 0, 'npm init');
-  // Pin which registry serves the scoped package, mirroring the root .npmrc
+  // Pin which npm registry serves the scoped package, mirroring the root .npmrc
   // (its rationale comment): the expected version was resolved against npmjs,
   // so the install must not route through a user-configured mirror whose
   // same-version artifact could differ.
@@ -313,7 +313,7 @@ function buildThemeConsumerSite(name, pkgSpec, expected) {
     assert.equal(
       installed,
       expected,
-      `installed version matches the registry's resolution of ${pkgSpec} (a mismatch usually means a local min-release-age gate redirected the install; ${AGE_GATE_REMEDY})`,
+      `installed version matches the npm registry's resolution of ${pkgSpec} (a mismatch usually means a local min-release-age gate redirected the install; ${AGE_GATE_REMEDY})`,
     );
   }
   installSiteSass(name, npmOpts);
@@ -375,19 +375,20 @@ test('tarball install of @docsy/theme packed from this checkout', () => {
   );
 });
 
-// Registry spec: an exact pin when the checkout is at a published release
+// Npm-registry spec: an exact pin when the checkout is at a published release
 // (stable manifest version whose git tag is an ancestor of HEAD: notes step
 // 15.4, tolerating unrelated merges landing after the tag); a stable-stamped
 // but untagged checkout is release prep pre-publish (notes step 8), where the
-// version isn't on the registry yet, so `latest` gets vetted instead. The
-// test resolves the spec's expected version registry-side (npm view, ungated
+// version isn't on the npm registry yet, so `latest` gets vetted instead. The
+// test resolves the spec's expected version npm-registry-side (npm view, ungated
 // by min-release-age) and asserts the installed version matches, so a local
 // age gate can't silently redirect any spec form to an older stable (the
 // 0.17.0 release vet installed 0.16.0). DOCSY_THEME_PKG overrides the spec:
 // e.g. @docsy/theme@next to vet an RC. `||`: an empty override means unset.
-const REGISTRY_PKG = process.env.DOCSY_THEME_PKG || derivedRegistrySpec();
+const NPM_REGISTRY_PKG =
+  process.env.DOCSY_THEME_PKG || derivedNpmRegistrySpec();
 let derivationError;
-function derivedRegistrySpec() {
+function derivedNpmRegistrySpec() {
   if (/^\d+\.\d+\.\d+$/.test(THEME_VERSION)) {
     const gitArgs = ['-C', repoRoot];
     const tag = run('git', [
@@ -419,32 +420,32 @@ function derivedRegistrySpec() {
       return `@docsy/theme@${THEME_VERSION}`;
     }
     progress(
-      `registry: ${THEME_VERSION} is stamped but its tag is ${
+      `npm registry: ${THEME_VERSION} is stamped but its tag is ${
         tag.status === 0 ? 'not in this history' : 'not created yet'
       } (pre-publish); vetting latest`,
     );
   }
   return '@docsy/theme@latest';
 }
-test(`registry install of ${REGISTRY_PKG}`, () => {
+test(`npm-registry install of ${NPM_REGISTRY_PKG}`, () => {
   if (derivationError) assert.fail(derivationError);
-  // The vet targets the registry package, by exact version or dist-tag only:
+  // The vet targets the npm-registry package, by exact version or dist-tag only:
   // a path or foreign-package override would test something else while
-  // reporting a registry vet, and on Windows the spec reaches npm through a
+  // reporting an npm-registry vet, and on Windows the spec reaches npm through a
   // shell (winShell), so metacharacters and ranges stay out.
   assert.match(
-    REGISTRY_PKG,
+    NPM_REGISTRY_PKG,
     /^@docsy\/theme(@[\w.+~-]+)?$/,
-    `DOCSY_THEME_PKG (${REGISTRY_PKG}) is an exact-version or dist-tag form of the @docsy/theme registry package`,
+    `DOCSY_THEME_PKG (${NPM_REGISTRY_PKG}) is an exact-version or dist-tag form of the @docsy/theme npm-registry package`,
   );
-  const view = run('npm', ['view', REGISTRY_PKG, 'version'], {
+  const view = run('npm', ['view', NPM_REGISTRY_PKG, 'version'], {
     cwd: repoRoot,
     shell: winShell,
   });
   const expected = (view.stdout ?? '').trim();
   if (view.status !== 0 || !expected) {
     assert.fail(
-      `${REGISTRY_PKG} resolves on the registry (view failed; for a fresh release, check that the npm publish landed: maintainer notes step 15)`,
+      `${NPM_REGISTRY_PKG} resolves on the npm registry (view failed; for a fresh release, check that the npm publish landed: maintainer notes step 15)`,
     );
   }
   // Range-ish specs make npm view emit labeled multi-line output; fail here,
@@ -452,7 +453,7 @@ test(`registry install of ${REGISTRY_PKG}`, () => {
   assert.match(
     expected,
     /^\d+\.\d+\.\d+\S*$/,
-    `${REGISTRY_PKG} resolves to a single version (got: ${expected})`,
+    `${NPM_REGISTRY_PKG} resolves to a single version (got: ${expected})`,
   );
   // A prerelease checkout names the artifact just published (manual RC flow);
   // any other resolution, a bare run's `latest` included, would vet the wrong
@@ -463,10 +464,10 @@ test(`registry install of ${REGISTRY_PKG}`, () => {
     assert.equal(
       expected,
       THEME_VERSION,
-      `${REGISTRY_PKG} resolves to this prerelease checkout's version (vet the prerelease explicitly by adding DOCSY_THEME_PKG=@docsy/theme@next to your command; a stale dist-tag vets the wrong artifact)`,
+      `${NPM_REGISTRY_PKG} resolves to this prerelease checkout's version (vet the prerelease explicitly by adding DOCSY_THEME_PKG=@docsy/theme@next to your command; a stale dist-tag vets the wrong artifact)`,
     );
-  progress(`smoke-registry: expecting @docsy/theme@${expected}`);
-  buildThemeConsumerSite('smoke-registry', REGISTRY_PKG, expected);
+  progress(`smoke-npm-registry: expecting @docsy/theme@${expected}`);
+  buildThemeConsumerSite('smoke-npm-registry', NPM_REGISTRY_PKG, expected);
 });
 
 // --- declared minimum Hugo version actually builds --------------------------

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -25,6 +25,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   readdirSync,
   rmSync,
@@ -65,7 +66,9 @@ assert.match(
 // transitive releases under the other pinned installs -- those stay under the
 // operator's ambient npm config, untouched in either direction.
 const AGE_GATE_REMEDY =
-  'add DOCSY_THEME_MIN_RELEASE_AGE=N to your command, N no lower than the release age in whole days (0 on release day); the suite applies it to the theme-package installs only';
+  'add DOCSY_THEME_MIN_RELEASE_AGE=N to your command, N = the release age in whole days (0 on release day): higher still blocks, lower over-relaxes; the suite applies it to the theme-package installs only';
+// Load-time on purpose (unlike derivationError): a mistyped operator value
+// should fail before any network work, and it concerns every theme install.
 const ageGateOverride = process.env.DOCSY_THEME_MIN_RELEASE_AGE || undefined;
 if (ageGateOverride !== undefined)
   assert.match(
@@ -325,7 +328,7 @@ function buildThemeConsumerSite(name, themePkgSpec, expected) {
     /with a date before/.test(install.stderr ?? '')
   ) {
     assert.fail(
-      `${themePkgSpec} is installable (blocked by your npm min-release-age setting; it is the artifact under test, so vet it deliberately: ${AGE_GATE_REMEDY})`,
+      `${themePkgSpec} is installable (blocked by your npm min-release-age setting; the theme package or its dependency pins are the artifact under test, so vet it deliberately: ${AGE_GATE_REMEDY})`,
     );
   }
   assert.equal(install.status, 0, `${themePkgSpec} installs`);
@@ -479,21 +482,26 @@ test(`npm-registry install of ${NPM_REGISTRY_PKG}`, () => {
     /^@docsy\/theme(@(\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?|[A-Za-z][\w.-]*))?$/,
     `DOCSY_THEME_PKG (${NPM_REGISTRY_PKG}) is the @docsy/theme npm-registry package, with an optional exact-version or dist-tag pin`,
   );
-  // --prefer-online: the expectation must come from the npm registry itself;
-  // under an offline/prefer-offline npm config, view and install would agree
-  // on a stale cached resolution and the equality below couldn't catch it.
+  // The expectation must come from the npm registry itself, so the view runs
+  // against a fresh, empty cache: a miss can't be served stale (under an
+  // offline config it fails loudly), whereas --prefer-online is a no-op here
+  // (view already prefers online) and loses to ambient offline/prefer-offline
+  // config, and a warm cache serves stale-if-error even online. The install
+  // keeps the shared cache: a stale install can't match a fresh expectation.
+  const viewCache = mkdtempSync(path.join(TMP, 'view-cache-'));
   const view = run(
     'npm',
-    ['view', '--prefer-online', NPM_REGISTRY_PKG, 'version'],
+    ['view', `--cache=${viewCache}`, NPM_REGISTRY_PKG, 'version'],
     {
       cwd: repoRoot,
       shell: winShell,
     },
   );
+  rmSync(viewCache, { recursive: true, force: true });
   const expected = (view.stdout ?? '').trim();
   if (view.status !== 0 || !expected) {
     assert.fail(
-      `${NPM_REGISTRY_PKG} resolves on the npm registry (view failed; for a fresh release, check that the npm publish landed: maintainer notes step 15)`,
+      `${NPM_REGISTRY_PKG} resolves on the npm registry (view failed: registry unreachable, or for a fresh release, check that the npm publish landed: maintainer notes step 15)`,
     );
   }
   // Range-ish specs make npm view emit labeled multi-line output; fail here,

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -218,7 +218,7 @@ before(() => {
   );
   if (probe.status !== 0 && /npm-guard/.test(probe.stderr ?? '')) {
     assert.fail(
-      'npm installs are blocked by a PATH guard; the suite installs pinned specs into throwaway scratch sites, so rerun deliberately: NPM_GUARD_ALLOW_BARE_INSTALL=1 npm run test:smoke',
+      'npm installs are runnable (a PATH guard blocked the probe; the suite installs pinned specs into throwaway scratch sites, so rerun deliberately: NPM_GUARD_ALLOW_BARE_INSTALL=1 npm run test:smoke)',
     );
   }
 });
@@ -269,7 +269,7 @@ for (const src of ['NPM', 'HUGO_MODULE']) {
 // check that covers the code under review. The registry test installs a
 // published spec: the post-publish check.
 
-function buildThemeConsumerSite(name, pkgSpec) {
+function buildThemeConsumerSite(name, pkgSpec, expected) {
   const site = path.join(TMP, name);
   rmSync(site, { recursive: true, force: true });
 
@@ -293,7 +293,7 @@ function buildThemeConsumerSite(name, pkgSpec) {
   // suite honors); map the failure to the deliberate rerun.
   if (install.status !== 0 && /ETARGET/.test(install.stderr ?? '')) {
     assert.fail(
-      `${pkgSpec} is blocked by your npm min-release-age setting; it is the artifact under test, so vet it deliberately: NPM_CONFIG_MIN_RELEASE_AGE=0 npm run test:smoke`,
+      `${pkgSpec} is installable (blocked by your npm min-release-age setting; it is the artifact under test, so vet it deliberately: NPM_CONFIG_MIN_RELEASE_AGE=0 npm run test:smoke)`,
     );
   }
   assert.equal(install.status, 0, `${pkgSpec} installs`);
@@ -304,6 +304,15 @@ function buildThemeConsumerSite(name, pkgSpec) {
     ),
   ).version;
   progress(`${name}: installed @docsy/theme@${installed}`);
+  // Assert before building: a redirected install would otherwise burn a full
+  // build of the wrong version, whose own failure could mask this diagnostic.
+  if (expected !== undefined) {
+    assert.equal(
+      installed,
+      expected,
+      `installed version matches the registry's resolution of ${pkgSpec} (a mismatch usually means a local min-release-age gate redirected the install; vet deliberately: NPM_CONFIG_MIN_RELEASE_AGE=0 npm run test:smoke)`,
+    );
+  }
   installSiteSass(name, npmOpts);
 
   // The one-line consumer config change (@ must be quoted in YAML).
@@ -354,9 +363,11 @@ test('tarball install of @docsy/theme packed from this checkout', () => {
     path.join(packDest, tgz),
   );
   // Dev versions pack with a build-ID stamp appended (scripts/pack-stamp.mjs);
-  // releases and RCs pack unchanged.
+  // releases and RCs pack unchanged, so only a -dev checkout may differ.
   assert.ok(
-    installed === THEME_VERSION || installed.startsWith(`${THEME_VERSION}+`),
+    installed === THEME_VERSION ||
+      (THEME_VERSION.endsWith('-dev') &&
+        installed.startsWith(`${THEME_VERSION}+`)),
     `packed theme version (${installed}) matches the checkout (${THEME_VERSION})`,
   );
 });
@@ -384,13 +395,15 @@ test(`registry install of ${REGISTRY_PKG}`, () => {
       `${REGISTRY_PKG} resolves on the registry (view failed; for a fresh release, check that the npm publish landed: maintainer notes step 15)`,
     );
   }
-  progress(`smoke-registry: expecting @docsy/theme@${expected}`);
-  const installed = buildThemeConsumerSite('smoke-registry', REGISTRY_PKG);
-  assert.equal(
-    installed,
+  // Range-ish specs make npm view emit labeled multi-line output; fail here,
+  // where the cause is visible, rather than at the version equality.
+  assert.match(
     expected,
-    `installed version matches the registry's resolution of ${REGISTRY_PKG} (a mismatch usually means a local min-release-age gate redirected the install; vet deliberately: NPM_CONFIG_MIN_RELEASE_AGE=0 npm run test:smoke)`,
+    /^\d+\.\d+\.\d+\S*$/,
+    `${REGISTRY_PKG} resolves to a single version (got: ${expected})`,
   );
+  progress(`smoke-registry: expecting @docsy/theme@${expected}`);
+  buildThemeConsumerSite('smoke-registry', REGISTRY_PKG, expected);
 });
 
 // --- declared minimum Hugo version actually builds --------------------------

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -134,12 +134,6 @@ const winShell = process.platform === 'win32';
 // checkouts) would override their pinned themes.
 delete process.env.HUGO_THEME;
 
-// The suite's installs are deliberate: pinned specs into throwaway sites.
-// Pre-authorize them under the npm-guard wrapper of the supply-chain setup
-// (rationale link in the root .npmrc); a no-op where the wrapper isn't
-// installed.
-process.env.NPM_GUARD_ALLOW_BARE_INSTALL = '1';
-
 // Run a command; surface its output only on failure.
 function run(cmd, args, opts = {}) {
   const r = spawnSync(cmd, args, { encoding: 'utf8', ...opts });
@@ -205,6 +199,22 @@ before(() => {
     /extended/,
     'extended Hugo is installed (missing? run `npm run install:safe` at the repo root)',
   );
+  // The suite never overrides local npm security settings; it fails loud and
+  // names the rerun instead. An install-blocking PATH guard (e.g. the
+  // npm-guard shim) would fail every consumer test the same way, so probe
+  // once here: a dry-run install resolves nothing and changes nothing.
+  const probe = run(
+    'npm',
+    ['install', '--dry-run', '--no-audit', '--no-fund'],
+    {
+      cwd: TMP,
+      shell: winShell,
+    },
+  );
+  assert.ok(
+    !(probe.status !== 0 && /npm-guard/.test(probe.stderr ?? '')),
+    'npm installs are unblocked (a PATH guard blocks the suite; its installs are pinned specs into throwaway scratch sites, so rerun deliberately: NPM_GUARD_ALLOW_BARE_INSTALL=1 npm run test:smoke)',
+  );
 });
 
 // An npm install of @docsy/theme wires the package bins into
@@ -268,26 +278,20 @@ function buildThemeConsumerSite(name, pkgSpec) {
   progress(`${name}: npm install ${pkgSpec}…`);
   const npmOpts = { cwd: site, shell: winShell };
   assert.equal(run('npm', ['init', '-y'], npmOpts).status, 0, 'npm init');
-  assert.equal(
-    run(
-      'npm',
-      [
-        'install',
-        '--ignore-scripts',
-        '--no-audit',
-        '--no-fund',
-        // The spec is exact (tarball path or pinned version), so a release-age
-        // cooldown adds nothing here; without the override, a gated npm config
-        // ETARGETs a fresh release instead of installing it. A flag, not
-        // NPM_CONFIG_* env: npm ignores the env form in direct spawns.
-        '--min-release-age=0',
-        pkgSpec,
-      ],
-      npmOpts,
-    ).status,
-    0,
-    `${pkgSpec} installs`,
+  const install = run(
+    'npm',
+    ['install', '--ignore-scripts', '--no-audit', '--no-fund', pkgSpec],
+    npmOpts,
   );
+  // A fresh release is younger than a local min-release-age gate; the suite
+  // honors the gate (never overrides it) and instead maps the failure to the
+  // deliberate rerun.
+  if (install.status !== 0 && /ETARGET/.test(install.stderr ?? '')) {
+    assert.fail(
+      `${pkgSpec} is blocked by your npm min-release-age setting; it is the artifact under test, so vet it deliberately: NPM_CONFIG_MIN_RELEASE_AGE=0 npm run test:smoke`,
+    );
+  }
+  assert.equal(install.status, 0, `${pkgSpec} installs`);
   const installed = JSON.parse(
     readFileSync(
       path.join(site, 'node_modules', '@docsy', 'theme', 'package.json'),

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -48,6 +48,9 @@ const HUGO_BIN = path.join(repoRoot, 'node_modules', '.bin', 'hugo');
 const THEME_VERSION = JSON.parse(
   readFileSync(path.join(repoRoot, 'theme', 'package.json'), 'utf8'),
 ).version;
+const SASS_VERSION = JSON.parse(
+  readFileSync(path.join(repoRoot, 'package.json'), 'utf8'),
+).devDependencies['sass-embedded'];
 
 // PATH for consumer-site Hugo builds: the site's own bin dir first, and this
 // checkout's directories removed, so a consumer site missing its own sass
@@ -67,9 +70,11 @@ function consumerEnv(site) {
 }
 
 // The documented consumer action for the dartsass transpiler: the site
-// provides its own sass compiler (Install Dart Sass, prerequisites doc).
+// provides its own sass compiler (Install Dart Sass, prerequisites doc) --
+// at the repo's tested pin, so a fresh upstream sass release can't perturb
+// the suite.
 function installSiteSass(label, npmOpts) {
-  progress(`${label}: npm install sass-embedded…`);
+  progress(`${label}: npm install sass-embedded@${SASS_VERSION}…`);
   assert.equal(
     run(
       'npm',
@@ -79,7 +84,7 @@ function installSiteSass(label, npmOpts) {
         '--no-audit',
         '--no-fund',
         '--save-dev',
-        'sass-embedded',
+        `sass-embedded@${SASS_VERSION}`,
       ],
       npmOpts,
     ).status,


### PR DESCRIPTION
- **Numbers step 15's publish-verify gates** (approve, check, re-point `next`, vet) so release trackers box each individually: the 0.17.0 run's single box hid the pending `next` re-point after the publish landed
- **Makes the smoke suite's npm-registry vet honest**: the 0.17.0 vet silently smoke-tested 0.16.0 (a local `min-release-age` gate redirected the bare install); the suite now vets an exact version (the checkout's, when its release tag is in the checkout's history; a stable-stamped untagged checkout is release prep pre-publish and keeps vetting `latest`), asserting the installed version against the npm registry's own resolution (fetched from a fresh cache) immediately after the install; a checkout without usable git identity fails the vet rather than guessing; overrides are restricted to exact-version or dist-tag forms, and the prerelease vet (`@next`) is documented at the manual-publish bullet
- **Honors local npm hardening in both directions**: the suite never relaxes ambient npm config on its own; an install guard fails the run with its own remedy, and an age-gated fresh theme fails naming `DOCSY_THEME_MIN_RELEASE_AGE=N`, a suite-owned knob applied to the theme-package installs only (review rounds falsified two earlier generic-knob designs on hardened machines)
- **Re-homes the smoke mechanics** in a new Test suites `### test:smoke` subsection (build matrix, security contract, overrides), leaving step 15.4 as the command
- **Pins scratch-site `sass-embedded`** to the repo's tested version on all six legs, and pins the scratch install's `@docsy` registry to npmjs (where the version expectation is resolved)
- **Preview**: [Publishing a release § step 15](https://deploy-preview-2786--docsydocs.netlify.app/project/about/maintainer-notes/#publishing-a-release)


