### PR TITLE
Plugins: gate tab persistence on the tabpane shortcode

### DIFF
--- a/docsy.dev/content/en/blog/2026/0.18.0.md
+++ b/docsy.dev/content/en/blog/2026/0.18.0.md
@@ -100,6 +100,11 @@ three features onto it ([#2789][]).
   [`hooks/head-end.html`][head-end] partial; for the affected authoring paths
   and the one-line partial, see [When a MarkMap doesn't
   render][markmap-not-rendering].
+- **If tabpanes reach a page through `.Content` or a printed section**: tab
+  persistence now loads only on pages that render a `tabpane` shortcode,
+  includes through `.RenderShortcodes` included; other reuse paths render the
+  tabs without persistence. Include through `.RenderShortcodes`
+  ([why][ug-flags]).
 - **If you override a moved file**, [review and move your
   override][update-overrides]; old copies are silently ignored:
   - `assets/js/markmap.js` and `assets/js/click-to-copy.js` moved to
@@ -129,6 +134,7 @@ three features onto it ([#2789][]).
 [markmap-not-rendering]:
   /docs/content/diagrams-and-formulae/#when-a-markmap-doesnt-render
 [markmap-version]: /docs/content/diagrams-and-formulae/#markmap-version
+[ug-flags]: /docs/content/plugins/#page-flags-in-included-content
 [ug-plugins]: /docs/content/plugins/
 [ug-plugins-warnings]: /docs/content/plugins/#warnings
 

--- a/docsy.dev/content/en/docs/content/plugins.md
+++ b/docsy.dev/content/en/docs/content/plugins.md
@@ -10,11 +10,11 @@ Docsy loads some of its optional JavaScript features, and any script you add, as
 
 ## Configure Docsy's plugins
 
-| Plugin            | What it does (Default / Loads on)                                                                  | Learn more                     |
-| ----------------- | -------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `click-to-copy`   | Adds a copy button to code blocks (On, but off under Prism, which has its own / Every page)        | [Copy to clipboard][]          |
-| `tabpane-persist` | Remembers the selected tab across pages (On / Every page ([why](#page-flags-in-included-content))) | [`tabpane`][]                  |
-| `markmap`         | Renders `markmap` code blocks as mind maps (Off / Pages with a `markmap` code block)               | [Activating MarkMap support][] |
+| Plugin            | What it does (Default / Loads on)                                                           | Learn more                     |
+| ----------------- | ------------------------------------------------------------------------------------------- | ------------------------------ |
+| `click-to-copy`   | Adds a copy button to code blocks (On, but off under Prism, which has its own / Every page) | [Copy to clipboard][]          |
+| `tabpane-persist` | Remembers the selected tab across pages (On / Pages with a [`tabpane`][] shortcode)         | [`tabpane`][]                  |
+| `markmap`         | Renders `markmap` code blocks as mind maps (Off / Pages with a `markmap` code block)        | [Activating MarkMap support][] |
 
 To turn a plugin off, set its `enable` field to `false`:
 
@@ -155,10 +155,10 @@ keys reach templates and plugin scripts lowercase: an option `apiKey` is
 ### Adjust a plugin per page
 
 A **shim** adjusts a plugin's registry entry for each page before the plugin
-loads. Add one for your own plugin, or for one of Docsy's. Two of Docsy's
-plugins ship a shim, `markmap` and `click-to-copy`: your file replaces it, gate,
-Prism guard, and deprecated-parameter handling included, so start from a copy of
-the theme's file, in [`scripts/plugins/`][theme-shims].
+loads. Add one for your own plugin, or for one of Docsy's. Each of Docsy's
+plugins ships a shim: your file replaces it, gate, Prism guard, and
+deprecated-parameter handling included, so start from a copy of the theme's
+file, in [`scripts/plugins/`][theme-shims].
 
 Create `layouts/_partials/scripts/plugins/`_`NAME`_`_docsy-shim.html`, with the
 plugin's registry name as _`NAME`_ ([shim contract][impl-shim]):
@@ -172,8 +172,10 @@ plugin's registry name as _`NAME`_ ([shim contract][impl-shim]):
 ```
 
 That shim loads the plugin only on pages that use it: a render hook of yours
-sets the flag with `.Page.Store.Set` where the feature's markup appears. Before
-relying on a flag, read
+sets the flag with `.Page.Store.Set` where the feature's markup appears. When a
+shortcode produces the markup, test for the shortcode instead of setting a flag
+(Docsy's `tabpane-persist` shim: `.Page.HasShortcode "tabpane"`). Before relying
+on either, read
 [Page flags in included content](#page-flags-in-included-content).
 
 ### Dependency versions
@@ -211,24 +213,26 @@ theme-provided pin, see [MarkMap version][markmap-version].
 
 ## Page flags in included content
 
-Some plugins load only on pages that need them: Docsy's `markmap` render hook
-sets a page flag whenever a page has a `markmap` code block, and the plugin
-ships where the flag is set. A flag counts only when it lands on the page whose
-output the plugin is emitted into.
+A shim's per-page check counts only when it holds on the page whose output the
+plugin is emitted into. What content reuse does to each kind of check:
 
 - A **render hook** runs in the context of the page being rendered, so a
   `markmap` block in content pulled in through [`.RenderShortcodes`][] flags the
   page that includes it.
 - A **shortcode** runs in the context of the page whose file contains it, so a
-  shortcode in included content would flag the _included_ page, and the
-  including page would never see the flag.
-- Content pulled in through `.Content` flags the included page in both cases.
+  flag a shortcode sets lands on the _included_ page, and the including page
+  never sees it. [`.HasShortcode`][] does follow `.RenderShortcodes`: Hugo
+  records the included page's shortcodes on the including page. That is why
+  `tabpane-persist` gates on the `tabpane` shortcode, not on a flag.
+- Content pulled in through `.Content` carries neither flags nor shortcodes to
+  the including page.
 
-That is why Docsy ships `tabpane-persist` ungated, on every page: tabpanes come
-from a shortcode. For MarkMap's authoring paths and the remedy, see [When a
-MarkMap doesn't render][].
+For MarkMap's authoring paths and the remedy, see [When a MarkMap doesn't
+render][]. Tabpanes pulled in through `.Content` render but don't persist;
+include them through `.RenderShortcodes` instead.
 
 <!-- prettier-ignore-start -->
+[`.HasShortcode`]: https://gohugo.io/methods/page/hasshortcode/
 [`.RenderShortcodes`]: https://gohugo.io/methods/page/rendershortcodes/
 [`tabpane`]: /docs/content/shortcodes/#tabpane
 [Activating MarkMap support]: /docs/content/diagrams-and-formulae/#activating-markmap-support

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -155,8 +155,8 @@ history since 0.17.0][].
   now use standard DOM APIs ([#1436][]).
 - **[Plugin conversions][0.18.0-blog-plugins]**: moved the script override
   points for MarkMap, tab persistence, and click-to-copy; page-gated MarkMap,
-  whose autoloader is now fetched at build time; reserved `params.docsy` for
-  theme settings ([#2789][]).
+  whose autoloader is now fetched at build time, and tab persistence; reserved
+  `params.docsy` for theme settings ([#2789][]).
 
 **New**:
 

--- a/docsy.dev/content/en/project/design/script-loading.md
+++ b/docsy.dev/content/en/project/design/script-loading.md
@@ -39,7 +39,8 @@ Gating lives at two levels. The dispatcher gates PlantUML (site param) and
 Mermaid and KaTeX (`.Page.Store` flags); MarkMap's plugin shim carries the same
 page-flag pattern (`hasMarkmap`), while the remaining sub-partials gate
 internally (Algolia search configuration, Prism, search bundle choice, dark
-mode, ScrollSpy). Tab persistence ships ungated ([why](#gating-decisions)).
+mode, ScrollSpy). Tab persistence gates on the `tabpane` shortcode
+([why](#gating-decisions)).
 
 ## The dispatcher as a seam
 
@@ -120,12 +121,16 @@ idiom.
 
 ### Gating decisions
 
-- **A theme default gates only on render-hook flags.** A shortcode's flag stays
-  on the page whose file contains it, so included content loses it (the
-  mechanics, for site authors: [Plugins § Page flags in included
-  content][ug-flags]). MarkMap (hook-flagged) is gated by default; tab
-  persistence (shortcode-produced) ships ungated on every page, as before 0.18:
-  no flag is set for it.
+- **A gate reads a render-hook flag or `.HasShortcode`, never a flag a shortcode
+  sets.** A hook runs in the including page's context and Hugo merges included
+  pages' shortcode names into `.HasShortcode` (since 0.123), so both cross a
+  `.RenderShortcodes` include; a shortcode's flag stays on the page whose file
+  contains it, so a gate on it silently drops the plugin for a documented Hugo
+  idiom (the mechanics, for site authors: [Plugins § Page flags in included
+  content][ug-flags]). MarkMap gates on its hook's `hasMarkmap`; tab persistence
+  on the `tabpane` shortcode, the shortcode itself untouched. Neither crosses
+  `.Content`. Pinned by `tests/fixture-site/included-content-flags.test.mjs` and
+  `tabpane-persist-plugin.test.mjs`.
 - **Gating is the plugin's, not a registry field.** The plugin's hook sets a
   flag and its shim reads it, the pairing the dispatcher uses for `hasmermaid`
   and `hasMath`; a site widens a gate by setting the flag from

--- a/docsy.dev/content/en/project/quality/script-loading.md
+++ b/docsy.dev/content/en/project/quality/script-loading.md
@@ -53,8 +53,11 @@ gate-to-partial wiring, offline.
 
 Three companion nets pin the conversions:
 
-- [`tabpane-persist-plugin.test.mjs`][tabpane-test]: the ungated default,
-  persistence opt-out, and theme-plugin shadowing.
+- [`tabpane-persist-plugin.test.mjs`][tabpane-test]: the shortcode gate across
+  reuse paths (direct, `.RenderShortcodes` include, `.Content` include),
+  persistence opt-out, and theme-plugin shadowing;
+  [`included-content-flags.test.mjs`][icf-test]: where hook flags, shortcode
+  flags, and shortcode names land per reuse path.
 - [`markmap-plugin.test.mjs`][markmap-test] and
   [`click-to-copy-plugin.test.mjs`][c2c-test]: the per-conversion contracts. The
   markmap cases stub the vendoring companion with a marker to stay offline; the
@@ -130,6 +133,7 @@ safeguard proves the signal:
 [markmap-test]: https://github.com/google/docsy/blob/main/tests/fixture-site/markmap-plugin.test.mjs
 [plugin-runtime-test]: https://github.com/google/docsy/blob/main/tests/visual/plugins-runtime.test.mjs
 [runtime-test]: https://github.com/google/docsy/blob/main/tests/visual/js-runtime.test.mjs
+[icf-test]: https://github.com/google/docsy/blob/main/tests/fixture-site/included-content-flags.test.mjs
 [tabpane-test]: https://github.com/google/docsy/blob/main/tests/fixture-site/tabpane-persist-plugin.test.mjs
 [visual-tests]: https://github.com/google/docsy/tree/main/tests/visual
 <!-- prettier-ignore-end -->

--- a/tests/fixture-site/included-content-flags.test.mjs
+++ b/tests/fixture-site/included-content-flags.test.mjs
@@ -1,0 +1,112 @@
+// Pins where page flags land when content is reused, per flag kind (render
+// hook vs shortcode) and reuse path (`.RenderShortcodes` vs `.Content`). The
+// documented claims: https://www.docsy.dev/docs/content/plugins/#page-flags-in-included-content.
+// One build per path: a page's Store is one object, so a second includer would
+// muddy where a flag came from.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSite } from './lib/build-site.mjs';
+
+const snippet =
+  '---\ntitle: Snippet\nbuild: { render: never, list: never }\n---\n\n' +
+  'SNIPPET-BODY\n\n' +
+  '```markmap\n# root\n## leaf\n```\n\n' +
+  '{{< flag >}}\n\n' +
+  '{{< tabpane text=true >}}\n{{< tab header="One" >}}one{{< /tab >}}\n{{< /tabpane >}}\n';
+
+const store = (who) =>
+  `<span data-${who}-hasmarkmap="{{ .Store.Get "hasMarkmap" }}" ` +
+  `data-${who}-hasflagshortcode="{{ .Store.Get "hasFlagShortcode" }}"></span>\n`;
+
+const files = {
+  'content/_index.md': '---\ntitle: Home\n---\nHome body\n',
+  'content/docs/_index.md': '---\ntitle: Docs\n---\nDocs body\n',
+  'content/docs/snippet.md': snippet,
+  // opentelemetry.io's include idiom; `{{% %}}` so the output parses as Markdown.
+  'layouts/_shortcodes/include.html':
+    '{{ with site.GetPage (.Get 0) }}{{ .RenderShortcodes }}{{ end }}',
+  'layouts/_shortcodes/contentof.html':
+    '{{ with site.GetPage (.Get 0) }}{{ .Content }}{{ end }}',
+  // A shortcode-set flag (the shape tabpane had before 0.18).
+  'layouts/_shortcodes/flag.html':
+    '{{ .Page.Store.Set "hasFlagShortcode" true }}',
+  // Offline: stub the autoloader fetch, as markmap-plugin.test.mjs does.
+  'layouts/_partials/scripts/plugins/markmap.html':
+    '<script data-vendor="markmap-autoloader"></script>\n',
+  // Prints, after content rendered, the shipping page's Store and the
+  // snippet's: where a flag the includer did not receive actually landed.
+  'layouts/_partials/hooks/body-end.html':
+    store('includer') +
+    `{{ with site.GetPage "/docs/snippet" }}${store('snippet')}{{ end }}`,
+};
+
+const build = (name, includer) => {
+  const r = buildSite(`included-content-flags-${name}`, {
+    files: { ...files, 'content/docs/includer.md': includer },
+    title: 'Docsy included-content flags fixture',
+    extraConfig:
+      'params:\n  docsy:\n    plugins:\n      markmap: { enable: true }\n',
+  });
+  assert.equal(r.status, 0, `hugo build succeeds:\n${r.stderr}`);
+  const html = r.publicFile('docs/includer/index.html');
+  // Sanity: the snippet, its fence, and its tabpane actually rendered here.
+  assert.match(html, /SNIPPET-BODY/, 'snippet body rendered on the includer');
+  assert.match(html, /language-markmap/, 'markmap fence rendered');
+  assert.match(html, /data-td-tp-persist/, 'tabpane rendered');
+  return html;
+};
+
+const storeOf = (html, who) => {
+  const m = html.match(
+    new RegExp(
+      `data-${who}-hasmarkmap="([^"]*)" data-${who}-hasflagshortcode="([^"]*)"`,
+    ),
+  );
+  assert.ok(m, `${who} Store is printed`);
+  return { hasMarkmap: m[1] === 'true', hasFlagShortcode: m[2] === 'true' };
+};
+
+test('.RenderShortcodes: the hook flags the includer, the shortcode flags the snippet', () => {
+  const html = build(
+    'rendershortcodes',
+    '---\ntitle: Includer\n---\n\n{{% include "/docs/snippet" %}}\n',
+  );
+  assert.deepEqual(
+    storeOf(html, 'includer'),
+    { hasMarkmap: true, hasFlagShortcode: false },
+    'includer Store',
+  );
+  assert.deepEqual(
+    storeOf(html, 'snippet'),
+    { hasMarkmap: false, hasFlagShortcode: true },
+    'snippet Store',
+  );
+  assert.match(
+    html,
+    /js\/plugins\/markmap/,
+    'gated markmap plugin ships on the includer',
+  );
+});
+
+test('.Content: both flags land on the snippet, none on the includer', () => {
+  const html = build(
+    'dotcontent',
+    '---\ntitle: Includer\n---\n\n{{< contentof "/docs/snippet" >}}\n',
+  );
+  assert.deepEqual(
+    storeOf(html, 'includer'),
+    { hasMarkmap: false, hasFlagShortcode: false },
+    'includer Store',
+  );
+  assert.deepEqual(
+    storeOf(html, 'snippet'),
+    { hasMarkmap: true, hasFlagShortcode: true },
+    'snippet Store',
+  );
+  assert.doesNotMatch(
+    html,
+    /js\/plugins\/markmap/,
+    'gated markmap plugin does not ship on the includer',
+  );
+});

--- a/tests/fixture-site/included-content-flags.test.mjs
+++ b/tests/fixture-site/included-content-flags.test.mjs
@@ -1,5 +1,6 @@
 // Pins where page flags land when content is reused, per flag kind (render
-// hook vs shortcode) and reuse path (`.RenderShortcodes` vs `.Content`). The
+// hook vs shortcode) and reuse path (`.RenderShortcodes` vs `.Content`), and
+// that `.HasShortcode` follows `.RenderShortcodes` (Hugo >= 0.123). The
 // documented claims: https://www.docsy.dev/docs/content/plugins/#page-flags-in-included-content.
 // One build per path: a page's Store is one object, so a second includer would
 // muddy where a flag came from.
@@ -38,7 +39,8 @@ const files = {
   // snippet's: where a flag the includer did not receive actually landed.
   'layouts/_partials/hooks/body-end.html':
     store('includer') +
-    `{{ with site.GetPage "/docs/snippet" }}${store('snippet')}{{ end }}`,
+    `{{ with site.GetPage "/docs/snippet" }}${store('snippet')}{{ end }}` +
+    '<span data-includer-hasshortcode="{{ .HasShortcode "flag" }}"></span>\n',
 };
 
 const build = (name, includer) => {
@@ -55,6 +57,12 @@ const build = (name, includer) => {
   assert.match(html, /language-markmap/, 'markmap fence rendered');
   assert.match(html, /data-td-tp-persist/, 'tabpane rendered');
   return html;
+};
+
+const hasShortcode = (html) => {
+  const m = html.match(/data-includer-hasshortcode="([^"]*)"/);
+  assert.ok(m, 'includer HasShortcode is printed');
+  return m[1] === 'true';
 };
 
 const storeOf = (html, who) => {
@@ -87,6 +95,11 @@ test('.RenderShortcodes: the hook flags the includer, the shortcode flags the sn
     /js\/plugins\/markmap/,
     'gated markmap plugin ships on the includer',
   );
+  assert.equal(
+    hasShortcode(html),
+    true,
+    'includer .HasShortcode sees the snippet shortcode',
+  );
 });
 
 test('.Content: both flags land on the snippet, none on the includer', () => {
@@ -108,5 +121,10 @@ test('.Content: both flags land on the snippet, none on the includer', () => {
     html,
     /js\/plugins\/markmap/,
     'gated markmap plugin does not ship on the includer',
+  );
+  assert.equal(
+    hasShortcode(html),
+    false,
+    'includer .HasShortcode does not see the snippet shortcode',
   );
 });

--- a/tests/fixture-site/plugins.test.mjs
+++ b/tests/fixture-site/plugins.test.mjs
@@ -163,7 +163,9 @@ test('env overrides reach registry entries and read as booleans', () => {
   const r = buildSite('plugins-env-override', {
     files: {
       ...content,
-      'content/docs/code.md': '---\ntitle: Code\n---\n\n```sh\necho hi\n```\n',
+      'content/docs/code.md':
+        '---\ntitle: Code\n---\n\n```sh\necho hi\n```\n\n' +
+        '{{< tabpane text=true >}}{{< tab header="One" >}}one{{< /tab >}}{{< /tabpane >}}\n',
     },
     env: {
       'HUGOxPARAMSxDOCSYxPLUGINSxCLICK-TO-COPYxENABLE': 'false',

--- a/tests/fixture-site/scripts-goldens/defaults--index.html.txt
+++ b/tests/fixture-site/scripts-goldens/defaults--index.html.txt
@@ -2,4 +2,3 @@
     </div>
     <script src="/js/main.min.0b4db99649bd7e7b2600a1160c1cde559bba27c41ae7eeb8af40b551b3452190.js" integrity="sha256-C025lkm9fnsmAKEWDBzeVZu6J8Qa5&#43;64r0C1UbNFIZA=" crossorigin="anonymous"></script>
 <script defer src="/js/plugins/click-to-copy.3cca71c9acfa59bc8c018d6e77353b6f6a9bc6c577b6e91f31a59c8758c8a036.js" integrity="sha256-PMpxyaz6WbyMAY1udzU7b2qbxsV3tukfMaWch1jIoDY=" crossorigin="anonymous"></script>
-<script src="/js/plugins/tabpane-persist.d14334f51386faeefb7f976f7df59c450aa780ebb6abe69c77d96f28f9fe2122.js" integrity="sha256-0UM09ROG&#43;u77f5dvffWcRQqngOu2q&#43;acd9lvKPn&#43;ISI=" crossorigin="anonymous"></script>

--- a/tests/fixture-site/scripts-goldens/featureful--index.html.txt
+++ b/tests/fixture-site/scripts-goldens/featureful--index.html.txt
@@ -17,4 +17,3 @@ for (let c of containers) {
   });
 }
 </script>
-<script src="/js/plugins/tabpane-persist.d14334f51386faeefb7f976f7df59c450aa780ebb6abe69c77d96f28f9fe2122.js" integrity="sha256-0UM09ROG&#43;u77f5dvffWcRQqngOu2q&#43;acd9lvKPn&#43;ISI=" crossorigin="anonymous"></script>

--- a/tests/fixture-site/tabpane-persist-plugin.test.mjs
+++ b/tests/fixture-site/tabpane-persist-plugin.test.mjs
@@ -1,4 +1,5 @@
-// Pins tabpane-persist as an ungated theme plugin (why:
+// Pins tab persistence as a theme plugin gated on the tabpane shortcode
+// (`.HasShortcode`, in the plugin's shim; why:
 // https://www.docsy.dev/project/design/script-loading/#gating-decisions).
 
 import { test } from 'node:test';
@@ -8,36 +9,70 @@ import { buildSite } from './lib/build-site.mjs';
 const tabs =
   '{{< tabpane text=true >}}\n' +
   '{{< tab header="One" >}}one{{< /tab >}}\n' +
+  '{{< tab header="Two" >}}two{{< /tab >}}\n' +
   '{{< /tabpane >}}\n';
+const page = (title, body) => `---\ntitle: ${title}\n---\n\n${body}`;
 
 const files = {
-  'content/_index.md': '---\ntitle: Home\n---\nHome body\n',
-  'content/docs/_index.md': '---\ntitle: Docs\n---\nDocs body\n',
-  'content/docs/aaa-tabs.md': '---\ntitle: Tabs first\n---\n\n' + tabs,
-  'content/docs/mmm-plain.md': '---\ntitle: Plain\n---\nNo tabs here\n',
-  'content/docs/zzz-tabs.md': '---\ntitle: Tabs last\n---\n\n' + tabs,
+  'content/_index.md': page('Home', 'Home body\n'),
+  'content/docs/_index.md': page('Docs', 'Docs body\n'),
+  'content/docs/_includes/tabs.md':
+    '---\ntitle: Tabs snippet\nbuild: { render: never, list: never }\n---\n\n' +
+    'INCLUDED-TABS\n\n' +
+    tabs,
+  'content/docs/direct.md': page('Direct', tabs),
+  'content/docs/included.md': page(
+    'Included',
+    '{{% include "/docs/_includes/tabs" %}}\n',
+  ),
+  'content/docs/dotcontent.md': page(
+    'DotContent',
+    '{{< contentof "/docs/_includes/tabs" >}}\n',
+  ),
+  'content/docs/plain.md': page('Plain', 'No tabs here\n'),
+  // opentelemetry.io's include, simplified: shortcode -> partial ->
+  // `.RenderShortcodes | safeHTML`, called with `{{% %}}`.
+  'layouts/_shortcodes/include.html':
+    '{{ partial "include.html" (dict "path" (.Get 0)) -}}\n',
+  'layouts/_partials/include.html':
+    '{{ with site.GetPage .path }}{{ .RenderShortcodes | safeHTML }}' +
+    '{{ else }}{{ errorf "include: %q not found" .path }}{{ end -}}\n',
+  'layouts/_shortcodes/contentof.html':
+    '{{ with site.GetPage (.Get 0) }}{{ .Content }}{{ end -}}\n',
 };
-const allPages = [
-  'index.html',
-  'docs/index.html',
-  'docs/aaa-tabs/index.html',
-  'docs/mmm-plain/index.html',
-  'docs/zzz-tabs/index.html',
-];
 const scriptRe = /<script[^>]*src="\/(js\/plugins\/tabpane-persist[^"]*\.js)"/;
-test('tabpane-persist ships on every page by default, fingerprinted', () => {
+
+test('tab persistence ships where the tabpane shortcode renders, .RenderShortcodes includes included', () => {
   const r = buildSite('tabpane-persist-default', {
     files,
     title: 'Docsy tab-persistence fixture',
   });
   assert.equal(r.status, 0, `hugo build succeeds:\n${r.stderr}`);
-  for (const page of allPages) {
-    const m = r.publicFile(page).match(scriptRe);
-    assert.ok(m, `${page} loads the tabpane-persist plugin`);
+  for (const p of ['included', 'dotcontent']) {
+    const html = r.publicFile(`docs/${p}/index.html`);
+    assert.match(html, /INCLUDED-TABS/, `${p}: snippet rendered`);
+    assert.match(html, /data-td-tp-persist/, `${p}: tabpane rendered`);
+  }
+  for (const p of ['direct', 'included']) {
+    const m = r.publicFile(`docs/${p}/index.html`).match(scriptRe);
+    assert.ok(m, `${p}: tab persistence ships, fingerprinted`);
     assert.match(
       r.publicFile(m[1]),
       /td-tp-persist/,
-      'emitted plugin is the persistence script',
+      `${p}: emitted plugin is the persistence script`,
+    );
+  }
+  // `.Content` carries neither shortcode names nor Store flags: the same hole
+  // hook-gated plugins have.
+  for (const p of [
+    'index.html',
+    'docs/plain/index.html',
+    'docs/dotcontent/index.html',
+  ]) {
+    assert.doesNotMatch(
+      r.publicFile(p),
+      scriptRe,
+      `${p}: tab persistence does not ship`,
     );
   }
 });
@@ -53,10 +88,8 @@ test('a project plugin shadows the theme plugin of the same name', () => {
     title: 'Docsy shadowing fixture',
   });
   assert.equal(r.status, 0, `hugo build succeeds:\n${r.stderr}`);
-  const html = r.publicFile('docs/aaa-tabs/index.html');
-  const m = html.match(
-    /<script[^>]*src="\/(js\/plugins\/tabpane-persist[^"]*\.js)"/,
-  );
+  const html = r.publicFile('docs/direct/index.html');
+  const m = html.match(scriptRe);
   assert.ok(m, 'tabpane-persist plugin script tag is emitted');
   const js = r.publicFile(m[1]);
   assert.match(
@@ -74,10 +107,12 @@ test('a project plugin shadows the theme plugin of the same name', () => {
 test('persist="disabled" tabs carry no persistence attributes', () => {
   const r = buildSite('tabpane-persist-optout', {
     files: {
-      'content/_index.md': '---\ntitle: Home\n---\nHome body\n',
-      'content/docs/off.md':
-        '---\ntitle: Off\n---\n\n{{< tabpane text=true persist="disabled" >}}\n' +
-        '{{< tab header="One" >}}one{{< /tab >}}\n{{< /tabpane >}}\n',
+      'content/_index.md': page('Home', 'Home body\n'),
+      'content/docs/off.md': page(
+        'Off',
+        '{{< tabpane text=true persist="disabled" >}}\n' +
+          '{{< tab header="One" >}}one{{< /tab >}}\n{{< /tabpane >}}\n',
+      ),
     },
   });
   assert.equal(r.status, 0, `hugo build succeeds:\n${r.stderr}`);

--- a/theme/layouts/_partials/scripts/plugins/tabpane-persist_docsy-shim.html
+++ b/theme/layouts/_partials/scripts/plugins/tabpane-persist_docsy-shim.html
@@ -1,0 +1,8 @@
+{{/* Gates tab persistence on the tabpane shortcode. `.HasShortcode` follows
+  `.RenderShortcodes` includes, which a shortcode-set Store flag never would
+  (why: https://www.docsy.dev/project/design/script-loading/#gating-decisions). */ -}}
+{{ $entry := .Plugin -}}
+{{ if not (.Page.HasShortcode "tabpane") -}}
+  {{ $entry = merge $entry (dict "enable" false) -}}
+{{ end -}}
+{{ return $entry -}}

--- a/theme/layouts/_partials/scripts/plugins/tabpane-persist_docsy-shim.html
+++ b/theme/layouts/_partials/scripts/plugins/tabpane-persist_docsy-shim.html
@@ -1,6 +1,7 @@
-{{/* Gates tab persistence on the tabpane shortcode. `.HasShortcode` follows
-  `.RenderShortcodes` includes, which a shortcode-set Store flag never would
-  (why: https://www.docsy.dev/project/design/script-loading/#gating-decisions). */ -}}
+{{/* Gates tab persistence on the tabpane shortcode: `.HasShortcode` follows
+  `.RenderShortcodes` includes, which a flag set by the shortcode never would
+  (why: https://www.docsy.dev/project/design/script-loading/#gating-decisions;
+  contract: https://www.docsy.dev/project/implementation/script-loading/#shims). */ -}}
 {{ $entry := .Plugin -}}
 {{ if not (.Page.HasShortcode "tabpane") -}}
   {{ $entry = merge $entry (dict "enable" false) -}}


### PR DESCRIPTION
- Contributes to #2789
- **Scope**:
  - `tabpane-persist` ships only on pages that render the `tabpane` shortcode, from a `.HasShortcode` check in the plugin's shim; loop, schema, and registry untouched
  - fixture nets: where hook flags, shortcode flags, and shortcode names land per reuse path; the gate across direct, `.RenderShortcodes`, and `.Content` tabpanes
  - docs on the #2797 contract: plugins guide (shortcode predicate in § Adjust a plugin per page; § Page flags in included content restated), design § Gating decisions, quality nets, changelog, 0.18 post upgrade item
- **Out of scope**: section print (gated scripts never reach it; the print flag-merge partial is parked); the shim's name and contract wording (queued separately)
- **Why the shortcode name, not a shortcode-set flag**: a Store flag stays on the page whose file sets it, so a tabpane included through `.RenderShortcodes` never flags the includer (why 0.18-dev shipped it ungated); Hugo carries included pages' shortcode names to the includer since 0.123, pinned by a fixture test, so the documented include idiom gets the script with no site cooperation
- **Behavior change**: tab-less pages drop the script (scripts goldens: home page only); tabpanes reached through `.Content` or a printed section render without persistence
