### PR TITLE
Project docs: re-home script/plugin architecture from code comments

### DIFF
--- a/docsy.dev/content/en/project/_index.md
+++ b/docsy.dev/content/en/project/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Project and website documentation
 linkTitle: Project docs
-description: Architecture and maintainer workflows for the Docsy theme and website
+description:
+  Architecture and maintainer workflows for the Docsy theme and website
 aliases: [site]
 cascade:
   type: docs

--- a/docsy.dev/content/en/project/_index.md
+++ b/docsy.dev/content/en/project/_index.md
@@ -31,8 +31,8 @@ Planned content organization (tentative):
   SCSS/JS customizations, patches, and internal shims.
 - [Build](build/): Tooling, local development setup, CI/CD workflows, deployment
   environments, and automation details.
-- [Quality](quality/): Tests, link checking, accessibility standards, and
-  review practices.
+- [Quality](quality/): Tests, link checking, accessibility standards, and review
+  practices.
 - **Roadmap**: Milestones, backlog, priorities, technical debt, and
   design/implementation decisions.
 

--- a/docsy.dev/content/en/project/_index.md
+++ b/docsy.dev/content/en/project/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Project and website documentation
 linkTitle: Project docs
-description: How Docsy theme and website are built, maintained, and deployed.
+description: Architecture and maintainer workflows for the Docsy theme and website
 aliases: [site]
 cascade:
   type: docs
@@ -10,8 +10,7 @@ cascade:
 cSpell:ignore: docsydocs
 ---
 
-This section is for Docsy maintainers and contributors. It documents how the
-theme and this website are organized, built, maintained, and released.
+This section is for Docsy maintainers and contributors.
 
 <span class="badge bg-warning text-bg-warning fs-6">
 {{% _param FAS person-digging " pe-2" %}} Section under construction. {{%

--- a/docsy.dev/content/en/project/_index.md
+++ b/docsy.dev/content/en/project/_index.md
@@ -31,8 +31,8 @@ Planned content organization (tentative):
   SCSS/JS customizations, patches, and internal shims.
 - [Build](build/): Tooling, local development setup, CI/CD workflows, deployment
   environments, and automation details.
-- [Quality](quality/): Link checking, accessibility standards, tests, review
-  practices, and other quality-related processes.
+- [Quality](quality/): Tests, link checking, accessibility standards, and
+  review practices.
 - **Roadmap**: Milestones, backlog, priorities, technical debt, and
   design/implementation decisions.
 

--- a/docsy.dev/content/en/project/_index.md
+++ b/docsy.dev/content/en/project/_index.md
@@ -10,6 +10,9 @@ cascade:
 cSpell:ignore: docsydocs
 ---
 
+This section is for Docsy maintainers and contributors. It documents how the
+theme and this website are organized, built, maintained, and released.
+
 <span class="badge bg-warning text-bg-warning fs-6">
 {{% _param FAS person-digging " pe-2" %}} Section under construction. {{%
 _param FAS person-digging " ps-2" %}}
@@ -28,8 +31,8 @@ Planned content organization (tentative):
   SCSS/JS customizations, patches, and internal shims.
 - [Build](build/): Tooling, local development setup, CI/CD workflows, deployment
   environments, and automation details.
-- **Quality**: Link checking, accessibility standards, tests, review practices,
-  and other quality-related processes.
+- [Quality](quality/): Link checking, accessibility standards, tests, review
+  practices, and other quality-related processes.
 - **Roadmap**: Milestones, backlog, priorities, technical debt, and
   design/implementation decisions.
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -38,7 +38,10 @@ restating them:
   milestone gathers the issues resolved. The release notes lead with links to
   the changelog entry and the release post. Authored artifacts link to these
   rather than reproducing the enumeration.
-- **Test and code comments**: implementation rationale and regression
+- **Project docs** (`project/`): architecture, design decisions, and quality-net
+  rationale, for maintainers and contributors. Architecture material lands here,
+  not in code comments; a comment keeps a purpose line and links its page.
+- **Test and code comments**: local implementation rationale and regression
   background.
 
 **Version values** follow the same ownership rule. An evergreen doc that cites a

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -5,8 +5,6 @@ description:
   points
 ---
 
-<span class="badge bg-info text-bg-info">As of Docsy 0.18.0</span>
-
 Docsy emits its JavaScript at the end of `<body>` through
 [`_partials/scripts.html`][scripts.html]: a small dispatcher that routes each
 feature to its own sub-partial under [`_partials/scripts/`][scripts-dir].

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -39,8 +39,7 @@ The decomposition has two design consequences:
   system, so a site can replace one mechanism by shadowing one file instead of
   copying all of `scripts.html`.
 - **A landing point**: the dispatcher is where the [plugin loop](#plugin-loop)
-  plugged in, and where built-in integrations convert onto the loop
-  ([#2789][]).
+  plugged in, and where built-in integrations convert onto the loop ([#2789][]).
 
 ### Override points
 
@@ -58,8 +57,8 @@ The decomposition has two design consequences:
 [`scripts/plugins.html`][plugins.html] emits each plugin registered in
 `params.docsy.plugins`. `pageGate` generalizes the Mermaid/KaTeX page-flag
 pattern, so any plugin can ship only on the pages that use its feature. For the
-registry contract, shape guards, and build details, see the
-[implementation notes][impl].
+registry contract, shape guards, and build details, see the [implementation
+notes][impl].
 
 Two ordering decisions:
 

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -15,14 +15,15 @@ out of scope here.)
 
 Before 0.18, `scripts.html` mixed a few sub-partial dispatches (MarkMap,
 Mermaid, KaTeX) with the other mechanisms' logic inline. The decomposition moved
-every mechanism into a per-feature sub-partial without changing the default
-rendered output:
+every mechanism out of the dispatcher into sub-partials without changing the
+default rendered output:
 
 - **Static theme scripts**, emitted as plain script tags: `deflate.js`
   (PlantUML), `tabpane-persist.js`, `prism.js`.
-- **The main bundle**: Bootstrap and the theme's core scripts, concatenated into
-  `main.js` (`scripts/main-bundle.html`), minified and fingerprinted in
-  production.
+- **The main bundle**: Bootstrap and the theme's core scripts, plus param-gated
+  feature scripts (search, PlantUML, MarkMap, draw.io, dark mode, ScrollSpy),
+  concatenated into `main.js` (`scripts/main-bundle.html`), minified and
+  fingerprinted in production.
 - **Individually processed theme scripts**: `click-to-copy.js` (Prism's mutually
   exclusive alternative; the two share `scripts/code-copy.html`).
 - **Pinned CDN tags with inline configuration**: the MarkMap autoloader and
@@ -52,9 +53,9 @@ The decomposition has two design consequences:
 
 - Every sub-partial the dispatcher routes to under `_partials/scripts/`.
 - `_partials/algolia/head.html` and `_partials/scripts/algolia.html`: real
-  partials as of 0.18. They were previously inline `define`s whose documented
-  override paths did not work; the internal template names `algolia/head` and
-  `algolia/scripts` no longer exist.
+  partials as of 0.18, replacing inline `define`s whose documented override
+  paths did not work (the internal template names `algolia/head` and
+  `algolia/scripts` no longer exist).
 - Per plugin: the script asset `assets/js/plugins/NAME.js`, its companion
   partial, and its companion stylesheet ([implementation notes][impl]).
 

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -21,25 +21,27 @@ rendered output:
 - **The main bundle**: Bootstrap and the theme's core scripts, concatenated into
   `main.js` (`scripts/main-bundle.html`), minified and fingerprinted in
   production.
-- **Individually processed theme scripts**: `click-to-copy.js`.
+- **Individually processed theme scripts**: `click-to-copy.js` (Prism's
+  mutually exclusive alternative; the two share `scripts/code-copy.html`).
 - **Pinned CDN tags with inline configuration**: the MarkMap autoloader and
   Algolia DocSearch.
 - **Build-time remote fetches**: KaTeX, whose CSS and fonts are copied and
   re-served as local assets, and Mermaid, whose pinned version is validated at
   build time while the browser imports the module straight from the CDN.
 
-The dispatcher preserves each mechanism's original gating, for example site
-params (MarkMap, PlantUML, Prism vs click-to-copy), `.Page.Store` flags
-(Mermaid, KaTeX), and search configuration (Algolia); some sub-partials carry
-further param gates internally (search bundle choice, dark mode, ScrollSpy).
+Gating lives at two levels, preserved from before the decomposition. The
+dispatcher itself gates MarkMap and PlantUML (site params) and Mermaid and
+KaTeX (`.Page.Store` flags); it always dispatches the other sub-partials, which
+gate internally (Algolia search configuration, Prism vs click-to-copy, search
+bundle choice, dark mode, ScrollSpy).
 
 ## The dispatcher as a seam
 
 The decomposition has two design consequences:
 
 - **Independent overrides**: each sub-partial resolves through Hugo's union file
-  system, so a site can replace one feature's emission by shadowing its
-  sub-partial instead of copying all of `scripts.html`.
+  system, so a site can replace one sub-partial by shadowing one file instead of
+  copying all of `scripts.html`.
 - **A landing point**: the dispatcher is where the [plugin loop](#plugin-loop)
   plugged in, and where converting built-in integrations onto the loop is
   planned ([#2789][]).
@@ -68,7 +70,7 @@ Two ordering decisions:
 - **Companions before the script**: a plugin's companion partial and stylesheet
   emit before its script tag, so a synchronous plugin script can rely on
   companion markup and styles being present.
-- **Body-end CSS, an interim placement**: the companion stylesheet's `<link>` is
+- **Body-end CSS (interim placement)**: the companion stylesheet's `<link>` is
   emitted where the loop runs (at the end of `<body>`), not in `<head>`, because
   `pageGate` reads `.Page.Store` flags that are only reliable after content
   render. Moving companion CSS into the head is a possible later refinement, and

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -12,9 +12,9 @@ feature to its own sub-partial under [`_partials/scripts/`][scripts-dir].
 ## Loading mechanisms
 
 Before 0.18, `scripts.html` mixed a few sub-partial dispatches (MarkMap,
-Mermaid, KaTeX) with the other mechanisms' logic inline. The decomposition
-moved every mechanism into a per-feature sub-partial without changing the
-default rendered output:
+Mermaid, KaTeX) with the other mechanisms' logic inline. The decomposition moved
+every mechanism into a per-feature sub-partial without changing the default
+rendered output:
 
 - **Static theme scripts**, emitted as plain script tags: `deflate.js`
   (PlantUML), `tabpane-persist.js`, `prism.js`.

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -5,9 +5,11 @@ description:
   points
 ---
 
-Docsy emits its JavaScript at the end of `<body>` through
-[`_partials/scripts.html`][scripts.html]: a small dispatcher that routes each
-feature to its own sub-partial under [`_partials/scripts/`][scripts-dir].
+Docsy loads its body-end JavaScript through
+[`_partials/scripts.html`][scripts.html]: a small dispatcher over per-feature
+sub-partials under [`_partials/scripts/`][scripts-dir]. (Head-side JS, such as
+theme initialization and analytics, is emitted by `_partials/head.html` and is
+out of scope here.)
 
 ## Loading mechanisms
 
@@ -31,9 +33,10 @@ rendered output:
 
 Gating lives at two levels, preserved from before the decomposition. The
 dispatcher itself gates MarkMap and PlantUML (site params) and Mermaid and KaTeX
-(`.Page.Store` flags); it always dispatches the other sub-partials, which gate
-internally (Algolia search configuration, Prism vs click-to-copy, search bundle
-choice, dark mode, ScrollSpy).
+(`.Page.Store` flags); the other sub-partials are always dispatched, some
+gating internally (Algolia search configuration, Prism vs click-to-copy, search
+bundle choice, dark mode, ScrollSpy) and some unconditional (tab-pane
+persistence).
 
 ## The dispatcher as a seam
 
@@ -53,13 +56,12 @@ The decomposition has two design consequences:
   partials as of 0.18. They were previously inline `define`s whose documented
   override paths did not work; the internal template names `algolia/head` and
   `algolia/scripts` no longer exist.
-- Per plugin: the script asset `assets/js/plugins/NAME.js` (a same-named project
-  file shadows the theme's), its companion partial, and its companion
-  stylesheet.
+- Per plugin: the script asset `assets/js/plugins/NAME.js`, its companion
+  partial, and its companion stylesheet ([implementation notes][impl]).
 
 ## The plugin loop {#plugin-loop}
 
-[`scripts/plugins.html`][plugins.html] emits each plugin registered in
+[`scripts/plugins.html`][plugins.html] emits each eligible plugin registered in
 `params.docsy.plugins`. `pageGate` generalizes the Mermaid/KaTeX page-flag
 pattern, so any plugin can ship only on the pages that use its feature. For the
 registry contract, shape guards, and build details, see the [implementation
@@ -81,12 +83,11 @@ Two ordering decisions:
 - [Implementation: script loading][impl]
 - [Quality: script loading][quality]: the test nets that pin this behavior
 
+<!-- prettier-ignore-start -->
 [#2789]: https://github.com/google/docsy/issues/2789
 [impl]: /project/implementation/script-loading/
-[plugins.html]:
-  https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts/plugins.html
+[plugins.html]: https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts/plugins.html
 [quality]: /project/quality/script-loading/
-[scripts-dir]:
-  https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts/
-[scripts.html]:
-  https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts.html
+[scripts-dir]: https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts/
+[scripts.html]: https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts.html
+<!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -11,8 +11,9 @@ feature to its own sub-partial under [`_partials/scripts/`][scripts-dir].
 
 ## Loading mechanisms
 
-Before 0.18, `scripts.html` had accreted five loading mechanisms inline. The
-decomposition moved each into a per-feature sub-partial without changing the
+Before 0.18, `scripts.html` mixed a few sub-partial dispatches (MarkMap,
+Mermaid, KaTeX) with the other mechanisms' logic inline. The decomposition
+moved every mechanism into a per-feature sub-partial without changing the
 default rendered output:
 
 - **Static theme scripts**, emitted as plain script tags: `deflate.js`
@@ -27,9 +28,10 @@ default rendered output:
   re-served as local assets, and Mermaid, whose pinned version is validated at
   build time while the browser imports the module straight from the CDN.
 
-The dispatcher preserves each mechanism's original gating: site params (MarkMap,
-PlantUML, Prism vs click-to-copy), `.Page.Store` flags (Mermaid, KaTeX), and
-search configuration (Algolia).
+The dispatcher preserves each mechanism's original gating, for example site
+params (MarkMap, PlantUML, Prism vs click-to-copy), `.Page.Store` flags
+(Mermaid, KaTeX), and search configuration (Algolia); some sub-partials carry
+further param gates internally (search bundle choice, dark mode, ScrollSpy).
 
 ## The dispatcher as a seam
 
@@ -39,7 +41,8 @@ The decomposition has two design consequences:
   system, so a site can replace one feature's emission by shadowing its
   sub-partial instead of copying all of `scripts.html`.
 - **A landing point**: the dispatcher is where the [plugin loop](#plugin-loop)
-  plugged in, and where built-in integrations convert onto the loop ([#2789][]).
+  plugged in, and where converting built-in integrations onto the loop is
+  planned ([#2789][]).
 
 ### Override points
 

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -33,10 +33,9 @@ rendered output:
 
 Gating lives at two levels, preserved from before the decomposition. The
 dispatcher itself gates MarkMap and PlantUML (site params) and Mermaid and KaTeX
-(`.Page.Store` flags); the other sub-partials are always dispatched, some
-gating internally (Algolia search configuration, Prism vs click-to-copy, search
-bundle choice, dark mode, ScrollSpy) and some unconditional (tab-pane
-persistence).
+(`.Page.Store` flags); the other sub-partials are always dispatched, some gating
+internally (Algolia search configuration, Prism vs click-to-copy, search bundle
+choice, dark mode, ScrollSpy) and some unconditional (tab-pane persistence).
 
 ## The dispatcher as a seam
 

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -1,0 +1,88 @@
+---
+title: Script loading
+description:
+  Dispatcher-and-sub-partials architecture, ordering decisions, and override
+  points
+---
+
+<span class="badge bg-info text-bg-info">As of Docsy 0.18.0</span>
+
+Docsy emits its JavaScript at the end of `<body>` through
+[`_partials/scripts.html`][scripts.html]: a small dispatcher that routes each
+feature to its own sub-partial under [`_partials/scripts/`][scripts-dir].
+
+## Loading mechanisms
+
+Before 0.18, `scripts.html` had accreted five loading mechanisms inline. The
+decomposition moved each into a per-feature sub-partial without changing the
+default rendered output:
+
+- **Static theme scripts**, emitted as plain script tags: `deflate.js`
+  (PlantUML), `tabpane-persist.js`, `prism.js`.
+- **The main bundle**: Bootstrap and the theme's core scripts, concatenated into
+  `main.js` (`scripts/main-bundle.html`), minified and fingerprinted in
+  production.
+- **Individually processed theme scripts**: `click-to-copy.js`.
+- **Pinned CDN tags with inline configuration**: the MarkMap autoloader and
+  Algolia DocSearch.
+- **Build-time remote fetches**, re-served as local assets: Mermaid and KaTeX.
+
+The dispatcher preserves each mechanism's original gating: site params (MarkMap,
+PlantUML), `.Page.Store` flags (Mermaid, KaTeX), and search configuration
+(Algolia).
+
+## The dispatcher as a seam
+
+The decomposition has two design consequences:
+
+- **Independent overrides**: each sub-partial resolves through Hugo's union file
+  system, so a site can replace one mechanism by shadowing one file instead of
+  copying all of `scripts.html`.
+- **A landing seam**: the dispatcher is where the [plugin loop](#plugin-loop)
+  plugged in, and it is the seam for converting built-in integrations onto the
+  loop ([#2789][]).
+
+### Override points
+
+- Every sub-partial under `_partials/scripts/`.
+- `_partials/algolia/head.html` and `_partials/scripts/algolia.html`: real
+  partials as of 0.18. They were previously inline `define`s whose documented
+  override paths did not work; the internal template names `algolia/head` and
+  `algolia/scripts` no longer exist.
+- Per plugin: the script asset `assets/js/plugins/NAME.js` (a same-named project
+  file shadows the theme's), its companion partial, and its companion
+  stylesheet.
+
+## The plugin loop {#plugin-loop}
+
+[`scripts/plugins.html`][plugins.html] emits each plugin registered in
+`params.docsy.plugins`: each script asset builds individually and ships
+fingerprinted with SRI, in registry order. `pageGate` generalizes the
+Mermaid/KaTeX page-flag pattern, so any plugin can ship only on the pages that
+use its feature. For the registry contract, shape guards, and build details, see
+the [implementation notes][impl].
+
+Two ordering decisions:
+
+- **Companions before the script**: a plugin's companion partial and stylesheet
+  emit before its script tag, so a synchronous plugin script can rely on
+  companion markup and styles being present.
+- **Body-end CSS, an interim placement**: the companion stylesheet's `<link>` is
+  emitted where the loop runs -- at the end of `<body>` -- rather than in
+  `<head>`. This keeps the plugin unit self-contained in the loop; moving
+  companion CSS into the head is a possible later refinement.
+
+## Related pages
+
+- [Implementation: script loading][impl]
+- [Quality: script loading][quality] -- the test nets that pin this behavior
+
+[#2789]: https://github.com/google/docsy/issues/2789
+[impl]: /project/implementation/script-loading/
+[plugins.html]:
+  https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts/plugins.html
+[quality]: /project/quality/script-loading/
+[scripts-dir]:
+  https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts/
+[scripts.html]:
+  https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts.html

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -64,9 +64,8 @@ The decomposition has two design consequences:
 
 [`scripts/plugins.html`][plugins.html] emits each eligible plugin registered in
 `params.docsy.plugins`. `pageGate` generalizes the Mermaid/KaTeX page-flag
-pattern. For the
-registry contract, shape guards, and build details, see the [implementation
-notes][impl].
+pattern. For the registry contract, shape guards, and build details, see the
+[implementation notes][impl].
 
 Two ordering decisions:
 

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -20,10 +20,11 @@ default rendered output:
 
 - **Static theme scripts**, emitted as plain script tags: `deflate.js`
   (PlantUML), `tabpane-persist.js`, `prism.js`.
-- **The main bundle**: Bootstrap and the theme's core scripts, plus param-gated
-  feature scripts (search, PlantUML, MarkMap, draw.io, dark mode, ScrollSpy),
+- **The main bundle**: Bootstrap plus the theme's core and feature scripts
+  (search, PlantUML, MarkMap, draw.io; dark mode and ScrollSpy when enabled),
   concatenated into `main.js` (`scripts/main-bundle.html`), minified and
-  fingerprinted in production.
+  fingerprinted in production. A site param picks which search script is
+  bundled, `search.js` or `offline-search.js`.
 - **Individually processed theme scripts**: `click-to-copy.js` (Prism's mutually
   exclusive alternative; the two share `scripts/code-copy.html`).
 - **Pinned CDN tags with inline configuration**: the MarkMap autoloader and
@@ -63,7 +64,7 @@ The decomposition has two design consequences:
 
 [`scripts/plugins.html`][plugins.html] emits each eligible plugin registered in
 `params.docsy.plugins`. `pageGate` generalizes the Mermaid/KaTeX page-flag
-pattern, so any plugin can ship only on the pages that use its feature. For the
+pattern. For the
 registry contract, shape guards, and build details, see the [implementation
 notes][impl].
 

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -28,22 +28,22 @@ default rendered output:
   build time while the browser imports the module straight from the CDN.
 
 The dispatcher preserves each mechanism's original gating: site params (MarkMap,
-PlantUML), `.Page.Store` flags (Mermaid, KaTeX), and search configuration
-(Algolia).
+PlantUML, Prism vs click-to-copy), `.Page.Store` flags (Mermaid, KaTeX), and
+search configuration (Algolia).
 
 ## The dispatcher as a seam
 
 The decomposition has two design consequences:
 
 - **Independent overrides**: each sub-partial resolves through Hugo's union file
-  system, so a site can replace one mechanism by shadowing one file instead of
-  copying all of `scripts.html`.
+  system, so a site can replace one feature's emission by shadowing its
+  sub-partial instead of copying all of `scripts.html`.
 - **A landing point**: the dispatcher is where the [plugin loop](#plugin-loop)
   plugged in, and where built-in integrations convert onto the loop ([#2789][]).
 
 ### Override points
 
-- Every sub-partial under `_partials/scripts/`.
+- Every sub-partial the dispatcher routes to under `_partials/scripts/`.
 - `_partials/algolia/head.html` and `_partials/scripts/algolia.html`: real
   partials as of 0.18. They were previously inline `define`s whose documented
   override paths did not work; the internal template names `algolia/head` and
@@ -66,9 +66,10 @@ Two ordering decisions:
   emit before its script tag, so a synchronous plugin script can rely on
   companion markup and styles being present.
 - **Body-end CSS, an interim placement**: the companion stylesheet's `<link>` is
-  emitted where the loop runs (at the end of `<body>`), not in `<head>`. This
-  keeps the plugin unit self-contained in the loop; moving companion CSS into
-  the head is a possible later refinement.
+  emitted where the loop runs (at the end of `<body>`), not in `<head>`, because
+  `pageGate` reads `.Page.Store` flags that are only reliable after content
+  render. Moving companion CSS into the head is a possible later refinement, and
+  has to solve that constraint or gated CSS silently drops ([#2789][]).
 
 ## Related pages
 

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -23,7 +23,9 @@ default rendered output:
 - **Individually processed theme scripts**: `click-to-copy.js`.
 - **Pinned CDN tags with inline configuration**: the MarkMap autoloader and
   Algolia DocSearch.
-- **Build-time remote fetches**, re-served as local assets: Mermaid and KaTeX.
+- **Build-time remote fetches**: KaTeX, whose CSS and fonts are copied and
+  re-served as local assets, and Mermaid, whose pinned version is validated at
+  build time while the browser imports the module straight from the CDN.
 
 The dispatcher preserves each mechanism's original gating: site params (MarkMap,
 PlantUML), `.Page.Store` flags (Mermaid, KaTeX), and search configuration
@@ -36,9 +38,9 @@ The decomposition has two design consequences:
 - **Independent overrides**: each sub-partial resolves through Hugo's union file
   system, so a site can replace one mechanism by shadowing one file instead of
   copying all of `scripts.html`.
-- **A landing seam**: the dispatcher is where the [plugin loop](#plugin-loop)
-  plugged in, and it is the seam for converting built-in integrations onto the
-  loop ([#2789][]).
+- **A landing point**: the dispatcher is where the [plugin loop](#plugin-loop)
+  plugged in, and where built-in integrations convert onto the loop
+  ([#2789][]).
 
 ### Override points
 
@@ -54,11 +56,10 @@ The decomposition has two design consequences:
 ## The plugin loop {#plugin-loop}
 
 [`scripts/plugins.html`][plugins.html] emits each plugin registered in
-`params.docsy.plugins`: each script asset builds individually and ships
-fingerprinted with SRI, in registry order. `pageGate` generalizes the
-Mermaid/KaTeX page-flag pattern, so any plugin can ship only on the pages that
-use its feature. For the registry contract, shape guards, and build details, see
-the [implementation notes][impl].
+`params.docsy.plugins`. `pageGate` generalizes the Mermaid/KaTeX page-flag
+pattern, so any plugin can ship only on the pages that use its feature. For the
+registry contract, shape guards, and build details, see the
+[implementation notes][impl].
 
 Two ordering decisions:
 
@@ -66,14 +67,14 @@ Two ordering decisions:
   emit before its script tag, so a synchronous plugin script can rely on
   companion markup and styles being present.
 - **Body-end CSS, an interim placement**: the companion stylesheet's `<link>` is
-  emitted where the loop runs -- at the end of `<body>` -- rather than in
-  `<head>`. This keeps the plugin unit self-contained in the loop; moving
-  companion CSS into the head is a possible later refinement.
+  emitted where the loop runs (at the end of `<body>`), not in `<head>`. This
+  keeps the plugin unit self-contained in the loop; moving companion CSS into
+  the head is a possible later refinement.
 
 ## Related pages
 
 - [Implementation: script loading][impl]
-- [Quality: script loading][quality] -- the test nets that pin this behavior
+- [Quality: script loading][quality]: the test nets that pin this behavior
 
 [#2789]: https://github.com/google/docsy/issues/2789
 [impl]: /project/implementation/script-loading/

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -21,8 +21,8 @@ rendered output:
 - **The main bundle**: Bootstrap and the theme's core scripts, concatenated into
   `main.js` (`scripts/main-bundle.html`), minified and fingerprinted in
   production.
-- **Individually processed theme scripts**: `click-to-copy.js` (Prism's
-  mutually exclusive alternative; the two share `scripts/code-copy.html`).
+- **Individually processed theme scripts**: `click-to-copy.js` (Prism's mutually
+  exclusive alternative; the two share `scripts/code-copy.html`).
 - **Pinned CDN tags with inline configuration**: the MarkMap autoloader and
   Algolia DocSearch.
 - **Build-time remote fetches**: KaTeX, whose CSS and fonts are copied and
@@ -30,10 +30,10 @@ rendered output:
   build time while the browser imports the module straight from the CDN.
 
 Gating lives at two levels, preserved from before the decomposition. The
-dispatcher itself gates MarkMap and PlantUML (site params) and Mermaid and
-KaTeX (`.Page.Store` flags); it always dispatches the other sub-partials, which
-gate internally (Algolia search configuration, Prism vs click-to-copy, search
-bundle choice, dark mode, ScrollSpy).
+dispatcher itself gates MarkMap and PlantUML (site params) and Mermaid and KaTeX
+(`.Page.Store` flags); it always dispatches the other sub-partials, which gate
+internally (Algolia search configuration, Prism vs click-to-copy, search bundle
+choice, dark mode, ScrollSpy).
 
 ## The dispatcher as a seam
 

--- a/docsy.dev/content/en/project/implementation/_index.md
+++ b/docsy.dev/content/en/project/implementation/_index.md
@@ -7,6 +7,11 @@ weight: 100
 no_list: true
 ---
 
+## Subsystems
+
+- [Script loading](/project/implementation/script-loading/): registry contract,
+  shape guards, and build details of the plugin loop
+
 ## Patches and workarounds
 
 - [ScrollSpy patch for Bootstrap](/project/implementation/scrollspy-patch/):

--- a/docsy.dev/content/en/project/implementation/script-loading.md
+++ b/docsy.dev/content/en/project/implementation/script-loading.md
@@ -1,0 +1,86 @@
+---
+title: Script loading
+description:
+  Registry contract, shape guards, and build details of the plugin loop
+---
+
+<span class="badge bg-info text-bg-info">As of Docsy 0.18.0</span>
+
+Code-level notes for [`_partials/scripts/plugins.html`][plugins.html], the loop
+behind `params.docsy.plugins`. For the architecture and ordering decisions, see
+the [design notes][design].
+
+## Registry contract
+
+`params.docsy.plugins` is a list of plugin entries:
+
+```yaml
+params:
+  docsy:
+    plugins:
+      - name: NAME # resolves assets/js/plugins/NAME.js
+        enable: true # optional; false skips the entry
+        defer: false # optional; adds `defer` to the script tag
+        pageGate: FLAG # optional; a .Page.Store flag name
+        options: {} # optional; reaches the module as @params
+      - NAME # bare-name shorthand for { name: NAME }
+```
+
+- A bare (non-map) entry is shorthand for `{ name: NAME }`.
+- Names are coerced to strings (`printf "%v"`): YAML auto-types entries like
+  `name: 2048`, and the loop must resolve the same asset path either way.
+- Registry order is emission order.
+- With `pageGate` set, the plugin is emitted only on pages carrying the named
+  `.Page.Store` flag.
+
+## Shape guards
+
+The registry read must not break sites that already carry a `params.docsy`
+value:
+
+- A scalar `params.docsy` is left untouched (the read is gated on
+  `reflect.IsMap`) and the loop emits nothing.
+- A non-list `params.docsy.plugins`, falsy scalars included, warns and is
+  ignored.
+- An entry with no usable name warns and is skipped.
+- A registered name with no asset at `assets/js/plugins/NAME.js` warns --
+  regardless of `pageGate`, so a typo can't hide behind a gate.
+
+Warnings are issued with `warnidf`, so each is suppressible through Hugo's
+`ignoreLogs`:
+
+| Warning ID             | Cause                                         |
+| ---------------------- | --------------------------------------------- |
+| `docsy-plugins-config` | `params.docsy.plugins` is not a list          |
+| `docsy-plugin-unnamed` | a registry entry has no name                  |
+| `docsy-plugin-missing` | no asset found at `assets/js/plugins/NAME.js` |
+
+## Build and emission
+
+- The script asset resolves through the union file system: theme, project, or
+  module-mounted, with a same-named project file shadowing the theme's.
+- Each plugin builds individually with `js.Build`; the entry's `options` travel
+  as build `params`, so the module reads them with
+  `import * as params from '@params'`. Production builds add `minify`.
+- **Fingerprinting runs in every environment**, not just production: distinct
+  builds of one source -- per-language sites, duplicate registrations with
+  different options -- must publish distinct paths, or the last write wins
+  site-wide.
+- The script tag carries SRI attributes (`integrity`, `crossorigin`), and
+  `defer` when the entry sets it.
+
+## Companions
+
+Optional companions resolve by naming convention and emit **before** the script
+tag ([why][design-ordering]):
+
+- `_partials/scripts/plugins/NAME.html`: a partial for vendored libraries,
+  component markup, and config-provider patterns; invoked with
+  `(dict "Page" PAGE "Plugin" ENTRY)`.
+- `assets/scss/plugins/NAME.scss`: a stylesheet compiled through the SCSS
+  pipeline, minified in production, fingerprinted, and emitted with SRI.
+
+[design]: /project/design/script-loading/
+[design-ordering]: /project/design/script-loading/#plugin-loop
+[plugins.html]:
+  https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts/plugins.html

--- a/docsy.dev/content/en/project/implementation/script-loading.md
+++ b/docsy.dev/content/en/project/implementation/script-loading.md
@@ -72,7 +72,8 @@ tag ([why][design-ordering]):
 - `assets/scss/plugins/NAME.scss`: a stylesheet compiled through the SCSS
   pipeline, minified in production, fingerprinted, and emitted with SRI.
 
+<!-- prettier-ignore-start -->
 [design]: /project/design/script-loading/
 [design-ordering]: /project/design/script-loading/#plugin-loop
-[plugins.html]:
-  https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts/plugins.html
+[plugins.html]: https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts/plugins.html
+<!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/project/implementation/script-loading.md
+++ b/docsy.dev/content/en/project/implementation/script-loading.md
@@ -4,8 +4,6 @@ description:
   Registry contract, shape guards, and build details of the plugin loop
 ---
 
-<span class="badge bg-info text-bg-info">As of Docsy 0.18.0</span>
-
 Code-level notes for [`_partials/scripts/plugins.html`][plugins.html], the loop
 behind `params.docsy.plugins`. For the architecture and ordering decisions, see
 the [design notes][design].

--- a/docsy.dev/content/en/project/implementation/script-loading.md
+++ b/docsy.dev/content/en/project/implementation/script-loading.md
@@ -24,7 +24,6 @@ params:
       - NAME # bare-name shorthand for { name: NAME }
 ```
 
-- A bare (non-map) entry is shorthand for `{ name: NAME }`.
 - Names are coerced to strings (`printf "%v"`): YAML auto-types entries like
   `name: 2048`, and the loop must resolve the same asset path either way.
 - Registry order is emission order.
@@ -38,20 +37,15 @@ value:
 
 - A scalar `params.docsy` is left untouched (the read is gated on
   `reflect.IsMap`) and the loop emits nothing.
-- A non-list `params.docsy.plugins`, falsy scalars included, warns and is
-  ignored.
-- An entry with no usable name warns and is skipped.
-- A registered name with no asset at `assets/js/plugins/NAME.js` warns --
-  regardless of `pageGate`, so a typo can't hide behind a gate.
+- A non-list `params.docsy.plugins`, falsy scalars included, warns
+  (`docsy-plugins-config`) and is ignored.
+- An entry with no usable name warns (`docsy-plugin-unnamed`) and is skipped.
+- A registered name with no asset at `assets/js/plugins/NAME.js` warns
+  (`docsy-plugin-missing`), regardless of `pageGate`, so a typo can't hide
+  behind a gate.
 
 Warnings are issued with `warnidf`, so each is suppressible through Hugo's
-`ignoreLogs`:
-
-| Warning ID             | Cause                                         |
-| ---------------------- | --------------------------------------------- |
-| `docsy-plugins-config` | `params.docsy.plugins` is not a list          |
-| `docsy-plugin-unnamed` | a registry entry has no name                  |
-| `docsy-plugin-missing` | no asset found at `assets/js/plugins/NAME.js` |
+`ignoreLogs`.
 
 ## Build and emission
 
@@ -61,8 +55,8 @@ Warnings are issued with `warnidf`, so each is suppressible through Hugo's
   as build `params`, so the module reads them with
   `import * as params from '@params'`. Production builds add `minify`.
 - **Fingerprinting runs in every environment**, not just production: distinct
-  builds of one source -- per-language sites, duplicate registrations with
-  different options -- must publish distinct paths, or the last write wins
+  builds of one source (per-language sites, duplicate registrations with
+  different options) must publish distinct paths, or the last write wins
   site-wide.
 - The script tag carries SRI attributes (`integrity`, `crossorigin`), and
   `defer` when the entry sets it.

--- a/docsy.dev/content/en/project/implementation/script-loading.md
+++ b/docsy.dev/content/en/project/implementation/script-loading.md
@@ -18,7 +18,7 @@ params:
     plugins:
       - name: NAME # resolves assets/js/plugins/NAME.js
         enable: true # optional; false skips the entry
-        defer: false # optional; adds `defer` to the script tag
+        defer: true # optional; adds `defer` to the script tag
         pageGate: FLAG # optional; a .Page.Store flag name
         options: {} # optional; reaches the module as @params
       - NAME # bare-name shorthand for { name: NAME }
@@ -40,7 +40,7 @@ value:
 - A non-list `params.docsy.plugins`, falsy scalars included, warns
   (`docsy-plugins-config`) and is ignored.
 - An entry with no usable name warns (`docsy-plugin-unnamed`) and is skipped.
-- A registered name with no asset at `assets/js/plugins/NAME.js` warns
+- An enabled registration with no asset at `assets/js/plugins/NAME.js` warns
   (`docsy-plugin-missing`), regardless of `pageGate`, so a typo can't hide
   behind a gate.
 

--- a/docsy.dev/content/en/project/quality/_index.md
+++ b/docsy.dev/content/en/project/quality/_index.md
@@ -1,7 +1,5 @@
 ---
 title: Quality
-description: >
-  Tests, link checking, accessibility standards, review practices, and other
-  quality-related processes
+description: Tests, link checking, accessibility standards, and review practices
 weight: 110
 ---

--- a/docsy.dev/content/en/project/quality/_index.md
+++ b/docsy.dev/content/en/project/quality/_index.md
@@ -1,0 +1,7 @@
+---
+title: Quality
+description: >
+  Tests, link checking, accessibility standards, review practices, and other
+  quality-related processes
+weight: 110
+---

--- a/docsy.dev/content/en/project/quality/script-loading.md
+++ b/docsy.dev/content/en/project/quality/script-loading.md
@@ -77,7 +77,8 @@ Two browser nets under `tests/visual/`:
 
 A net that passes for the wrong reason (building nothing, matching an empty
 region) is worse than a red one: it hides breakage behind green. The nets were
-built red-first, and each carries a persistent safeguard proving its signal:
+built red-first, and where a no-op could masquerade as success, a persistent
+safeguard proves the signal:
 
 - Zero-output cases are asserted against: a golden's script region must be
   non-empty.

--- a/docsy.dev/content/en/project/quality/script-loading.md
+++ b/docsy.dev/content/en/project/quality/script-loading.md
@@ -60,8 +60,9 @@ Two browser nets under `tests/visual/`:
   alongside behavior probes (search, diagrams, navbar). Markup and visual
   goldens can't see JS runtime breakage (a missing global, a botched
   conversion); this net can ([#1436][]).
-  - Two fixture variants cover both search bundles: `scripts.html` ships
-    `offline-search.js` or `search.js`, never both.
+  - Two fixture variants cover both search bundles: the main bundle
+    (`scripts/main-bundle.html`) concatenates `offline-search.js` or
+    `search.js` into `main.js`, never both.
   - Pages load their real CDN script dependencies, so the net needs network
     access. The console tally filters off-origin and non-code resource noise but
     keeps same-origin script and stylesheet load failures (a broken first-party
@@ -86,8 +87,9 @@ its signal:
   broken plugin must be the error tally's only entry, so an empty tally from the
   healthy plugin is meaningful.
 - The site runtime net carries a collector self-test: a page that deliberately
-  throws must be reported, so a silent collector (wrong event names, races)
-  can't masquerade as all-green.
+  throws and drops a same-origin script must have both reported, so a silent
+  collector (wrong event names, races, a broken filter) can't masquerade as
+  all-green.
 
 [#1436]: https://github.com/google/docsy/issues/1436
 [acceptance-test]:

--- a/docsy.dev/content/en/project/quality/script-loading.md
+++ b/docsy.dev/content/en/project/quality/script-loading.md
@@ -5,8 +5,6 @@ description:
   their goldens
 ---
 
-<span class="badge bg-info text-bg-info">As of Docsy 0.18.0</span>
-
 Four complementary nets pin the script-loading subsystem ([design][],
 [implementation][]). The first three run in `npm run test:repo`; the runtime net
 runs in `npm run test:visual`.

--- a/docsy.dev/content/en/project/quality/script-loading.md
+++ b/docsy.dev/content/en/project/quality/script-loading.md
@@ -76,11 +76,8 @@ Two browser nets under `tests/visual/`:
 ## Red-proof rationale
 
 A net that passes for the wrong reason (building nothing, matching an empty
-region) is worse than a red one: it hides breakage behind green. Each net proves
-its signal:
-
-- Every net was made to fail against a deliberately broken input before being
-  trusted.
+region) is worse than a red one: it hides breakage behind green. The nets were
+built red-first, and each carries a persistent safeguard proving its signal:
 - Zero-output cases are asserted against: a golden's script region must be
   non-empty.
 - The plugin runtime net's red-proof doubles as an assertion: a deliberately
@@ -91,20 +88,15 @@ its signal:
   collector (wrong event names, races, a broken filter) can't masquerade as
   all-green.
 
+<!-- prettier-ignore-start -->
 [#1436]: https://github.com/google/docsy/issues/1436
-[acceptance-test]:
-  https://github.com/google/docsy/blob/main/tests/fixture-site/plugins-acceptance.test.mjs
+[acceptance-test]: https://github.com/google/docsy/blob/main/tests/fixture-site/plugins-acceptance.test.mjs
 [design]: /project/design/script-loading/
-[dispatch-test]:
-  https://github.com/google/docsy/blob/main/tests/fixture-site/scripts-dispatch.test.mjs
-[golden-test]:
-  https://github.com/google/docsy/blob/main/tests/fixture-site/scripts-golden.test.mjs
-[goldens-lib]:
-  https://github.com/google/docsy/blob/main/tests/fixture-site/lib/scripts-goldens.mjs
+[dispatch-test]: https://github.com/google/docsy/blob/main/tests/fixture-site/scripts-dispatch.test.mjs
+[golden-test]: https://github.com/google/docsy/blob/main/tests/fixture-site/scripts-golden.test.mjs
+[goldens-lib]: https://github.com/google/docsy/blob/main/tests/fixture-site/lib/scripts-goldens.mjs
 [implementation]: /project/implementation/script-loading/
-[loop-test]:
-  https://github.com/google/docsy/blob/main/tests/fixture-site/plugins.test.mjs
-[plugin-runtime-test]:
-  https://github.com/google/docsy/blob/main/tests/visual/plugins-runtime.test.mjs
-[runtime-test]:
-  https://github.com/google/docsy/blob/main/tests/visual/js-runtime.test.mjs
+[loop-test]: https://github.com/google/docsy/blob/main/tests/fixture-site/plugins.test.mjs
+[plugin-runtime-test]: https://github.com/google/docsy/blob/main/tests/visual/plugins-runtime.test.mjs
+[runtime-test]: https://github.com/google/docsy/blob/main/tests/visual/js-runtime.test.mjs
+<!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/project/quality/script-loading.md
+++ b/docsy.dev/content/en/project/quality/script-loading.md
@@ -56,9 +56,9 @@ contains no `layouts/` directory).
 Two browser nets under `tests/visual/`:
 
 - [`js-runtime.test.mjs`][runtime-test] loads representative fixture pages in a
-  real browser and asserts that no uncaught exception or console error fires,
-  alongside behavior probes (search, diagrams, navbar). Markup and visual
-  goldens can't see JS runtime breakage (a missing global, a botched
+  real browser and asserts that no uncaught exception or in-scope console error
+  fires, alongside behavior probes (search, diagrams, navbar). Markup and
+  visual goldens can't see JS runtime breakage (a missing global, a botched
   conversion); this net can ([#1436][]).
   - Two fixture variants cover both search bundles: the main bundle
     (`scripts/main-bundle.html`) concatenates `offline-search.js` or `search.js`
@@ -66,12 +66,13 @@ Two browser nets under `tests/visual/`:
   - Pages load their real CDN script dependencies, so the net needs network
     access. The console tally filters off-origin and non-code resource noise but
     keeps same-origin script and stylesheet load failures (a broken first-party
-    bundle is a defect), and any JS breakage the filtered noise causes still
-    surfaces as a page error.
+    bundle is a defect). Filtered breakage that throws (a dependent script's
+    missing global) still surfaces as a page error; silent feature degradation
+    is what the behavior probes catch.
 - [`plugins-runtime.test.mjs`][plugin-runtime-test] proves an emitted plugin
   actually executes: its options reach the runtime and its DOM effects land. A
-  static-markup check can bless output whose runtime is broken (wrong script
-  ordering, a botched build); this net can't.
+  static-markup check can bless output whose runtime is broken (a botched
+  build); this net can't.
 
 ## Red-proof rationale
 

--- a/docsy.dev/content/en/project/quality/script-loading.md
+++ b/docsy.dev/content/en/project/quality/script-loading.md
@@ -57,8 +57,8 @@ Two browser nets under `tests/visual/`:
 
 - [`js-runtime.test.mjs`][runtime-test] loads representative fixture pages in a
   real browser and asserts that no uncaught exception or in-scope console error
-  fires, alongside behavior probes (search, diagrams, navbar). Markup and
-  visual goldens can't see JS runtime breakage (a missing global, a botched
+  fires, alongside behavior probes (search, diagrams, navbar). Markup and visual
+  goldens can't see JS runtime breakage (a missing global, a botched
   conversion); this net can ([#1436][]).
   - Two fixture variants cover both search bundles: the main bundle
     (`scripts/main-bundle.html`) concatenates `offline-search.js` or `search.js`

--- a/docsy.dev/content/en/project/quality/script-loading.md
+++ b/docsy.dev/content/en/project/quality/script-loading.md
@@ -61,8 +61,8 @@ Two browser nets under `tests/visual/`:
   goldens can't see JS runtime breakage (a missing global, a botched
   conversion); this net can ([#1436][]).
   - Two fixture variants cover both search bundles: the main bundle
-    (`scripts/main-bundle.html`) concatenates `offline-search.js` or
-    `search.js` into `main.js`, never both.
+    (`scripts/main-bundle.html`) concatenates `offline-search.js` or `search.js`
+    into `main.js`, never both.
   - Pages load their real CDN script dependencies, so the net needs network
     access. The console tally filters off-origin and non-code resource noise but
     keeps same-origin script and stylesheet load failures (a broken first-party

--- a/docsy.dev/content/en/project/quality/script-loading.md
+++ b/docsy.dev/content/en/project/quality/script-loading.md
@@ -1,13 +1,13 @@
 ---
 title: Script loading
 description:
-  The golden, dispatch, loop-contract, and runtime nets, and how to refresh
-  their goldens
+  The golden, dispatch, loop-contract, acceptance, and runtime nets, and how to
+  refresh the goldens
 ---
 
-Four complementary nets pin the script-loading subsystem ([design][],
-[implementation][]). The first three run in `npm run test:repo`; the runtime net
-runs in `npm run test:visual`.
+Complementary test nets pin the script-loading subsystem ([design][],
+[implementation][]). The fixture-site nets run in `npm run test:repo`; the
+browser nets run in `npm run test:visual`.
 
 ## Golden net
 
@@ -44,37 +44,54 @@ shape-guard warnings, name coercion, and fingerprint distinctness (duplicate
 registrations publish distinct builds, in development too). Theme-plugin
 shadowing gets its pin when the first theme plugin ships.
 
-## Runtime net
+## Acceptance test
 
-[`js-runtime.test.mjs`][runtime-test] loads representative fixture pages in a
-real browser and asserts that no uncaught exception or console error fires,
-alongside behavior probes (search, diagrams, navbar). Markup and visual goldens
-can't see JS runtime breakage -- a missing global, a botched conversion -- but
-this net can, cheaply ([#1436][]).
+[`plugins-acceptance.test.mjs`][acceptance-test] proves adoption end to end: a
+project site drops `assets/js/plugins/hello.js` plus one registry entry and
+gets its script loaded, with zero layout overrides asserted structurally (the
+fixture contains no `layouts/` directory).
 
-Particulars:
+## Runtime nets
 
-- Two fixture variants cover both search bundles: `scripts.html` ships
-  `offline-search.js` or `search.js`, never both.
-- Pages load their real CDN script dependencies, so the net needs network
-  access. Failed resource loads are filtered from the console tally: they're
-  environment noise, and any JS breakage they cause still surfaces as a page
-  error.
+Two browser nets under `tests/visual/`:
+
+- [`js-runtime.test.mjs`][runtime-test] loads representative fixture pages in a
+  real browser and asserts that no uncaught exception or console error fires,
+  alongside behavior probes (search, diagrams, navbar). Markup and visual
+  goldens can't see JS runtime breakage (a missing global, a botched
+  conversion); this net can ([#1436][]).
+  - Two fixture variants cover both search bundles: `scripts.html` ships
+    `offline-search.js` or `search.js`, never both.
+  - Pages load their real CDN script dependencies, so the net needs network
+    access. The console tally filters off-origin and non-code resource noise
+    but keeps same-origin script and stylesheet load failures (a broken
+    first-party bundle is a defect), and any JS breakage the filtered noise
+    causes still surfaces as a page error.
+- [`plugins-runtime.test.mjs`][plugin-runtime-test] proves an emitted plugin
+  actually executes: its options reach the runtime and its DOM effects land. A
+  static-markup check can bless output whose runtime is broken (wrong script
+  ordering, a botched build); this net can't.
 
 ## Red-proof rationale
 
-A net that passes for the wrong reason -- building nothing, matching an empty
-region -- is worse than a red one: it hides breakage behind green. Each net
+A net that passes for the wrong reason (building nothing, matching an empty
+region) is worse than a red one: it hides breakage behind green. Each net
 proves its signal:
 
 - Every net was made to fail against a deliberately broken input before being
   trusted.
 - Zero-output cases are asserted against: a golden's script region must be
   non-empty.
-- The runtime net carries a built-in structural red-proof: an uncaught page
-  exception must surface as the error collector's exact tally.
+- The plugin runtime net's red-proof doubles as an assertion: a deliberately
+  broken plugin must be the error tally's only entry, so an empty tally from
+  the healthy plugin is meaningful.
+- The site runtime net carries a collector self-test: a page that deliberately
+  throws must be reported, so a silent collector (wrong event names, races)
+  can't masquerade as all-green.
 
 [#1436]: https://github.com/google/docsy/issues/1436
+[acceptance-test]:
+  https://github.com/google/docsy/blob/main/tests/fixture-site/plugins-acceptance.test.mjs
 [design]: /project/design/script-loading/
 [dispatch-test]:
   https://github.com/google/docsy/blob/main/tests/fixture-site/scripts-dispatch.test.mjs
@@ -85,5 +102,7 @@ proves its signal:
 [implementation]: /project/implementation/script-loading/
 [loop-test]:
   https://github.com/google/docsy/blob/main/tests/fixture-site/plugins.test.mjs
+[plugin-runtime-test]:
+  https://github.com/google/docsy/blob/main/tests/visual/plugins-runtime.test.mjs
 [runtime-test]:
   https://github.com/google/docsy/blob/main/tests/visual/js-runtime.test.mjs

--- a/docsy.dev/content/en/project/quality/script-loading.md
+++ b/docsy.dev/content/en/project/quality/script-loading.md
@@ -47,9 +47,9 @@ shadowing gets its pin when the first theme plugin ships.
 ## Acceptance test
 
 [`plugins-acceptance.test.mjs`][acceptance-test] proves adoption end to end: a
-project site drops `assets/js/plugins/hello.js` plus one registry entry and
-gets its script loaded, with zero layout overrides asserted structurally (the
-fixture contains no `layouts/` directory).
+project site drops `assets/js/plugins/hello.js` plus one registry entry and gets
+its script loaded, with zero layout overrides asserted structurally (the fixture
+contains no `layouts/` directory).
 
 ## Runtime nets
 
@@ -63,10 +63,10 @@ Two browser nets under `tests/visual/`:
   - Two fixture variants cover both search bundles: `scripts.html` ships
     `offline-search.js` or `search.js`, never both.
   - Pages load their real CDN script dependencies, so the net needs network
-    access. The console tally filters off-origin and non-code resource noise
-    but keeps same-origin script and stylesheet load failures (a broken
-    first-party bundle is a defect), and any JS breakage the filtered noise
-    causes still surfaces as a page error.
+    access. The console tally filters off-origin and non-code resource noise but
+    keeps same-origin script and stylesheet load failures (a broken first-party
+    bundle is a defect), and any JS breakage the filtered noise causes still
+    surfaces as a page error.
 - [`plugins-runtime.test.mjs`][plugin-runtime-test] proves an emitted plugin
   actually executes: its options reach the runtime and its DOM effects land. A
   static-markup check can bless output whose runtime is broken (wrong script
@@ -75,16 +75,16 @@ Two browser nets under `tests/visual/`:
 ## Red-proof rationale
 
 A net that passes for the wrong reason (building nothing, matching an empty
-region) is worse than a red one: it hides breakage behind green. Each net
-proves its signal:
+region) is worse than a red one: it hides breakage behind green. Each net proves
+its signal:
 
 - Every net was made to fail against a deliberately broken input before being
   trusted.
 - Zero-output cases are asserted against: a golden's script region must be
   non-empty.
 - The plugin runtime net's red-proof doubles as an assertion: a deliberately
-  broken plugin must be the error tally's only entry, so an empty tally from
-  the healthy plugin is meaningful.
+  broken plugin must be the error tally's only entry, so an empty tally from the
+  healthy plugin is meaningful.
 - The site runtime net carries a collector self-test: a page that deliberately
   throws must be reported, so a silent collector (wrong event names, races)
   can't masquerade as all-green.

--- a/docsy.dev/content/en/project/quality/script-loading.md
+++ b/docsy.dev/content/en/project/quality/script-loading.md
@@ -1,0 +1,91 @@
+---
+title: Script loading
+description:
+  The golden, dispatch, loop-contract, and runtime nets, and how to refresh
+  their goldens
+---
+
+<span class="badge bg-info text-bg-info">As of Docsy 0.18.0</span>
+
+Four complementary nets pin the script-loading subsystem ([design][],
+[implementation][]). The first three run in `npm run test:repo`; the runtime net
+runs in `npm run test:visual`.
+
+## Golden net
+
+[`scripts-golden.test.mjs`][golden-test] pins, across fixture configurations:
+
+- the rendered **script region** of selected pages, and
+- **every locally built script**, byte-exact.
+
+Fixture builds, region extraction, and the comparison form live in
+[`lib/scripts-goldens.mjs`][goldens-lib]. The net was committed and verified
+green against untouched `main` before the `scripts.html` decomposition, so the
+refactor's no-output-change claim is machine-checked, not asserted.
+
+The goldens are committed. After a reviewed, intended output change, refresh
+them with:
+
+```sh
+npm run update:scripts-goldens
+```
+
+## Dispatch net
+
+[`scripts-dispatch.test.mjs`][dispatch-test] pins the dispatcher's page-flag
+wiring: the `.Page.Store`-gated partials (Mermaid, KaTeX) are dispatched on
+flagged pages only. The real partials fetch remote assets at build time, so
+fixture marker overrides stand in for them; what's pinned is exactly the
+gate-to-partial wiring, offline.
+
+## Loop-contract tests
+
+[`plugins.test.mjs`][loop-test] pins the plugin loop's registry contract:
+emission with `@params`, `enable`/`defer`/`pageGate` handling, both companions,
+shape-guard warnings, name coercion, and fingerprint distinctness (duplicate
+registrations publish distinct builds, in development too). Theme-plugin
+shadowing gets its pin when the first theme plugin ships.
+
+## Runtime net
+
+[`js-runtime.test.mjs`][runtime-test] loads representative fixture pages in a
+real browser and asserts that no uncaught exception or console error fires,
+alongside behavior probes (search, diagrams, navbar). Markup and visual goldens
+can't see JS runtime breakage -- a missing global, a botched conversion -- but
+this net can, cheaply ([#1436][]).
+
+Particulars:
+
+- Two fixture variants cover both search bundles: `scripts.html` ships
+  `offline-search.js` or `search.js`, never both.
+- Pages load their real CDN script dependencies, so the net needs network
+  access. Failed resource loads are filtered from the console tally: they're
+  environment noise, and any JS breakage they cause still surfaces as a page
+  error.
+
+## Red-proof rationale
+
+A net that passes for the wrong reason -- building nothing, matching an empty
+region -- is worse than a red one: it hides breakage behind green. Each net
+proves its signal:
+
+- Every net was made to fail against a deliberately broken input before being
+  trusted.
+- Zero-output cases are asserted against: a golden's script region must be
+  non-empty.
+- The runtime net carries a built-in structural red-proof: an uncaught page
+  exception must surface as the error collector's exact tally.
+
+[#1436]: https://github.com/google/docsy/issues/1436
+[design]: /project/design/script-loading/
+[dispatch-test]:
+  https://github.com/google/docsy/blob/main/tests/fixture-site/scripts-dispatch.test.mjs
+[golden-test]:
+  https://github.com/google/docsy/blob/main/tests/fixture-site/scripts-golden.test.mjs
+[goldens-lib]:
+  https://github.com/google/docsy/blob/main/tests/fixture-site/lib/scripts-goldens.mjs
+[implementation]: /project/implementation/script-loading/
+[loop-test]:
+  https://github.com/google/docsy/blob/main/tests/fixture-site/plugins.test.mjs
+[runtime-test]:
+  https://github.com/google/docsy/blob/main/tests/visual/js-runtime.test.mjs

--- a/docsy.dev/content/en/project/quality/script-loading.md
+++ b/docsy.dev/content/en/project/quality/script-loading.md
@@ -78,6 +78,7 @@ Two browser nets under `tests/visual/`:
 A net that passes for the wrong reason (building nothing, matching an empty
 region) is worse than a red one: it hides breakage behind green. The nets were
 built red-first, and each carries a persistent safeguard proving its signal:
+
 - Zero-output cases are asserted against: a golden's script region must be
   non-empty.
 - The plugin runtime net's red-proof doubles as an assertion: a deliberately

--- a/docsy.dev/link-cache.jsonc
+++ b/docsy.dev/link-cache.jsonc
@@ -1064,6 +1064,31 @@
     "when": "2026-06-27T12:29:27Z",
     "via": "lychee",
   },
+  "https://github.com/google/docsy/blob/main/tests/fixture-site/lib/scripts-goldens.mjs": {
+    "status": 200,
+    "when": "2026-09-02T19:09:14Z",
+    "via": "lychee",
+  },
+  "https://github.com/google/docsy/blob/main/tests/fixture-site/plugins.test.mjs": {
+    "status": 200,
+    "when": "2026-09-02T19:09:14Z",
+    "via": "lychee",
+  },
+  "https://github.com/google/docsy/blob/main/tests/fixture-site/scripts-dispatch.test.mjs": {
+    "status": 200,
+    "when": "2026-09-02T19:09:15Z",
+    "via": "lychee",
+  },
+  "https://github.com/google/docsy/blob/main/tests/fixture-site/scripts-golden.test.mjs": {
+    "status": 200,
+    "when": "2026-09-02T19:09:14Z",
+    "via": "lychee",
+  },
+  "https://github.com/google/docsy/blob/main/tests/visual/js-runtime.test.mjs": {
+    "status": 200,
+    "when": "2026-09-02T19:09:15Z",
+    "via": "lychee",
+  },
   "https://github.com/google/docsy/blob/main/theme/": {
     "status": 200,
     "when": "2026-09-02T08:07:11Z",
@@ -1194,9 +1219,19 @@
     "when": "2026-06-26T18:24:04Z",
     "via": "lychee",
   },
+  "https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts/": {
+    "status": 200,
+    "when": "2026-09-02T19:09:15Z",
+    "via": "lychee",
+  },
   "https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts/mermaid.html": {
     "status": 200,
     "when": "2026-08-09T11:36:12Z",
+    "via": "lychee",
+  },
+  "https://github.com/google/docsy/blob/main/theme/layouts/_partials/scripts/plugins.html": {
+    "status": 200,
+    "when": "2026-09-02T19:09:14Z",
     "via": "lychee",
   },
   "https://github.com/google/docsy/blob/main/theme/layouts/_partials/search-input.html": {
@@ -1779,6 +1814,11 @@
     "when": "2026-08-28T16:21:12Z",
     "via": "lychee",
   },
+  "https://github.com/google/docsy/issues/2789": {
+    "status": 200,
+    "when": "2026-09-02T19:09:15Z",
+    "via": "lychee",
+  },
   "https://github.com/google/docsy/issues/331": {
     "status": 200,
     "when": "2026-06-26T18:23:57Z",
@@ -2094,6 +2134,11 @@
     "when": "2026-06-26T18:29:06Z",
     "via": "lychee",
   },
+  "https://github.com/google/docsy/issues/new?title=Quality": {
+    "status": 200,
+    "when": "2026-09-02T19:09:14Z",
+    "via": "lychee",
+  },
   "https://github.com/google/docsy/issues/new?title=ReadMe": {
     "status": 200,
     "when": "2026-06-26T18:29:07Z",
@@ -2137,6 +2182,11 @@
   "https://github.com/google/docsy/issues/new?title=Repository-root%20markdown%20files": {
     "status": 200,
     "when": "2026-06-26T18:29:07Z",
+    "via": "lychee",
+  },
+  "https://github.com/google/docsy/issues/new?title=Script%20loading": {
+    "status": 200,
+    "when": "2026-09-02T19:09:15Z",
     "via": "lychee",
   },
   "https://github.com/google/docsy/issues/new?title=ScrollSpy%20patch": {
@@ -4353,6 +4403,13 @@
     "when": "2026-08-30T20:58:27Z",
     "via": "lychee",
   },
+  // New-page seed: goes live when the script-loading project docs deploy.
+  "https://main--docsydocs.netlify.app/project/design/script-loading/": {
+    "status": 206,
+    "when": "2026-09-02T19:10:00Z",
+    "via": "manual",
+    "expires": "2026-10-15",
+  },
   "https://main--docsydocs.netlify.app/project/design/semantic-classes/": {
     "status": 200,
     "when": "2026-08-25T14:43:44Z",
@@ -4363,10 +4420,31 @@
     "when": "2026-06-27T12:29:27Z",
     "via": "lychee",
   },
+  // New-page seed: goes live when the script-loading project docs deploy.
+  "https://main--docsydocs.netlify.app/project/implementation/script-loading/": {
+    "status": 206,
+    "when": "2026-09-02T19:10:00Z",
+    "via": "manual",
+    "expires": "2026-10-15",
+  },
   "https://main--docsydocs.netlify.app/project/implementation/scrollspy-patch/": {
     "status": 200,
     "when": "2026-06-26T18:24:04Z",
     "via": "lychee",
+  },
+  // New-page seed: goes live when the script-loading project docs deploy.
+  "https://main--docsydocs.netlify.app/project/quality/": {
+    "status": 206,
+    "when": "2026-09-02T19:10:00Z",
+    "via": "manual",
+    "expires": "2026-10-15",
+  },
+  // New-page seed: goes live when the script-loading project docs deploy.
+  "https://main--docsydocs.netlify.app/project/quality/script-loading/": {
+    "status": 206,
+    "when": "2026-09-02T19:10:00Z",
+    "via": "manual",
+    "expires": "2026-10-15",
   },
   "https://main--docsydocs.netlify.app/project/repo/": {
     "status": 200,
@@ -5170,6 +5248,13 @@
     "when": "2026-08-30T20:58:27Z",
     "via": "lychee",
   },
+  // New-page seed: goes live when the script-loading project docs deploy.
+  "https://www.docsy.dev/project/design/script-loading/": {
+    "status": 206,
+    "when": "2026-09-02T19:10:00Z",
+    "via": "manual",
+    "expires": "2026-10-15",
+  },
   "https://www.docsy.dev/project/design/semantic-classes/": {
     "status": 200,
     "when": "2026-08-30T20:58:27Z",
@@ -5180,10 +5265,31 @@
     "when": "2026-06-27T12:29:27Z",
     "via": "lychee",
   },
+  // New-page seed: goes live when the script-loading project docs deploy.
+  "https://www.docsy.dev/project/implementation/script-loading/": {
+    "status": 206,
+    "when": "2026-09-02T19:10:00Z",
+    "via": "manual",
+    "expires": "2026-10-15",
+  },
   "https://www.docsy.dev/project/implementation/scrollspy-patch/": {
     "status": 200,
     "when": "2026-06-26T18:24:04Z",
     "via": "lychee",
+  },
+  // New-page seed: goes live when the script-loading project docs deploy.
+  "https://www.docsy.dev/project/quality/": {
+    "status": 206,
+    "when": "2026-09-02T19:10:00Z",
+    "via": "manual",
+    "expires": "2026-10-15",
+  },
+  // New-page seed: goes live when the script-loading project docs deploy.
+  "https://www.docsy.dev/project/quality/script-loading/": {
+    "status": 206,
+    "when": "2026-09-02T19:10:00Z",
+    "via": "manual",
+    "expires": "2026-10-15",
   },
   "https://www.docsy.dev/project/repo/": {
     "status": 200,

--- a/docsy.dev/link-cache.jsonc
+++ b/docsy.dev/link-cache.jsonc
@@ -1069,6 +1069,11 @@
     "when": "2026-09-02T19:09:14Z",
     "via": "lychee",
   },
+  "https://github.com/google/docsy/blob/main/tests/fixture-site/plugins-acceptance.test.mjs": {
+    "status": 200,
+    "when": "2026-09-02T20:03:23Z",
+    "via": "lychee",
+  },
   "https://github.com/google/docsy/blob/main/tests/fixture-site/plugins.test.mjs": {
     "status": 200,
     "when": "2026-09-02T19:09:14Z",
@@ -1087,6 +1092,11 @@
   "https://github.com/google/docsy/blob/main/tests/visual/js-runtime.test.mjs": {
     "status": 200,
     "when": "2026-09-02T19:09:15Z",
+    "via": "lychee",
+  },
+  "https://github.com/google/docsy/blob/main/tests/visual/plugins-runtime.test.mjs": {
+    "status": 200,
+    "when": "2026-09-02T20:03:23Z",
     "via": "lychee",
   },
   "https://github.com/google/docsy/blob/main/theme/": {

--- a/docsy.dev/tests/md-output/goldens/fr/index.md
+++ b/docsy.dev/tests/md-output/goldens/fr/index.md
@@ -147,6 +147,6 @@ Section pages:
 - [Community](/fr/community/)
 - [Welcome to Docsy](/fr/docs/)
 - [Examples and templates](/fr/examples/): Get started with a template or explore some Docsy-based sites
-- [Project and website documentation](/fr/project/): How Docsy theme and website are built, maintained, and deployed.
+- [Project and website documentation](/fr/project/): Architecture and maintainer workflows for the Docsy theme and website
 - [Search Results](/fr/search/)
 - [Docsy tests](/fr/tests/): Tests of Docsy features

--- a/docsy.dev/tests/md-output/goldens/index.md
+++ b/docsy.dev/tests/md-output/goldens/index.md
@@ -145,6 +145,6 @@ Section pages:
 - [Community](/community/)
 - [Welcome to Docsy](/docs/)
 - [Examples and templates](/examples/): Get started with a template or explore some Docsy-based sites
-- [Project and website documentation](/project/): How Docsy theme and website are built, maintained, and deployed.
+- [Project and website documentation](/project/): Architecture and maintainer workflows for the Docsy theme and website
 - [Search Results](/search/)
 - [Docsy tests](/tests/): Tests of Docsy features

--- a/tests/fixture-site/plugins-acceptance.test.mjs
+++ b/tests/fixture-site/plugins-acceptance.test.mjs
@@ -1,7 +1,6 @@
-// The plugin architecture's acceptance test: a project site drops
-// assets/js/plugins/hello.js + one params.docsy.plugins entry and gets its
-// script loaded, with zero layout overrides asserted structurally (the
-// fixture contains no layouts/ directory).
+// The plugin architecture's acceptance test: a project site adds one asset
+// and one registry entry, zero layout overrides. Rationale:
+// https://www.docsy.dev/project/quality/script-loading/
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/fixture-site/plugins.test.mjs
+++ b/tests/fixture-site/plugins.test.mjs
@@ -1,4 +1,4 @@
-// Loop-contract tests for params.docsy.plugins; the contract:
+// Loop-contract tests for params.docsy.plugins:
 // https://www.docsy.dev/project/implementation/script-loading/
 
 import { test } from 'node:test';

--- a/tests/fixture-site/plugins.test.mjs
+++ b/tests/fixture-site/plugins.test.mjs
@@ -1,7 +1,5 @@
-// Loop-contract tests for params.docsy.plugins; the contract lives in the
-// plugin loop's header (theme/layouts/_partials/scripts/plugins.html).
-// Theme-plugin shadowing is pinned when the first theme plugin ships (none
-// exists to shadow yet).
+// Loop-contract tests for params.docsy.plugins; the contract:
+// https://www.docsy.dev/project/implementation/script-loading/
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/fixture-site/plugins.test.mjs
+++ b/tests/fixture-site/plugins.test.mjs
@@ -1,5 +1,7 @@
-// Loop-contract tests for params.docsy.plugins:
+// Loop-contract tests for params.docsy.plugins. Contract:
 // https://www.docsy.dev/project/implementation/script-loading/
+// Net inventory and rationale:
+// https://www.docsy.dev/project/quality/script-loading/
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/fixture-site/plugins.test.mjs
+++ b/tests/fixture-site/plugins.test.mjs
@@ -336,7 +336,7 @@ test('a nameless registry entry is skipped with a warning', () => {
 
 test('duplicate registrations publish distinct builds, in development too', () => {
   // Same source, different options: the builds must not share one
-  // published path (see the loop's fingerprint note).
+  // published path (the always-fingerprint rule; implementation page).
   const r = buildSite('plugins-duplicates', {
     files: { ...content, 'assets/js/plugins/hello.js': helloJs },
     args: ['--environment', 'development'],

--- a/tests/fixture-site/scripts-dispatch.test.mjs
+++ b/tests/fixture-site/scripts-dispatch.test.mjs
@@ -1,4 +1,4 @@
-// Legacy dispatch net: scripts.html keeps dispatching the .Page.Store-gated
+// Dispatch net: scripts.html keeps dispatching the .Page.Store-gated
 // partials (mermaid, katex), pinned offline through marker overrides.
 // Rationale: https://www.docsy.dev/project/quality/script-loading/
 
@@ -39,7 +39,7 @@ for (const [flag, page, otherFlag, otherPage] of [
     assert.doesNotMatch(
       r.publicFile(otherPage),
       new RegExp(`data-dispatch="${flag}"`),
-      `the ${otherFlag}-flagged page carries no ${flag} dispatch`,
+      `the ${otherFlag}-flagged page is free of ${flag} dispatches`,
     );
     assert.doesNotMatch(
       r.publicFile('index.html'),

--- a/tests/fixture-site/scripts-dispatch.test.mjs
+++ b/tests/fixture-site/scripts-dispatch.test.mjs
@@ -26,15 +26,20 @@ test('the dispatch fixture builds', () => {
   assert.equal(r.status, 0, `hugo build succeeds:\n${r.stderr}`);
 });
 
-for (const [flag, page] of [
-  ['katex', 'docs/math/index.html'],
-  ['mermaid', 'docs/diagram/index.html'],
+for (const [flag, page, otherFlag, otherPage] of [
+  ['katex', 'docs/math/index.html', 'mermaid', 'docs/diagram/index.html'],
+  ['mermaid', 'docs/diagram/index.html', 'katex', 'docs/math/index.html'],
 ]) {
   test(`the ${flag} partial is dispatched on flagged pages only`, () => {
     assert.match(
       r.publicFile(page),
       new RegExp(`data-dispatch="${flag}"`),
       `the flagged page carries the ${flag} dispatch`,
+    );
+    assert.doesNotMatch(
+      r.publicFile(otherPage),
+      new RegExp(`data-dispatch="${flag}"`),
+      `the ${otherFlag}-flagged page carries no ${flag} dispatch`,
     );
     assert.doesNotMatch(
       r.publicFile('index.html'),

--- a/tests/fixture-site/scripts-dispatch.test.mjs
+++ b/tests/fixture-site/scripts-dispatch.test.mjs
@@ -1,7 +1,6 @@
 // Legacy dispatch net: scripts.html keeps dispatching the .Page.Store-gated
-// partials (mermaid, katex). The real partials fetch remote assets at build
-// time, so fixture-site marker overrides stand in for them; what's pinned
-// is exactly the dispatcher's gate → partial wiring, offline.
+// partials (mermaid, katex), pinned offline through marker overrides.
+// Rationale: https://www.docsy.dev/project/quality/script-loading/
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/fixture-site/scripts-golden.test.mjs
+++ b/tests/fixture-site/scripts-golden.test.mjs
@@ -1,8 +1,6 @@
 // Golden-output net for the scripts.html decomposition: the rendered script
-// region and every locally built script must match their goldens across
-// the refactor. Fixtures, region extraction, and comparison form:
-// lib/scripts-goldens.mjs.
-// Refresh: npm run update:scripts-goldens
+// region and every locally built script must match their goldens. Rationale
+// and refresh: https://www.docsy.dev/project/quality/script-loading/
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/visual/js-runtime.test.mjs
+++ b/tests/visual/js-runtime.test.mjs
@@ -161,8 +161,7 @@ async function collectPageErrors(url) {
   return errors;
 }
 
-// Collector self-test: a page that throws must be reported, so a silent
-// collector (wrong event names, races) can't masquerade as all-green.
+// Collector self-test (red-proof: quality page, file header).
 test('js-runtime collector: an uncaught page exception is reported', async () => {
   const errors = await collectPageErrors(selfTestUrl);
   assert.ok(

--- a/tests/visual/js-runtime.test.mjs
+++ b/tests/visual/js-runtime.test.mjs
@@ -1,15 +1,8 @@
 // Runtime JS console-error net (google/docsy#1436): loads representative
 // fixture-site pages in a real browser and asserts that no uncaught
-// exception or console error fires. The markup and visual goldens can't
-// see JS runtime breakage (a missing global, a botched conversion); this
-// net can, cheaply. Two fixture variants cover both search bundles:
-// scripts.html ships offline-search.js or search.js, never both.
-//
-// Unlike the visual shots, pages here load their real CDN script deps
-// (lunr, markmap, mermaid), so this suite needs network access. Failed
-// resource loads are filtered from the console tally: they're environment
-// noise here, and any JS breakage they cause still surfaces as a
-// pageerror (e.g. a dependent script's missing global).
+// exception or console error fires. Needs network access (real CDN deps).
+// Rationale and particulars:
+// https://www.docsy.dev/project/quality/script-loading/
 
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/visual/js-runtime.test.mjs
+++ b/tests/visual/js-runtime.test.mjs
@@ -131,10 +131,7 @@ after(async () => {
 });
 
 // Load a page and collect JS failures: uncaught exceptions (pageerror)
-// and console-level errors. Resource-load failures are kept only for
-// same-origin scripts and stylesheets (a broken first-party bundle is a
-// defect); off-origin (CDN) and non-code resource noise is filtered, and
-// any JS breakage such noise causes still surfaces as a pageerror.
+// and console-level errors, filtered per the quality page (file header).
 // Bounded window: errors scheduled well after the settle delay are out of
 // scope here; interaction probes carry their own collectors.
 async function collectPageErrors(url) {

--- a/tests/visual/js-runtime.test.mjs
+++ b/tests/visual/js-runtime.test.mjs
@@ -1,7 +1,7 @@
 // Runtime JS console-error net (google/docsy#1436): loads representative
 // fixture-site pages in a real browser and asserts that no uncaught
-// exception or console error fires. Needs network access (real CDN deps).
-// Rationale and particulars:
+// exception or in-scope console error fires. Needs network access (real
+// CDN deps). Rationale and particulars:
 // https://www.docsy.dev/project/quality/script-loading/
 
 import { test, before, after } from 'node:test';

--- a/tests/visual/js-runtime.test.mjs
+++ b/tests/visual/js-runtime.test.mjs
@@ -131,7 +131,7 @@ after(async () => {
 });
 
 // Load a page and collect JS failures: uncaught exceptions (pageerror)
-// and console-level errors, filtered per the quality page (file header).
+// and console-level errors, filtered per the quality page (URL above).
 // Bounded window: errors scheduled well after the settle delay are out of
 // scope here; interaction probes carry their own collectors.
 async function collectPageErrors(url) {
@@ -161,7 +161,7 @@ async function collectPageErrors(url) {
   return errors;
 }
 
-// Collector self-test (red-proof: quality page, file header).
+// Collector self-test (red-proof rationale: the quality page, URL above).
 test('js-runtime collector: an uncaught page exception is reported', async () => {
   const errors = await collectPageErrors(selfTestUrl);
   assert.ok(

--- a/tests/visual/plugins-runtime.test.mjs
+++ b/tests/visual/plugins-runtime.test.mjs
@@ -71,9 +71,7 @@ test('an emitted plugin executes: options and DOM effects land', async () => {
   assert.equal(probe.token, 'runtime-net', 'plugin options reach the runtime');
   assert.equal(probe.dataset, 'ran', 'the plugin mutated the DOM');
   await page.close();
-  // Red-proof doubling as the assertion: the broken plugin's error must be
-  // visible to the collector, so an empty tally from the probe plugin
-  // would be meaningful.
+  // Red-proof doubling as the assertion (rationale: quality page).
   assert.equal(errors.length, 1, 'error tally sees exactly the broken plugin');
   assert.match(
     errors[0],

--- a/tests/visual/plugins-runtime.test.mjs
+++ b/tests/visual/plugins-runtime.test.mjs
@@ -47,8 +47,8 @@ async function loadHome() {
   const errors = [];
   page.on('pageerror', (err) => errors.push(String(err)));
   page.on('console', (msg) => {
-    // Failed resource loads (aborted off-origin fetches, a missing favicon)
-    // are environment noise, same policy as js-runtime.test.mjs.
+    // Failed resource loads are environment noise here: off-origin
+    // requests abort by design (offline-safe runs).
     if (msg.type() === 'error' && !/Failed to load resource/.test(msg.text()))
       errors.push(msg.text());
   });

--- a/tests/visual/plugins-runtime.test.mjs
+++ b/tests/visual/plugins-runtime.test.mjs
@@ -1,8 +1,6 @@
-// Plugin runtime net: proves an emitted plugin actually *executes* in a
-// browser: a static-markup check can bless output whose runtime is broken
-// (wrong script ordering, a botched build). Red-proof built in: a
-// deliberately broken plugin must land in the error tally, so an empty
-// tally can't false-green.
+// Plugin runtime net: an emitted plugin must actually execute in a browser.
+// Rationale and red-proof:
+// https://www.docsy.dev/project/quality/script-loading/
 
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';

--- a/theme/layouts/_partials/scripts.html
+++ b/theme/layouts/_partials/scripts.html
@@ -1,4 +1,6 @@
 {{/* cSpell:ignore plantuml hasmermaid */ -}}
+{{/* Body-end script dispatcher. Architecture and override points:
+  https://www.docsy.dev/project/design/script-loading/ */ -}}
 
 {{ if .Site.Params.markmap.enable -}}
   {{ partial "scripts/markmap.html" . -}}

--- a/theme/layouts/_partials/scripts/plugins.html
+++ b/theme/layouts/_partials/scripts/plugins.html
@@ -1,24 +1,6 @@
-{{/* Plugin loop: emits each plugin registered in params.docsy.plugins, a
-  list of { name, enable, defer, pageGate, options } entries (a bare NAME
-  is shorthand for { name: NAME }). A plugin's script lives at
-  assets/js/plugins/NAME.js (theme, project, or module-mounted; a
-  same-named project file shadows the theme's) and is built individually
-  with js.Build; options reach the module via
-  `import * as params from '@params'`. Registry order is the emission
-  order. pageGate names a .Page.Store flag; when set, the plugin is
-  emitted only on pages carrying the flag (a missing asset warns
-  regardless of the gate). Fingerprinting runs in every environment:
-  distinct builds of one source (per-language sites, duplicate
-  registrations with different options) must publish distinct paths, or
-  the last write wins site-wide.
-
-  Optional companions, by naming convention, both emitted **before** the
-  script tag so a synchronous plugin script can rely on them:
-  - scripts/plugins/NAME.html: a partial (vendored libraries, component
-    markup), invoked with (dict "Page" PAGE "Plugin" ENTRY); config-
-    provider patterns belong in the companion too.
-  - assets/scss/plugins/NAME.scss: a stylesheet compiled through the SCSS
-    pipeline. */ -}}
+{{/* Emits each plugin registered in params.docsy.plugins. Registry contract,
+  shape guards, and companion conventions:
+  https://www.docsy.dev/project/implementation/script-loading/ */ -}}
 {{ $registry := slice -}}
 {{ $docsy := .Site.Params.docsy -}}
 {{ if reflect.IsMap $docsy -}}

--- a/theme/layouts/_partials/scripts/plugins.html
+++ b/theme/layouts/_partials/scripts/plugins.html
@@ -16,7 +16,7 @@
   {{ if not (reflect.IsMap $entry) -}}
     {{ $entry = dict "name" $entry -}}
   {{ end -}}
-  {{/* Names must be strings: YAML auto-types entries like `name: 2048`. */ -}}
+  {{/* Names must be strings (YAML auto-types bare values). */ -}}
   {{ $name := "" -}}
   {{ with $entry.name }}{{ $name = printf "%v" . }}{{ end -}}
   {{ if not $name -}}


### PR DESCRIPTION
- Contributes to #2789.
- **Adds three pages under one slug** (`script-loading`): design (dispatcher + sub-partials, ordering decisions, override points), implementation (plugin-loop registry contract and guards), and quality (the test nets and golden refresh), creating the **Quality** project-docs section.
- **Shrinks comments to purpose line + pointer**: the plugin-loop header and the six script-net test headers link their project-docs homes instead of carrying the contract.
- **Routes** future architecture material to project docs (maintainer notes, Content placement) and adds the project section's audience clarifier.
- **Hardens the dispatch net** with cross-negative asserts (a flagged page must not carry the other flag's dispatch), red-proven.
- **Seeds the link cache** for the new page URLs until they deploy.
- **Previews**:
  - https://deploy-preview-2790--docsydocs.netlify.app/project/design/script-loading/
  - https://deploy-preview-2790--docsydocs.netlify.app/project/implementation/script-loading/
  - https://deploy-preview-2790--docsydocs.netlify.app/project/quality/script-loading/
